### PR TITLE
이 위치 재검색 및 바텀 시트 스타일 변경

### DIFF
--- a/android/app/src/main/res/drawable/background_course_item_default.xml
+++ b/android/app/src/main/res/drawable/background_course_item_default.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/background_border" />
+        </shape>
+    </item>
+    <item>
+        <inset
+            android:insetLeft="1dp"
+            android:insetRight="1dp">
+            <shape android:shape="rectangle">
+                <solid android:color="@color/background_primary" />
+            </shape>
+        </inset>
+    </item>
+</layer-list>

--- a/android/app/src/main/res/drawable/background_course_item_selected.xml
+++ b/android/app/src/main/res/drawable/background_course_item_selected.xml
@@ -11,7 +11,7 @@
             android:insetLeft="1dp"
             android:insetRight="1dp">
             <shape android:shape="rectangle">
-                <solid android:color="@color/background_secondary" />
+                <solid android:color="@color/background_tertiary" />
             </shape>
         </inset>
     </item>

--- a/android/app/src/main/res/drawable/background_course_item_selected.xml
+++ b/android/app/src/main/res/drawable/background_course_item_selected.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/background_border" />
+        </shape>
+    </item>
+    <item>
+        <inset
+            android:insetLeft="1dp"
+            android:insetRight="1dp">
+            <shape android:shape="rectangle">
+                <solid android:color="@color/background_secondary" />
+            </shape>
+        </inset>
+    </item>
+</layer-list>

--- a/android/app/src/main/res/drawable/background_course_item_selector.xml
+++ b/android/app/src/main/res/drawable/background_course_item_selector.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/background_course_item_selected" android:state_selected="true" />
+    <item android:drawable="@drawable/background_course_item_default" />
+</selector>

--- a/android/app/src/main/res/drawable/background_course_selected.xml
+++ b/android/app/src/main/res/drawable/background_course_selected.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/background_tertiary" android:state_selected="true" />
-    <item android:drawable="@color/background_primary" />
-</selector>

--- a/android/app/src/main/res/drawable/background_search_this_area.xml
+++ b/android/app/src/main/res/drawable/background_search_this_area.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <corners android:radius="100dp"/>
-    <solid android:color="@color/white"/>
-    <stroke android:color="@color/gray3" android:width="1dp"/>
+    <corners android:radius="9999dp" />
+    <solid android:color="@color/background_primary" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/background_border" />
 </shape>

--- a/android/app/src/main/res/drawable/icon_search_this_area.xml
+++ b/android/app/src/main/res/drawable/icon_search_this_area.xml
@@ -1,5 +1,11 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
-      
-    <path android:fillColor="@android:color/white" android:pathData="M480,800Q346,800 253,707Q160,614 160,480Q160,346 253,253Q346,160 480,160Q549,160 612,188.5Q675,217 720,270L720,160L800,160L800,440L520,440L520,360L688,360Q656,304 600.5,272Q545,240 480,240Q380,240 310,310Q240,380 240,480Q240,580 310,650Q380,720 480,720Q557,720 619,676Q681,632 706,560L790,560Q762,666 676,733Q590,800 480,800Z"/>
-    
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="@color/item_primary"
+        android:pathData="M480,800Q346,800 253,707Q160,614 160,480Q160,346 253,253Q346,160 480,160Q549,160 612,188.5Q675,217 720,270L720,160L800,160L800,440L520,440L520,360L688,360Q656,304 600.5,272Q545,240 480,240Q380,240 310,310Q240,380 240,480Q240,580 310,650Q380,720 480,720Q557,720 619,676Q681,632 706,560L790,560Q762,666 676,733Q590,800 480,800Z" />
+
 </vector>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -53,7 +53,7 @@
                 android:layout_height="wrap_content"
                 android:gravity="center"
                 android:text="@string/main_search_this_area"
-                android:textColor="@color/black"
+                android:textColor="@color/item_primary"
                 android:textSize="14sp" />
 
         </LinearLayout>

--- a/android/app/src/main/res/layout/item_course.xml
+++ b/android/app/src/main/res/layout/item_course.xml
@@ -20,7 +20,7 @@
         isSelected="@{course.selected}"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/background_course_selected"
+        android:background="@drawable/background_course_item_selector"
         android:onClick="@{() -> onSelectCourseListener.select(course)}">
 
         <TextView


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
UI 스타일이 변경됩니다.
이 위치 재검색 버튼에 다크 모드가 적용되지 않는 현상이 수정됩니다.

## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- `이 위치 재검색` 버튼에 다크 모드가 적용됩니다.
- 바텀 시트의 좌우 경계선이 코스 항목에 가려지지 않도록 변경됩니다.

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경사항이 있다면 변경 전후 스크린샷을 첨부해주세요 -->
||As-is|To-be|
|-|-|-|
|다크 모드 적용|<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/b598a65e-226d-4d7f-aaf0-bda6ae429672" />|<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/01cbe4f3-0b72-4879-81b2-531eb8770c01" />|
|경계선 수정|<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/2675f2f1-d24a-409a-ae6d-8f85d19a5ed4" />|<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/5b012681-9439-4002-8733-384944d8b2bf" />|


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #134 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 코스 아이템의 배경과 선택 시 효과가 새로운 테마 색상과 둥근 모서리로 개선되었습니다.
  * "이 지역 검색" 버튼과 아이콘의 색상이 테마에 맞게 변경되었습니다.
  * 텍스트 색상과 배경 색상이 하드코딩 값에서 테마 색상으로 통일되었습니다.

* **버그 수정**
  * 코스 아이템 선택 시 배경 효과가 올바르게 적용되도록 리소스가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->