### PR TITLE
주변 코스 조회 기능 응답에 id 추가

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/dto/CourseResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/CourseResponse.java
@@ -7,6 +7,7 @@ import coursepick.coursepick.domain.Meter;
 import java.util.List;
 
 public record CourseResponse(
+        Long id,
         String name,
         List<Coordinate> coordinates,
         Meter meter,
@@ -14,6 +15,7 @@ public record CourseResponse(
 ) {
     public static CourseResponse from(Course course, Coordinate target) {
         return new CourseResponse(
+                course.id(),
                 course.name(),
                 course.coordinates(),
                 course.minDistanceFrom(target),

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -61,6 +61,10 @@ public class Course {
         return min;
     }
 
+    public Long id() {
+        return id;
+    }
+
     public String name() {
         return name;
     }

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/GeoJson.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/GeoJson.java
@@ -25,12 +25,13 @@ public record GeoJson(
     }
 
     record PropertiesResponse(
+            long id,
             String name,
             double distance,
             double length
     ) {
-        public static PropertiesResponse from(String name, double distance, double length) {
-            return new PropertiesResponse(name, distance, length);
+        public static PropertiesResponse from(long id, String name, double distance, double length) {
+            return new PropertiesResponse(id, name, distance, length);
         }
     }
 
@@ -38,7 +39,7 @@ public record GeoJson(
         return new GeoJson(
                 "Feature",
                 GeometryResponse.from(courseResponse.coordinates()),
-                PropertiesResponse.from(courseResponse.name(), courseResponse.meter().value(), courseResponse.length().value())
+                PropertiesResponse.from(courseResponse.id(), courseResponse.name(), courseResponse.meter().value(), courseResponse.length().value())
         );
     }
 


### PR DESCRIPTION
## 📋 변경 사항 요약
- 주변 코스 조회 기능 응답에 id 필드를 추가했습니다.

## 🛠️ 주요 변경 사항

```
"properties": {
    "id": 1 // <- 이 부분 수정됨!!!!!!!
    "name": "루터회관 산악길",
    "distance": 100,
    "length": 3721
}
```

## 🔗 관련 이슈
- Closes #60 
