### PR TITLE
코스 목록 표시 시 m/km 단위 변환

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/view/BindingAdapter.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/BindingAdapter.kt
@@ -1,9 +1,36 @@
 package io.coursepick.coursepick.view
 
+import android.content.Context
 import android.view.View
+import android.widget.TextView
 import androidx.databinding.BindingAdapter
+import io.coursepick.coursepick.R
 
 @BindingAdapter("isSelected")
 fun View.selected(isSelected: Boolean) {
     this.isSelected = isSelected
 }
+
+@BindingAdapter("courseLength")
+fun TextView.setCourseLength(meter: Int) {
+    this.text = formattedMeter(this.context, meter)
+}
+
+@BindingAdapter("courseDistance")
+fun TextView.setCourseDistance(meter: Int) {
+    this.text =
+        this.context.getString(
+            R.string.main_course_distance_suffix,
+            formattedMeter(this.context, meter),
+        )
+}
+
+private fun formattedMeter(
+    context: Context,
+    meter: Int,
+): String =
+    if (meter < 1000) {
+        context.getString(R.string.main_course_unit_meter, meter)
+    } else {
+        context.getString(R.string.main_course_unit_kilometer, meter / 1000.0)
+    }

--- a/android/app/src/main/res/layout/item_course.xml
+++ b/android/app/src/main/res/layout/item_course.xml
@@ -39,10 +39,10 @@
 
         <TextView
             android:id="@+id/courseDistance"
+            courseDistance="@{course.distance}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="15dp"
-            android:text="@{@string/main_course_distance(course.distance)}"
             android:textSize="12sp"
             app:layout_constraintBottom_toBottomOf="@id/courseName"
             app:layout_constraintEnd_toEndOf="parent"
@@ -61,12 +61,12 @@
 
         <TextView
             android:id="@+id/courseLength"
+            courseLength="@{course.length}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
             android:layout_marginTop="10dp"
             android:layout_marginBottom="15dp"
-            android:text="@{@string/main_course_length(course.length)}"
             android:textSize="14sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/courseLengthIcon"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">CoursePick</string>
-    <string name="main_course_distance">%dm만큼 떨어짐</string>
-    <string name="main_course_length">%dkm</string>
+    <string name="main_course_distance_suffix">%s만큼 떨어짐</string>
+    <string name="main_course_unit_meter">%dm</string>
+    <string name="main_course_unit_kilometer">%.2fkm</string>
 </resources>


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
미터로 나타낼 수 있는 단위를 표기할 때, 1000m 미만일 경우 미터로, 1000m 이상일 경우 킬로미터로 소수점 아래 2자리까지 반올림하여 나타냅니다.

## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- 1000m 미만의 길이/거리는 미터 단위로 나타냅니다. (e.g. `123m` → `123m`)
- 1000m 이상의 길이/거리는 킬로미터 단위로 소수점 아래 2자리까지 반올림하여 나타냅니다. (e.g. `1234m` → `1.23km`, `5678m` → `5.68km`)

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경사항이 있다면 변경 전후 스크린샷을 첨부해주세요 -->

|As-is|To-be|
|-|-|
|<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/a154bfcd-7c18-4f56-9a6e-302d934b0986" />|<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/d2370182-48a3-4974-993e-8588b6b34d47" />|

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- Closes #59 
