### PR TITLE
도메인 엔티티의 getter를 lombok으로 치환

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -2,7 +2,9 @@ package coursepick.coursepick.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,6 +15,8 @@ import static coursepick.coursepick.application.exception.ErrorType.INVALID_NAME
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@Getter
+@Accessors(fluent = true)
 public class Course {
 
     @Id
@@ -92,22 +96,6 @@ public class Course {
         };
 
         return Math.clamp(score, 1, 10);
-    }
-
-    public Long id() {
-        return id;
-    }
-
-    public String name() {
-        return name;
-    }
-
-    public List<Coordinate> coordinates() {
-        return coordinates;
-    }
-
-    public RoadType roadType() {
-        return roadType;
     }
 
     private static String compactName(String name) {


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 기존 getter를 제거했습니다.
- 대신 롬복의 `@Getter`와 `@Accessors`를 통해 record 스타일의 getter를 추가했습니다.

[롬복 공식 링크](https://projectlombok.org/features/experimental/Accessors)

## 🔗 관련 이슈
- closes #149 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 내부 코드 구조를 개선하여 getter 메서드를 자동 생성하도록 변경하였습니다. 외부에서 사용하는 기능이나 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->