### PR TITLE
주변 코스 조회 API를 세그먼트 단위로 자르고, 경사 정보 추가

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/dto/CourseResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/CourseResponse.java
@@ -10,21 +10,21 @@ import java.util.List;
 public record CourseResponse(
         Long id,
         String name,
-        List<Coordinate> coordinates,
         Meter distance,
         Meter length,
         RoadType roadType,
-        double difficulty
+        double difficulty,
+        List<SegmentResponse> segments
 ) {
     public static CourseResponse from(Course course, Coordinate target) {
         return new CourseResponse(
                 course.id(),
                 course.name(),
-                course.coordinates(),
                 course.distanceFrom(target),
                 course.length(),
                 course.roadType(),
-                course.difficulty()
+                course.difficulty(),
+                SegmentResponse.from(course.segments())
         );
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/application/dto/SegmentResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/SegmentResponse.java
@@ -1,0 +1,17 @@
+package coursepick.coursepick.application.dto;
+
+import coursepick.coursepick.domain.Coordinate;
+import coursepick.coursepick.domain.InclineType;
+import coursepick.coursepick.domain.Segment;
+
+import java.util.List;
+
+public record SegmentResponse(
+        InclineType inclineType,
+        List<Coordinate> coordinates
+) {
+    public static List<SegmentResponse> from(List<Segment> segments) {
+        // TODO : 구현
+        return null;
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/application/dto/SegmentResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/SegmentResponse.java
@@ -11,7 +11,8 @@ public record SegmentResponse(
         List<Coordinate> coordinates
 ) {
     public static List<SegmentResponse> from(List<Segment> segments) {
-        // TODO : 구현
-        return null;
+        return segments.stream()
+                .map(segment -> new SegmentResponse(segment.inclineType(), segment.coordinates()))
+                .toList();
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -93,10 +93,11 @@ public class Course {
 
         return Math.clamp(score, 1, 10);
     }
-    
+
     public List<Segment> segments() {
         List<Segment> segments = Segment.split(coordinates);
-        return Segment.mergeSameInclineType(segments);
+        List<Segment> sameDirectionSegments = Segment.mergeSameDirection(segments);
+        return Segment.mergeSameInclineType(sameDirectionSegments);
     }
 
     public Long id() {

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -94,6 +94,11 @@ public class Course {
         return Math.clamp(score, 1, 10);
     }
 
+    public List<Segment> segments() {
+        // TODO : 구현
+        return null;
+    }
+
     public Long id() {
         return id;
     }

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -95,7 +95,11 @@ public class Course {
     }
 
     public List<Segment> segments() {
-        List<Segment> segments = Segment.split(coordinates);
+        List<GeoLine> geoLines = GeoLine.split(coordinates);
+        List<Segment> segments = geoLines.stream()
+                .map(GeoLine::toSegment)
+                .toList();
+
         List<Segment> sameDirectionSegments = Segment.mergeSameDirection(segments);
         return Segment.mergeSameInclineType(sameDirectionSegments);
     }

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -93,10 +93,10 @@ public class Course {
 
         return Math.clamp(score, 1, 10);
     }
-
+    
     public List<Segment> segments() {
-        // TODO : 구현
-        return null;
+        List<Segment> segments = Segment.split(coordinates);
+        return Segment.mergeSameInclineType(segments);
     }
 
     public Long id() {

--- a/backend/src/main/java/coursepick/coursepick/domain/GeoLine.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/GeoLine.java
@@ -6,6 +6,9 @@ import org.locationtech.spatial4j.distance.GeodesicSphereDistCalc;
 import org.locationtech.spatial4j.shape.Point;
 import org.locationtech.spatial4j.shape.ShapeFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public record GeoLine(
         Coordinate start,
         Coordinate end
@@ -14,6 +17,20 @@ public record GeoLine(
 
     public static GeoLine between(Coordinate start, Coordinate end) {
         return new GeoLine(start, end);
+    }
+
+    public static List<GeoLine> split(List<Coordinate> coordinates) {
+        List<GeoLine> geoLines = new ArrayList<>();
+        for (int i = 0; i < coordinates.size() - 1; i++) {
+            Coordinate front = coordinates.get(i);
+            Coordinate back = coordinates.get(i + 1);
+            geoLines.add(GeoLine.between(front, back));
+        }
+        return geoLines;
+    }
+
+    public Segment toSegment() {
+        return new Segment(List.of(start, end));
     }
 
     public Meter length() {

--- a/backend/src/main/java/coursepick/coursepick/domain/InclineType.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/InclineType.java
@@ -3,5 +3,26 @@ package coursepick.coursepick.domain;
 public enum InclineType {
     UPHILL,
     DOWNHILL,
-    FLAT
+    FLAT;
+
+    /**
+     * 두 좌표간 경사 타입을 계산한다.
+     * DOWNHILL: ~ -5도
+     * FLAT: -4도 ~ 4도
+     * UPHILL: 5도 ~
+     */
+    public static InclineType of(Coordinate start, Coordinate end) {
+        double elevationChange = end.elevation() - start.elevation();
+        double distance = GeoLine.between(start, end).length().value();
+
+        double angleInDegrees = Math.toDegrees(Math.atan2(elevationChange, distance));
+
+        if (angleInDegrees >= 5.0) {
+            return UPHILL;
+        } else if (angleInDegrees <= -5.0) {
+            return DOWNHILL;
+        } else {
+            return FLAT;
+        }
+    }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/InclineType.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/InclineType.java
@@ -1,0 +1,7 @@
+package coursepick.coursepick.domain;
+
+public enum InclineType {
+    UPHILL,
+    DOWNHILL,
+    FLAT
+}

--- a/backend/src/main/java/coursepick/coursepick/domain/Segment.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Segment.java
@@ -66,6 +66,12 @@ public record Segment(
         return Collections.unmodifiableList(coordinates);
     }
 
+    private enum Direction {
+        UP,
+        DOWN,
+        STRAIGHT
+    }
+
     private Direction direction() {
         double startElevation = coordinates.getFirst().elevation();
         double endElevation = coordinates.getLast().elevation();
@@ -84,11 +90,5 @@ public record Segment(
         mergedCoordinates.removeLast();
         mergedCoordinates.addAll(other.coordinates);
         return new Segment(mergedCoordinates);
-    }
-
-    private enum Direction {
-        UP,
-        DOWN,
-        STRAIGHT
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/Segment.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Segment.java
@@ -1,0 +1,9 @@
+package coursepick.coursepick.domain;
+
+import java.util.List;
+
+public record Segment(
+        InclineType inclineType,
+        List<Coordinate> coordinates
+) {
+}

--- a/backend/src/main/java/coursepick/coursepick/domain/Segment.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Segment.java
@@ -1,27 +1,98 @@
 package coursepick.coursepick.domain;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class Segment {
 
+    public final List<Coordinate> coordinates;
+
+    private Segment(List<Coordinate> coordinates) {
+        this.coordinates = new ArrayList<>(coordinates);
+    }
+
+    // 좌표들을 2개 단위의 세그먼트로 쪼갠다.
     public static List<Segment> split(List<Coordinate> coordinates) {
-        return null;
+        List<Segment> segments = new ArrayList<>();
+        for (int i = 0; i < coordinates.size() - 1; i++) {
+            Coordinate front = coordinates.get(i);
+            Coordinate back = coordinates.get(i + 1);
+            segments.add(new Segment(List.of(front, back)));
+        }
+        return segments;
     }
 
+    // 경향성이 같은 것끼리 합친다.
+    public static List<Segment> mergeSameDirection(List<Segment> segments) {
+        List<Segment> mergedSegments = new ArrayList<>();
+        mergedSegments.add(segments.getFirst());
+        for (int i = 1; i < segments.size(); i++) {
+            Segment beforeSegment = mergedSegments.removeLast();
+            Segment currentSegment = segments.get(i);
+            Direction beforeDirection = beforeSegment.direction();
+            Direction currentDirection = currentSegment.direction();
+
+            if (beforeDirection == currentDirection) {
+                mergedSegments.add(beforeSegment.merge(currentSegment));
+            } else {
+                mergedSegments.add(beforeSegment);
+                mergedSegments.add(currentSegment);
+            }
+        }
+        return mergedSegments;
+    }
+
+    // 경사타입이 같은 것끼리 합친다.
     public static List<Segment> mergeSameInclineType(List<Segment> segments) {
-        return null;
+        List<Segment> mergedSegments = new ArrayList<>();
+        mergedSegments.add(segments.getFirst());
+        for (int i = 1; i < segments.size(); i++) {
+            Segment beforeSegment = mergedSegments.removeLast();
+            Segment currentSegment = segments.get(i);
+            InclineType beforeInclineType = beforeSegment.inclineType();
+            InclineType currentInclineType = currentSegment.inclineType();
+
+            if (beforeInclineType == currentInclineType) {
+                mergedSegments.add(beforeSegment.merge(currentSegment));
+            } else {
+                mergedSegments.add(beforeSegment);
+                mergedSegments.add(currentSegment);
+            }
+        }
+        return mergedSegments;
     }
 
-    /*
-    -5도 이하 다운힐
-    -4도 ~ 4도 평지
-    5도 이상 업힐
-     */
     public InclineType inclineType() {
-        return null;
+        return InclineType.of(coordinates.getFirst(), coordinates.getLast());
     }
 
     public List<Coordinate> coordinates() {
-        return null;
+        return Collections.unmodifiableList(coordinates);
+    }
+
+    private Direction direction() {
+        double startElevation = coordinates.getFirst().elevation();
+        double endElevation = coordinates.getLast().elevation();
+        if (startElevation < endElevation) {
+            return Direction.DOWN;
+        } else if (startElevation > endElevation) {
+            return Direction.UP;
+        } else {
+            return Direction.STRAIGHT;
+        }
+    }
+
+    private Segment merge(Segment other) {
+        ArrayList<Coordinate> mergedCoordinates = new ArrayList<>();
+        mergedCoordinates.addAll(this.coordinates);
+        mergedCoordinates.addAll(other.coordinates);
+        return new Segment(mergedCoordinates);
+    }
+
+    private enum Direction {
+        UP,
+        DOWN,
+        STRAIGHT
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/Segment.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Segment.java
@@ -7,17 +7,6 @@ import java.util.List;
 public record Segment(
         List<Coordinate> coordinates
 ) {
-    // 좌표들을 2개 단위의 세그먼트로 쪼갠다.
-    public static List<Segment> split(List<Coordinate> coordinates) {
-        List<Segment> segments = new ArrayList<>();
-        for (int i = 0; i < coordinates.size() - 1; i++) {
-            Coordinate front = coordinates.get(i);
-            Coordinate back = coordinates.get(i + 1);
-            segments.add(new Segment(List.of(front, back)));
-        }
-        return segments;
-    }
-
     // 경향성이 같은 것끼리 합친다.
     public static List<Segment> mergeSameDirection(List<Segment> segments) {
         List<Segment> mergedSegments = new ArrayList<>();

--- a/backend/src/main/java/coursepick/coursepick/domain/Segment.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Segment.java
@@ -76,9 +76,9 @@ public record Segment(
         double startElevation = coordinates.getFirst().elevation();
         double endElevation = coordinates.getLast().elevation();
         if (startElevation < endElevation) {
-            return Direction.DOWN;
-        } else if (startElevation > endElevation) {
             return Direction.UP;
+        } else if (startElevation > endElevation) {
+            return Direction.DOWN;
         } else {
             return Direction.STRAIGHT;
         }

--- a/backend/src/main/java/coursepick/coursepick/domain/Segment.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Segment.java
@@ -4,14 +4,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class Segment {
-
-    public final List<Coordinate> coordinates;
-
-    private Segment(List<Coordinate> coordinates) {
-        this.coordinates = new ArrayList<>(coordinates);
-    }
-
+public record Segment(
+        List<Coordinate> coordinates
+) {
     // 좌표들을 2개 단위의 세그먼트로 쪼갠다.
     public static List<Segment> split(List<Coordinate> coordinates) {
         List<Segment> segments = new ArrayList<>();
@@ -86,6 +81,7 @@ public class Segment {
     private Segment merge(Segment other) {
         ArrayList<Coordinate> mergedCoordinates = new ArrayList<>();
         mergedCoordinates.addAll(this.coordinates);
+        mergedCoordinates.removeLast();
         mergedCoordinates.addAll(other.coordinates);
         return new Segment(mergedCoordinates);
     }

--- a/backend/src/main/java/coursepick/coursepick/domain/Segment.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Segment.java
@@ -2,8 +2,26 @@ package coursepick.coursepick.domain;
 
 import java.util.List;
 
-public record Segment(
-        InclineType inclineType,
-        List<Coordinate> coordinates
-) {
+public class Segment {
+
+    public static List<Segment> split(List<Coordinate> coordinates) {
+        return null;
+    }
+
+    public static List<Segment> mergeSameInclineType(List<Segment> segments) {
+        return null;
+    }
+
+    /*
+    -5도 이하 다운힐
+    -4도 ~ 4도 평지
+    5도 이상 업힐
+     */
+    public InclineType inclineType() {
+        return null;
+    }
+
+    public List<Coordinate> coordinates() {
+        return null;
+    }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
@@ -19,7 +19,7 @@ public record CourseWebResponse(
         RoadType roadType,
         @Schema(example = "1.235")
         double difficulty,
-        List<CoordinateWebResponse> coordinates
+        List<SegmentWebResponse> segments
 ) {
     public static List<CourseWebResponse> from(List<CourseResponse> courseResponses) {
         return courseResponses.stream()
@@ -30,7 +30,7 @@ public record CourseWebResponse(
                         courseResponse.length().value(),
                         courseResponse.roadType(),
                         courseResponse.difficulty(),
-                        CoordinateWebResponse.from(courseResponse.coordinates())
+                        SegmentWebResponse.from(courseResponse.segments())
                 )).toList();
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/SegmentWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/SegmentWebResponse.java
@@ -1,0 +1,18 @@
+package coursepick.coursepick.presentation.dto;
+
+import coursepick.coursepick.application.dto.SegmentResponse;
+import coursepick.coursepick.domain.InclineType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record SegmentWebResponse(
+        @Schema(example = "UPHILL")
+        InclineType inclineType,
+        List<CoordinateWebResponse> coordinates
+) {
+    public static List<SegmentWebResponse> from(List<SegmentResponse> segments) {
+        // TODO : 구현
+        return null;
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/SegmentWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/SegmentWebResponse.java
@@ -11,8 +11,9 @@ public record SegmentWebResponse(
         InclineType inclineType,
         List<CoordinateWebResponse> coordinates
 ) {
-    public static List<SegmentWebResponse> from(List<SegmentResponse> segments) {
-        // TODO : 구현
-        return null;
+    public static List<SegmentWebResponse> from(List<SegmentResponse> segmentResponses) {
+        return segmentResponses.stream()
+                .map(segmentResponse -> new SegmentWebResponse(segmentResponse.inclineType(), CoordinateWebResponse.from(segmentResponse.coordinates())))
+                .toList();
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/domain/CourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/CourseTest.java
@@ -293,4 +293,60 @@ class CourseTest {
                 )
         );
     }
+
+    @Nested
+    class 세그먼트_분리_테스트 {
+
+        @Test
+        void 코스의_세그먼트를_생성한다() {
+            Course course = new Course("테스트코스", List.of(
+                    new Coordinate(0, 0, 0),        // 시작점
+                    new Coordinate(0, 0.0001, 10),  // 오르막 (UPHILL)
+                    new Coordinate(0, 0.0002, 20),  // 오르막 (UPHILL)
+                    new Coordinate(0, 0.0003, 20),  // 평지 (FLAT)
+                    new Coordinate(0, 0.0002, 10),  // 내리막 (DOWNHILL)
+                    new Coordinate(0, 0, 0)         // 시작점으로 돌아옴
+            ));
+
+            List<Segment> segments = course.segments();
+
+            assertThat(segments).hasSize(3);
+
+            assertThat(segments.get(0).inclineType()).isEqualTo(InclineType.UPHILL);
+            assertThat(segments.get(0).coordinates()).hasSize(3).containsExactly(
+                    new Coordinate(0, 0, 0),        // 시작점
+                    new Coordinate(0, 0.0001, 10),  // 오르막 (UPHILL)
+                    new Coordinate(0, 0.0002, 20)   // 오르막 (UPHILL)
+            );
+
+            assertThat(segments.get(1).inclineType()).isEqualTo(InclineType.FLAT);
+            assertThat(segments.get(1).coordinates()).hasSize(2).containsExactly(
+                    new Coordinate(0, 0.0002, 20),  // 오르막 (UPHILL)
+                    new Coordinate(0, 0.0003, 20)   // 평지 (FLAT)
+            );
+
+            assertThat(segments.get(2).inclineType()).isEqualTo(InclineType.DOWNHILL);
+            assertThat(segments.get(2).coordinates()).hasSize(3).containsExactly(
+                    new Coordinate(0, 0.0003, 20),  // 평지 (FLAT)
+                    new Coordinate(0, 0.0002, 10),  // 내리막 (DOWNHILL)
+                    new Coordinate(0, 0, 0)         // 시작점으로 돌아옴
+            );
+        }
+
+        @Test
+        void 동일한_경사타입과_방향의_세그먼트들이_올바르게_병합된다() {
+            Course course = new Course("병합테스트코스", List.of(
+                    new Coordinate(0, 0, 0),
+                    new Coordinate(0, 0.0010, 8),   // 오르막 (약 4.5도)
+                    new Coordinate(0, 0.0020, 16),  // 오르막 (약 4.5도)
+                    new Coordinate(0, 0.0010, 8),   // 내리막 (약 -4.5도)
+                    new Coordinate(0, 0, 0)         // 내리막 (약 -4.5도)
+            ));
+
+            List<Segment> segments = course.segments();
+
+            // 같은 방향과 경사타입의 세그먼트들이 병합되어야 함
+            assertThat(segments).hasSize(1);
+        }
+    }
 }

--- a/backend/src/test/java/coursepick/coursepick/domain/GeoLineTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/GeoLineTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GeoLineTest {
@@ -30,6 +32,26 @@ class GeoLineTest {
         Meter distance = geoLine.length();
 
         assertThat(distance.value()).isCloseTo(0, Percentage.withPercentage(1));
+    }
+
+    @Test
+    void 좌표들을_2개_단위로_쪼갠다() {
+        List<Coordinate> coordinates = List.of(
+                new Coordinate(0, 0, 0),
+                new Coordinate(1, 1, 10),
+                new Coordinate(2, 2, 20),
+                new Coordinate(3, 3, 30)
+        );
+
+        List<GeoLine> geoLines = GeoLine.split(coordinates);
+
+        assertThat(geoLines).hasSize(3);
+        assertThat(geoLines.get(0).start()).isEqualTo(new Coordinate(0, 0, 0));
+        assertThat(geoLines.get(0).end()).isEqualTo(new Coordinate(1, 1, 10));
+        assertThat(geoLines.get(1).start()).isEqualTo(new Coordinate(1, 1, 10));
+        assertThat(geoLines.get(1).end()).isEqualTo(new Coordinate(2, 2, 20));
+        assertThat(geoLines.get(2).start()).isEqualTo(new Coordinate(2, 2, 20));
+        assertThat(geoLines.get(2).end()).isEqualTo(new Coordinate(3, 3, 30));
     }
 
     @Nested

--- a/backend/src/test/java/coursepick/coursepick/domain/InclineTypeTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/InclineTypeTest.java
@@ -1,0 +1,34 @@
+package coursepick.coursepick.domain;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InclineTypeTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0, 0, 0, 0.0009, 0, FLAT",          // 0도
+            "0, 0, 0, 0, 0.0009, 3, FLAT",          // 1.7x도
+            "0, 0, 0, 0, 0.0009, 7, FLAT",          // 4.0x도
+            "0, 0, 0, 0, 0.0009, 8.8, UPHILL",      // 5.1x도
+            "0, 0, 0, 0, 0.0009, 15, UPHILL",       // 8.5x도
+            "0, 0, 0, 0, 0.0009, -15, DOWNHILL",    // -8.5x도
+            "0, 0, 0, 0, 0.0009, -8.8, DOWNHILL",   // -5.1x도
+            "0, 0, 0, 0, 0.0009, -7, FLAT",         // -4.0x도
+            "0, 0, 0, 0, 0.0009, -3, FLAT"          // -1.7x도
+    })
+    void 두_좌표간_경사_타입을_계산한다(
+            double startLat, double startLng, double startElev,
+            double endLat, double endLng, double endElev,
+            InclineType expected
+    ) {
+        Coordinate start = new Coordinate(startLat, startLng, startElev);
+        Coordinate end = new Coordinate(endLat, endLng, endElev);
+
+        InclineType result = InclineType.of(start, end);
+
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/domain/SegmentTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/SegmentTest.java
@@ -9,32 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SegmentTest {
 
     @Test
-    void 좌표들을_2개_단위의_세그먼트로_쪼갠다() {
-        List<Coordinate> coordinates = List.of(
-                new Coordinate(0, 0, 0),
-                new Coordinate(1, 1, 10),
-                new Coordinate(2, 2, 20),
-                new Coordinate(3, 3, 30)
-        );
-
-        List<Segment> segments = Segment.split(coordinates);
-
-        assertThat(segments).hasSize(3);
-        assertThat(segments.get(0).coordinates()).containsExactly(
-                new Coordinate(0, 0, 0),
-                new Coordinate(1, 1, 10)
-        );
-        assertThat(segments.get(1).coordinates()).containsExactly(
-                new Coordinate(1, 1, 10),
-                new Coordinate(2, 2, 20)
-        );
-        assertThat(segments.get(2).coordinates()).containsExactly(
-                new Coordinate(2, 2, 20),
-                new Coordinate(3, 3, 30)
-        );
-    }
-
-    @Test
     void 경향성이_같은_세그먼트끼리_합친다() {
         List<Segment> segments = List.of(
                 new Segment(List.of(new Coordinate(0, 0, 0), new Coordinate(1, 1, 10))),    // UP

--- a/backend/src/test/java/coursepick/coursepick/domain/SegmentTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/SegmentTest.java
@@ -1,0 +1,87 @@
+package coursepick.coursepick.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SegmentTest {
+
+    @Test
+    void 좌표들을_2개_단위의_세그먼트로_쪼갠다() {
+        List<Coordinate> coordinates = List.of(
+                new Coordinate(0, 0, 0),
+                new Coordinate(1, 1, 10),
+                new Coordinate(2, 2, 20),
+                new Coordinate(3, 3, 30)
+        );
+
+        List<Segment> segments = Segment.split(coordinates);
+
+        assertThat(segments).hasSize(3);
+        assertThat(segments.get(0).coordinates()).containsExactly(
+                new Coordinate(0, 0, 0),
+                new Coordinate(1, 1, 10)
+        );
+        assertThat(segments.get(1).coordinates()).containsExactly(
+                new Coordinate(1, 1, 10),
+                new Coordinate(2, 2, 20)
+        );
+        assertThat(segments.get(2).coordinates()).containsExactly(
+                new Coordinate(2, 2, 20),
+                new Coordinate(3, 3, 30)
+        );
+    }
+
+    @Test
+    void 경향성이_같은_세그먼트끼리_합친다() {
+        List<Segment> segments = List.of(
+                new Segment(List.of(new Coordinate(0, 0, 0), new Coordinate(1, 1, 10))),    // UP
+                new Segment(List.of(new Coordinate(1, 1, 10), new Coordinate(2, 2, 20))),   // UP
+                new Segment(List.of(new Coordinate(2, 2, 20), new Coordinate(3, 3, 10)))    // DOWN
+        );
+
+        List<Segment> mergedSegments = Segment.mergeSameDirection(segments);
+
+        assertThat(mergedSegments).hasSize(2);
+        assertThat(mergedSegments.get(0).coordinates()).containsExactly(
+                new Coordinate(0, 0, 0),
+                new Coordinate(1, 1, 10),
+                new Coordinate(2, 2, 20)
+        );
+        assertThat(mergedSegments.get(1).coordinates()).containsExactly(
+                new Coordinate(2, 2, 20),
+                new Coordinate(3, 3, 10)
+        );
+    }
+
+    @Test
+    void 경사타입이_같은_세그먼트끼리_합친다() {
+        List<Segment> segments = List.of(
+                new Segment(List.of(new Coordinate(0, 0, 0), new Coordinate(0, 0.0009, 15))),       // UPHILL
+                new Segment(List.of(new Coordinate(0, 0.0009, 15), new Coordinate(0, 0.0018, 30))), // UPHILL
+                new Segment(List.of(new Coordinate(0, 0.0018, 30), new Coordinate(0, 0.0027, 30))), // FLAT
+                new Segment(List.of(new Coordinate(0, 0.0027, 30), new Coordinate(0, 0.0036, 30))), // FLAT
+                new Segment(List.of(new Coordinate(0, 0.0036, 30), new Coordinate(0, 0.0048, 15)))  // DOWNHILL
+        );
+
+        List<Segment> mergedSegments = Segment.mergeSameInclineType(segments);
+
+        assertThat(mergedSegments).hasSize(3);
+        assertThat(mergedSegments.get(0).coordinates()).containsExactly(
+                new Coordinate(0, 0, 0),
+                new Coordinate(0, 0.0009, 15),
+                new Coordinate(0, 0.0018, 30)
+        );
+        assertThat(mergedSegments.get(1).coordinates()).containsExactly(
+                new Coordinate(0, 0.0018, 30),
+                new Coordinate(0, 0.0027, 30),
+                new Coordinate(0, 0.0036, 30)
+        );
+        assertThat(mergedSegments.get(2).coordinates()).containsExactly(
+                new Coordinate(0, 0.0036, 30),
+                new Coordinate(0, 0.0048, 15)
+        );
+    }
+}


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- API 응답에 경사 정보가 추가되었습니다.
- `Segment` 값 객체가 도입되어, 경사 정보를 계산하는데 도움을 줍니다.

### 경사 정보 계산하기
1. 좌표를 2개짜리 `GeoLine`로 분리합니다. (7개 좌표라면 6개 `GeoLine`로 분리)
2. `GeoLine`을 `Segment`로 1:1 변환합니다.
3. `Segment`들을 경사 경향성에 따라 합칩니다. (ex. 상승-상승-하강-평지-평지 -> 상승-하강-평지)
4. `Segment`들을 경사 정보에 따라 합칩니다. (ex. 상승(6도)-하강(-2도)-평지(0도) -> 상승(6도)-평지(-2도))
(여기서 경사 정보란, -4도~4도 를 평지로 계산하는 로직을 뜻합니다.)

## 📸 스크린샷
<img width="517" height="609" alt="image" src="https://github.com/user-attachments/assets/ddfb52f5-f812-430c-950f-a7a30c33af07" />

## 🔗 관련 이슈
- closes #162 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 코스 경로 데이터가 좌표 단위에서 경사 타입(오르막, 내리막, 평지)을 포함한 세그먼트 단위로 변경되었습니다.
  * 세그먼트별 경사 타입 분류 및 병합 기능이 추가되었습니다.

* **테스트**
  * 세그먼트 분리 및 병합, 경사 타입 계산에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->