### PR TITLE
주변 코스 조회, 파일 파싱 및 삽입 쿼리 최적화

### DIFF
--- a/backend/docker/docker-compose.local.yml
+++ b/backend/docker/docker-compose.local.yml
@@ -9,3 +9,8 @@ services:
       - 'MYSQL_PASSWORD=secret'
     ports:
       - '3307:3306'
+    volumes:
+      - 'mysql_data:/var/lib/mysql'
+
+volumes:
+  mysql_data:

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -3,6 +3,7 @@ package coursepick.coursepick.domain;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,6 +26,7 @@ public class Course {
     @Enumerated(EnumType.STRING)
     private final RoadType roadType;
 
+    @BatchSize(size = 30)
     @ElementCollection
     @CollectionTable(name = "coordinate")
     private final List<Coordinate> coordinates;

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -2,6 +2,11 @@ spring:
   application.name: coursepick
   jpa:
     open-in-view: true
+    properties:
+      hibernate:
+        jdbc.batch_size: 50 # 한 번에 처리할 배치 크기
+        order_inserts: true  # INSERT 순서 최적화
+        order_updates: true  # UPDATE 순서 최적화
 
 springdoc:
   default-consumes-media-type: application/json


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 주변 코스 조회시의 N+1 문제를 해결했습니다.
  - 기존: N개의 코스를 조회한 후(1), 각 코스에 대한 좌표를 조회(N)하는 N+1 문제가 발생하고 있었습니다.
  - 개선: `@BatchSize`을 통해서 각 코스에 대한 좌표를 한번에 쿼리하여 1+1 쿼리로 개선하였습니다.
- 파일 파싱/삽입시의 N+1 문제를 해결했습니다.
  - 기존: 코스를 한개 삽입한 후(1), 각 좌표를 삽입(N)하는 N+1 문제가 발생하고 있었습니다.
  - 개선: `hibernate batch size`를 설정하여 각 좌표를 한번에 삽입하는 1+1 쿼리로 개선하였습니다.

## 조회 효율 개선

**기존 조회 효율**
<img width="1045" height="239" alt="image" src="https://github.com/user-attachments/assets/3708ad10-1b84-4239-a8e1-df0fbf127694" />

**변경된 삽입 효율**
<img width="1045" height="236" alt="image" src="https://github.com/user-attachments/assets/507b6248-30c9-4e3e-a4a8-cec61ecdbeb9" />

### 분석 결과

실행 속도가 약 **66.8%** 정도 감소했습니다. (약 **3배** 더 빠릅니다.)

## 삽입 효율 개선

**기존 삽입 효율**
<img width="1018" height="242" alt="image" src="https://github.com/user-attachments/assets/b3888c49-b50d-4a1a-a6b1-fe8c91bd4db8" />

**변경된 삽입 효율**
<img width="1018" height="234" alt="image" src="https://github.com/user-attachments/assets/be7dbb17-7722-4bf8-95c6-8480bf9dd569" />

### 분석 결과
실행 속도가 약 **91.5%** 정도 감속했습니다. (약 **11.8배** 빠릅니다.)

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #147 
