### PR TITLE
러닝 코스 선택 시 코스 전체가 보이도록 카메라를 조정하는 기능 추가

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/view/ContextExtensions.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/ContextExtensions.kt
@@ -1,5 +1,0 @@
-package io.coursepick.coursepick.view
-
-import android.content.Context
-
-fun Context.dpToPx(dp: Float): Float = dp * resources.displayMetrics.density

--- a/android/app/src/main/java/io/coursepick/coursepick/view/CourseItem.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/CourseItem.kt
@@ -2,6 +2,8 @@ package io.coursepick.coursepick.view
 
 import io.coursepick.coursepick.domain.Coordinate
 import io.coursepick.coursepick.domain.Course
+import io.coursepick.coursepick.domain.Latitude
+import io.coursepick.coursepick.domain.Longitude
 
 data class CourseItem(
     private val course: Course,
@@ -12,4 +14,18 @@ data class CourseItem(
     val distance: Int = course.distance.meter
     val length: Int = course.length.meter
     val coordinates: List<Coordinate> = course.coordinates
+
+    private val westernmost: Latitude =
+        coordinates.minBy { coordinate: Coordinate -> coordinate.latitude.value }.latitude
+    private val easternmost: Latitude =
+        coordinates.maxBy { coordinate: Coordinate -> coordinate.latitude.value }.latitude
+    private val southernmost: Longitude =
+        coordinates.minBy { coordinate: Coordinate -> coordinate.longitude.value }.longitude
+    private val northernmost: Longitude =
+        coordinates.maxBy { coordinate: Coordinate -> coordinate.longitude.value }.longitude
+
+    val northwest: Coordinate = Coordinate(westernmost, northernmost)
+    val northeast: Coordinate = Coordinate(easternmost, northernmost)
+    val southeast: Coordinate = Coordinate(easternmost, southernmost)
+    val southwest: Coordinate = Coordinate(westernmost, southernmost)
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/view/CourseItem.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/CourseItem.kt
@@ -2,8 +2,6 @@ package io.coursepick.coursepick.view
 
 import io.coursepick.coursepick.domain.Coordinate
 import io.coursepick.coursepick.domain.Course
-import io.coursepick.coursepick.domain.Latitude
-import io.coursepick.coursepick.domain.Longitude
 
 data class CourseItem(
     private val course: Course,
@@ -14,18 +12,4 @@ data class CourseItem(
     val distance: Int = course.distance.meter
     val length: Int = course.length.meter
     val coordinates: List<Coordinate> = course.coordinates
-
-    private val westernmost: Latitude =
-        coordinates.minBy { coordinate: Coordinate -> coordinate.latitude.value }.latitude
-    private val easternmost: Latitude =
-        coordinates.maxBy { coordinate: Coordinate -> coordinate.latitude.value }.latitude
-    private val southernmost: Longitude =
-        coordinates.minBy { coordinate: Coordinate -> coordinate.longitude.value }.longitude
-    private val northernmost: Longitude =
-        coordinates.maxBy { coordinate: Coordinate -> coordinate.longitude.value }.longitude
-
-    val northwest: Coordinate = Coordinate(westernmost, northernmost)
-    val northeast: Coordinate = Coordinate(easternmost, northernmost)
-    val southeast: Coordinate = Coordinate(easternmost, southernmost)
-    val southwest: Coordinate = Coordinate(westernmost, southernmost)
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapCameraController.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapCameraController.kt
@@ -25,13 +25,14 @@ class KakaoMapCameraController(
         map: KakaoMap,
         northeast: Coordinate,
         southwest: Coordinate,
+        padding: Int,
     ) {
         val bounds =
             LatLngBounds(
                 LatLng.from(northeast.latitude.value, northeast.longitude.value),
                 LatLng.from(southwest.latitude.value, southwest.longitude.value),
             )
-        val cameraUpdate: CameraUpdate = CameraUpdateFactory.fitMapPoints(bounds)
+        val cameraUpdate: CameraUpdate = CameraUpdateFactory.fitMapPoints(bounds, padding)
         map.moveCamera(cameraUpdate)
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapCameraController.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapCameraController.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import androidx.annotation.RequiresPermission
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
-import com.kakao.vectormap.LatLngBounds
 import com.kakao.vectormap.camera.CameraUpdate
 import com.kakao.vectormap.camera.CameraUpdateFactory
 import io.coursepick.coursepick.domain.Coordinate
@@ -23,16 +22,15 @@ class KakaoMapCameraController(
 
     fun fitTo(
         map: KakaoMap,
-        northeast: Coordinate,
-        southwest: Coordinate,
+        coordinates: List<Coordinate>,
         padding: Int,
     ) {
-        val bounds =
-            LatLngBounds(
-                LatLng.from(northeast.latitude.value, northeast.longitude.value),
-                LatLng.from(southwest.latitude.value, southwest.longitude.value),
-            )
-        val cameraUpdate: CameraUpdate = CameraUpdateFactory.fitMapPoints(bounds, padding)
+        val latLngs: Array<LatLng> =
+            coordinates
+                .map { coordinate: Coordinate ->
+                    LatLng.from(coordinate.latitude.value, coordinate.longitude.value)
+                }.toTypedArray()
+        val cameraUpdate: CameraUpdate = CameraUpdateFactory.fitMapPoints(latLngs, padding)
         map.moveCamera(cameraUpdate)
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapCameraController.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapCameraController.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import androidx.annotation.RequiresPermission
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.LatLng
+import com.kakao.vectormap.LatLngBounds
 import com.kakao.vectormap.camera.CameraUpdate
 import com.kakao.vectormap.camera.CameraUpdateFactory
 import io.coursepick.coursepick.domain.Coordinate
@@ -18,6 +19,20 @@ class KakaoMapCameraController(
         coordinate: Coordinate,
     ) {
         moveTo(map, coordinate.latitude.value, coordinate.longitude.value)
+    }
+
+    fun fitTo(
+        map: KakaoMap,
+        northeast: Coordinate,
+        southwest: Coordinate,
+    ) {
+        val bounds =
+            LatLngBounds(
+                LatLng.from(northeast.latitude.value, northeast.longitude.value),
+                LatLng.from(southwest.latitude.value, southwest.longitude.value),
+            )
+        val cameraUpdate: CameraUpdate = CameraUpdateFactory.fitMapPoints(bounds)
+        map.moveCamera(cameraUpdate)
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapDrawer.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapDrawer.kt
@@ -9,6 +9,7 @@ import com.kakao.vectormap.route.RouteLineSegment
 import com.kakao.vectormap.route.RouteLineStyle
 import com.kakao.vectormap.route.RouteLineStyles
 import com.kakao.vectormap.route.RouteLineStylesSet
+import io.coursepick.coursepick.R
 import io.coursepick.coursepick.domain.Coordinate
 
 class KakaoMapDrawer(
@@ -21,7 +22,7 @@ class KakaoMapDrawer(
         val layer: RouteLineLayer = kakaoMap.routeLineManager?.layer ?: return
         layer.removeAll()
 
-        val lineWidthPx: Float = context.dpToPx(LINE_WIDTH_DP)
+        val lineWidthPx: Float = context.resources.getDimension(R.dimen.course_route_width)
         val styleSet =
             RouteLineStylesSet.from(
                 STYLE_ID,
@@ -38,7 +39,6 @@ class KakaoMapDrawer(
 
     companion object {
         private const val STYLE_ID = "CoursePickRouteLineStyle"
-        private const val LINE_WIDTH_DP = 4f
         private const val LINE_COLOR = 0xFF0000FF.toInt()
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
@@ -7,8 +7,6 @@ import com.kakao.vectormap.MapGravity
 import com.kakao.vectormap.MapView
 import io.coursepick.coursepick.R
 import io.coursepick.coursepick.domain.Coordinate
-import io.coursepick.coursepick.domain.Latitude
-import io.coursepick.coursepick.domain.Longitude
 
 class KakaoMapManager(
     private val mapView: MapView,
@@ -49,17 +47,9 @@ class KakaoMapManager(
     }
 
     fun fitTo(course: CourseItem) {
-        val latitudes: List<Latitude> =
-            course.coordinates.map { coordinate: Coordinate -> coordinate.latitude }
-        val longitudes: List<Longitude> =
-            course.coordinates.map { coordinate: Coordinate -> coordinate.longitude }
-        val northeast =
-            Coordinate(latitudes.maxBy(Latitude::value), longitudes.maxBy(Longitude::value))
-        val southwest =
-            Coordinate(latitudes.minBy(Latitude::value), longitudes.minBy(Longitude::value))
         val padding = mapView.context.dpToPx(COURSE_PADDING_DP).toInt()
         kakaoMap?.let { map: KakaoMap ->
-            cameraController.fitTo(map, northeast, southwest, padding)
+            cameraController.fitTo(map, course.coordinates, padding)
         }
     }
 
@@ -81,6 +71,6 @@ class KakaoMapManager(
 
     companion object {
         private const val LOGO_POSITION_OFFSET_DP = 10F
-        private const val COURSE_PADDING_DP = 20F
+        private const val COURSE_PADDING_DP = 10F
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
@@ -19,12 +19,14 @@ class KakaoMapManager(
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     fun start(onMapReady: (KakaoMap) -> Unit) {
+        val offsetPx: Float =
+            mapView.context.resources.getDimension(R.dimen.map_logo_position_offset)
         lifecycleHandler.start { map: KakaoMap ->
             kakaoMap = map
             map.logo?.setPosition(
                 MapGravity.TOP or MapGravity.LEFT,
-                mapView.context.dpToPx(LOGO_POSITION_OFFSET_DP),
-                mapView.context.dpToPx(LOGO_POSITION_OFFSET_DP),
+                offsetPx,
+                offsetPx,
             )
             map.setPadding(
                 0,
@@ -47,7 +49,7 @@ class KakaoMapManager(
     }
 
     fun fitTo(course: CourseItem) {
-        val padding = mapView.context.dpToPx(COURSE_PADDING_DP).toInt()
+        val padding = mapView.context.resources.getDimensionPixelSize(R.dimen.course_route_padding)
         kakaoMap?.let { map: KakaoMap ->
             cameraController.fitTo(map, course.coordinates, padding)
         }
@@ -67,10 +69,5 @@ class KakaoMapManager(
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     fun moveToCurrentLocation() {
         kakaoMap?.let { map: KakaoMap -> cameraController.moveToCurrentLocation(map) }
-    }
-
-    companion object {
-        private const val LOGO_POSITION_OFFSET_DP = 10F
-        private const val COURSE_PADDING_DP = 10F
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
@@ -6,6 +6,8 @@ import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.MapGravity
 import com.kakao.vectormap.MapView
 import io.coursepick.coursepick.domain.Coordinate
+import io.coursepick.coursepick.domain.Latitude
+import io.coursepick.coursepick.domain.Longitude
 
 class KakaoMapManager(
     private val mapView: MapView,
@@ -36,6 +38,20 @@ class KakaoMapManager(
     fun draw(course: CourseItem) {
         kakaoMap?.let { map: KakaoMap ->
             drawer.drawCourse(map, course)
+        }
+    }
+
+    fun fitTo(course: CourseItem) {
+        val latitudes: List<Latitude> =
+            course.coordinates.map { coordinate: Coordinate -> coordinate.latitude }
+        val longitudes: List<Longitude> =
+            course.coordinates.map { coordinate: Coordinate -> coordinate.longitude }
+        val northeast =
+            Coordinate(latitudes.maxBy(Latitude::value), longitudes.maxBy(Longitude::value))
+        val southwest =
+            Coordinate(latitudes.minBy(Latitude::value), longitudes.minBy(Longitude::value))
+        kakaoMap?.let { map: KakaoMap ->
+            cameraController.fitTo(map, northeast, southwest)
         }
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
@@ -57,8 +57,9 @@ class KakaoMapManager(
             Coordinate(latitudes.maxBy(Latitude::value), longitudes.maxBy(Longitude::value))
         val southwest =
             Coordinate(latitudes.minBy(Latitude::value), longitudes.minBy(Longitude::value))
+        val padding = mapView.context.dpToPx(COURSE_PADDING_DP).toInt()
         kakaoMap?.let { map: KakaoMap ->
-            cameraController.fitTo(map, northeast, southwest)
+            cameraController.fitTo(map, northeast, southwest, padding)
         }
     }
 
@@ -80,5 +81,6 @@ class KakaoMapManager(
 
     companion object {
         private const val LOGO_POSITION_OFFSET_DP = 10F
+        private const val COURSE_PADDING_DP = 20F
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/KakaoMapManager.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RequiresPermission
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.MapGravity
 import com.kakao.vectormap.MapView
+import io.coursepick.coursepick.R
 import io.coursepick.coursepick.domain.Coordinate
 import io.coursepick.coursepick.domain.Latitude
 import io.coursepick.coursepick.domain.Longitude
@@ -26,6 +27,12 @@ class KakaoMapManager(
                 MapGravity.TOP or MapGravity.LEFT,
                 mapView.context.dpToPx(LOGO_POSITION_OFFSET_DP),
                 mapView.context.dpToPx(LOGO_POSITION_OFFSET_DP),
+            )
+            map.setPadding(
+                0,
+                0,
+                0,
+                mapView.context.resources.getDimensionPixelSize(R.dimen.main_bottom_sheet_peek_height),
             )
             onMapReady(map)
         }

--- a/android/app/src/main/java/io/coursepick/coursepick/view/MainActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/view/MainActivity.kt
@@ -126,7 +126,7 @@ class MainActivity : AppCompatActivity() {
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     private fun selectCourse(course: CourseItem) {
         mapManager.draw(course)
-        mapManager.moveTo(course)
+        mapManager.fitTo(course)
     }
 
     private fun requestLocationPermissions() {

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -26,7 +26,7 @@
             android:background="@drawable/background_courses"
             android:paddingBottom="10dp"
             app:behavior_hideable="false"
-            app:behavior_peekHeight="280dp"
+            app:behavior_peekHeight="@dimen/main_bottom_sheet_peek_height"
             app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
             <View

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="main_bottom_sheet_peek_height">280dp</dimen>
+</resources>

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="main_bottom_sheet_peek_height">280dp</dimen>
+    <dimen name="map_logo_position_offset">10dp</dimen>
+    <dimen name="course_route_padding">10dp</dimen>
+    <dimen name="course_route_width">4dp</dimen>
 </resources>


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
코스 선택 시 선택된 코스가 화면을 채우도록 카메라가 조정됩니다.

## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- 코스 선택 시 해당 코스가 화면을 채우도록 표시됩니다.
- 카카오맵 Viewport에 하단 패딩을 추가해 바텀 시트에 가려지지 않은 영역을 기준으로 지도가 표시됩니다.

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경사항이 있다면 변경 전후 스크린샷을 첨부해주세요 -->
|As-is|To-be|
|-|-|
|<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/39afd595-b0ea-4921-a365-878d06e661fa" />|<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/00c3ddfa-9038-42ab-818c-c10aa9075d78" />|

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #81 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 코스 선택 시 지도에서 전체 코스가 화면에 맞춰 보이도록 지도 뷰 확대/이동 기능이 추가되었습니다.
  * 지도 뷰 하단에 패딩이 적용되어 하단 시트와의 겹침을 방지합니다.

* **스타일**
  * 하단 시트의 초기 높이 값을 하드코딩에서 리소스 값으로 변경하여 유지보수성을 향상시켰습니다.
  * 지도 경로 선의 두께 값을 리소스에서 관리하도록 개선하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->