### PR TITLE
파일 로깅 형태를 JSON 형태로 변경

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
     // Geographic libraries for comparison
     implementation("org.locationtech.spatial4j:spatial4j:0.8")
-    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
+    implementation("net.logstash.logback:logstash-logback-encoder:8.1")
 }
 
 tasks.withType<Test> {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 
     // Geographic libraries for comparison
     implementation("org.locationtech.spatial4j:spatial4j:0.8")
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
-    <property name="LOG_FILE_PATH" value="./logs"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>${LOG_PATTERN}</pattern>
-        </encoder>
-    </appender>
+    <property name="LOG_FILE_PATH" value="./logs"/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE_PATH}/coursepick.log</file>
@@ -29,7 +25,6 @@
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_FILE"/>
         </root>
     </springProfile>
 

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -12,9 +12,11 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE_PATH}/coursepick.log</file>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_FILE_PATH}/coursepick.%d{yyyy-MM-dd}.log</fileNamePattern>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_FILE_PATH}/coursepick.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxHistory>30</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <!-- 공통 변수 설정 -->
     <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
     <property name="LOG_FILE_PATH" value="./logs"/>
-    <property name="LOG_FILE_NAME" value="application"/>
 
-    <!-- 콘솔 Appender -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
-    <!-- 파일 Appender (Rolling) -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE_PATH}/coursepick.log</file>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
@@ -22,14 +18,12 @@
         </rollingPolicy>
     </appender>
 
-    <!-- local 프로필: 콘솔만 -->
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
 
-    <!-- dev 프로필: 파일 + CloudWatch -->
     <springProfile name="dev">
         <root level="INFO">
             <appender-ref ref="FILE"/>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -15,9 +15,7 @@
     <!-- 파일 Appender (Rolling) -->
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE_PATH}/coursepick.log</file>
-        <encoder>
-            <pattern>${LOG_PATTERN}</pattern>
-        </encoder>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${LOG_FILE_PATH}/coursepick.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -20,16 +20,22 @@
         </rollingPolicy>
     </appender>
 
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE"/>
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>256</queueSize>
+    </appender>
+
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="ASYNC_FILE"/>
         </root>
     </springProfile>
 
     <springProfile name="dev">
         <root level="INFO">
-            <appender-ref ref="FILE"/>
+            <appender-ref ref="ASYNC_FILE"/>
         </root>
     </springProfile>
-
 </configuration>


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 파일 로깅을 Logstash Encoder를 활용하여 JSON 형태로 로깅
- 기존 콘솔 로깅은 기본 Appender를 사용 (이제 색 표현 가능합니다.)
- 비동기 Appender를 통한 인터럽트없는 파일 로깅 기능
- 파일 로깅을 시간 뿐만 아니라 크기로도 분류, 로그 파일 크기 총합 제한 추가

## 🔗 관련 이슈
- closes #100 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개발 환경에서 로그 파일이 Logstash 호환 JSON 형식으로 저장되도록 개선되었습니다.
  * 로그 파일의 용량 및 보관 정책이 강화되어, 파일당 10MB, 전체 1GB, 최대 30일간 보관이 적용됩니다.

* **리팩터**
  * 로깅 설정이 표준 Spring Boot Logback 기본값과 리소스를 활용하도록 정리되었습니다.
  * 파일 로그 기록이 비동기 방식으로 전환되어 성능이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->