### PR TITLE
일자 코스 관련 객체 추가

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -6,7 +6,7 @@ public enum ErrorType {
     INVALID_LONGITUDE_RANGE("경도는 -180 이상, 180 미만이어야 합니다. 입력값=%s"),
     INVALID_NAME_LENGTH("이름은 2-30자 사이이어야 합니다. 입력값=%s"),
     INVALID_COORDINATE_COUNT("코스는 2개 이상의 좌표로 구성되어야 합니다. 현재 개수=%s"),
-    NOT_CONNECTED_COURSE("코스는 첫 좌표와 끝 좌표가 동일해야 합니다. 첫 좌표=%s, 끝 좌표=%s"),
+    NOT_CONNECTED_CIRCLE_COURSE("원형 코스는 첫 좌표와 끝 좌표가 동일해야 합니다. 첫 좌표=%s, 끝 좌표=%s"),
     NOT_EXIST_COURSE("코스가 존재하지 않습니다. 코스id=%d"),
     INVALID_FILE_EXTENSION("파싱할 수 없는 파일 확장자입니다."),
     ;

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -9,6 +9,7 @@ public enum ErrorType {
     NOT_CONNECTED_CIRCLE_COURSE("원형 코스는 첫 좌표와 끝 좌표가 동일해야 합니다. 첫 좌표=%s, 끝 좌표=%s"),
     NOT_EXIST_COURSE("코스가 존재하지 않습니다. 코스id=%d"),
     INVALID_FILE_EXTENSION("파싱할 수 없는 파일 확장자입니다."),
+    INVALID_FILE("파")
     ;
 
     private final String message;

--- a/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
@@ -46,7 +46,7 @@ public class CircleCourse extends Course {
 
     private void validateIsCircle(List<Coordinate> coordinates) {
         if (!coordinates.getFirst().hasSameLatitudeAndLongitude(coordinates.getLast())) {
-            throw new IllegalArgumentException(ErrorType.NOT_CONNECTED_CIRCLE_COURSE.message());
+            throw new IllegalArgumentException(ErrorType.NOT_CONNECTED_CIRCLE_COURSE.message(coordinates.getFirst(), coordinates.getLast()));
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
@@ -1,0 +1,78 @@
+package coursepick.coursepick.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+
+import jakarta.persistence.Entity;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("Circle")
+@NoArgsConstructor
+public class CircleCourse extends Course {
+
+    public CircleCourse(String name, RoadType roadType, List<Coordinate> coordinates) {
+        super(name, roadType, sortByCounterClockwise(coordinates));
+        validateIsCircle(coordinates);
+    }
+
+    public CircleCourse(String name, List<Coordinate> coordinates) {
+        this(name, RoadType.알수없음, coordinates);
+    }
+
+    @Override
+    public Coordinate closestCoordinateFrom(Coordinate target) {
+        Coordinate closestCoordinate = coordinates.getFirst();
+        Meter minDistance = Meter.max();
+
+        for (int i = 0; i < coordinates.size() - 1; i++) {
+            GeoLine line = GeoLine.between(coordinates.get(i), coordinates.get(i + 1));
+
+            Coordinate closestCoordinateOnLine = line.closestCoordinateFrom(target);
+            Meter distanceOnLine = GeoLine.between(target, closestCoordinateOnLine).length();
+            if (distanceOnLine.isWithin(minDistance)) {
+                minDistance = distanceOnLine;
+                closestCoordinate = closestCoordinateOnLine;
+            }
+        }
+
+        return closestCoordinate;
+    }
+
+    private void validateIsCircle(List<Coordinate> coordinates) {
+        if (!coordinates.getFirst().equals(coordinates.getLast())) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private static List<Coordinate> sortByCounterClockwise(List<Coordinate> coordinates) {
+        int lowestCoordinateIndex = findLowestCoordinateIndex(coordinates);
+        List<Coordinate> counterClockWiseCoordinates = new ArrayList<>(coordinates);
+        if (isClockwise(coordinates, lowestCoordinateIndex)) {
+            Collections.reverse(counterClockWiseCoordinates);
+        }
+        return counterClockWiseCoordinates;
+    }
+
+    private static int findLowestCoordinateIndex(List<Coordinate> coordinates) {
+        int lowestCoordinateIndex = 0;
+        double lowestLatitude = Double.MAX_VALUE;
+        for (int i = 0; i < coordinates.size(); i++) {
+            Coordinate coordinate = coordinates.get(i);
+            if (coordinate.latitude() < lowestLatitude) {
+                lowestLatitude = coordinate.latitude();
+                lowestCoordinateIndex = i;
+            }
+        }
+        return lowestCoordinateIndex;
+    }
+
+    private static boolean isClockwise(List<Coordinate> coordinates, int lowestCoordinateIndex) {
+        int nextIndex = (lowestCoordinateIndex + 1) % coordinates.size();
+        return coordinates.get(lowestCoordinateIndex).isRightOf(coordinates.get(nextIndex));
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
@@ -1,5 +1,6 @@
 package coursepick.coursepick.domain;
 
+import coursepick.coursepick.application.exception.ErrorType;
 import jakarta.persistence.DiscriminatorValue;
 
 import jakarta.persistence.Entity;
@@ -17,7 +18,7 @@ public class CircleCourse extends Course {
 
     public CircleCourse(String name, RoadType roadType, List<Coordinate> coordinates) {
         super(name, roadType, sortByCounterClockwise(coordinates));
-        validateIsCircle(coordinates);
+        validateIsCircle(this.coordinates);
     }
 
     public CircleCourse(String name, List<Coordinate> coordinates) {
@@ -45,7 +46,7 @@ public class CircleCourse extends Course {
 
     private void validateIsCircle(List<Coordinate> coordinates) {
         if (!coordinates.getFirst().equals(coordinates.getLast())) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException(ErrorType.NOT_CONNECTED_CIRCLE_COURSE.message());
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CircleCourse.java
@@ -45,7 +45,7 @@ public class CircleCourse extends Course {
     }
 
     private void validateIsCircle(List<Coordinate> coordinates) {
-        if (!coordinates.getFirst().equals(coordinates.getLast())) {
+        if (!coordinates.getFirst().hasSameLatitudeAndLongitude(coordinates.getLast())) {
             throw new IllegalArgumentException(ErrorType.NOT_CONNECTED_CIRCLE_COURSE.message());
         }
     }

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -1,35 +1,40 @@
 package coursepick.coursepick.domain;
 
 import jakarta.persistence.*;
+
+import java.util.ArrayList;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static coursepick.coursepick.application.exception.ErrorType.INVALID_COORDINATE_COUNT;
 import static coursepick.coursepick.application.exception.ErrorType.INVALID_NAME_LENGTH;
 
 @Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DTYPE")
 @NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
-public class Course {
+public abstract class Course {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private final Long id;
+    protected final Long id;
 
     @Column(nullable = false, length = 50)
-    private final String name;
+    protected final String name;
 
     @Enumerated(EnumType.STRING)
-    private final RoadType roadType;
+    protected final RoadType roadType;
 
     @ElementCollection
     @CollectionTable(name = "coordinate")
-    private final List<Coordinate> coordinates;
+    protected final List<Coordinate> coordinates;
 
-    public Course(String name, RoadType roadType, List<Coordinate> coordinates) {
+    public abstract Coordinate closestCoordinateFrom(Coordinate target);
+
+    protected Course(String name, RoadType roadType, List<Coordinate> coordinates) {
         String compactName = compactName(name);
         validateNameLength(compactName);
         validateCoordinatesCount(coordinates);
@@ -37,11 +42,7 @@ public class Course {
         this.id = null;
         this.name = compactName;
         this.roadType = roadType;
-        this.coordinates = sortByCounterClockwise(connectStartEndCoordinate(coordinates));
-    }
-
-    public Course(String name, List<Coordinate> coordinates) {
-        this(name, RoadType.알수없음, coordinates);
+        this.coordinates = new ArrayList<>(coordinates);
     }
 
     public Meter length() {
@@ -56,24 +57,6 @@ public class Course {
         }
 
         return total;
-    }
-
-    public Coordinate closestCoordinateFrom(Coordinate target) {
-        Coordinate closestCoordinate = coordinates.getFirst();
-        Meter minDistance = Meter.max();
-
-        for (int i = 0; i < coordinates.size() - 1; i++) {
-            GeoLine line = GeoLine.between(coordinates.get(i), coordinates.get(i + 1));
-
-            Coordinate closestCoordinateOnLine = line.closestCoordinateFrom(target);
-            Meter distanceOnLine = GeoLine.between(target, closestCoordinateOnLine).length();
-            if (distanceOnLine.isWithin(minDistance)) {
-                minDistance = distanceOnLine;
-                closestCoordinate = closestCoordinateOnLine;
-            }
-        }
-
-        return closestCoordinate;
     }
 
     public Meter distanceFrom(Coordinate target) {
@@ -124,44 +107,5 @@ public class Course {
         if (coordinates.size() < 2) {
             throw new IllegalArgumentException(INVALID_COORDINATE_COUNT.message(coordinates.size()));
         }
-    }
-
-    private List<Coordinate> connectStartEndCoordinate(List<Coordinate> coordinates) {
-        if (isFirstAndLastCoordinateDifferent(coordinates)) {
-            coordinates = new ArrayList<>(coordinates);
-            coordinates.add(coordinates.getFirst());
-        }
-        return coordinates;
-    }
-
-    private static boolean isFirstAndLastCoordinateDifferent(List<Coordinate> coordinates) {
-        return !coordinates.getFirst().hasSameLatitudeAndLongitude(coordinates.getLast());
-    }
-
-    private static List<Coordinate> sortByCounterClockwise(List<Coordinate> coordinates) {
-        int lowestCoordinateIndex = findLowestCoordinateIndex(coordinates);
-        List<Coordinate> counterClockWiseCoordinates = new ArrayList<>(coordinates);
-        if (isClockwise(coordinates, lowestCoordinateIndex)) {
-            Collections.reverse(counterClockWiseCoordinates);
-        }
-        return counterClockWiseCoordinates;
-    }
-
-    private static int findLowestCoordinateIndex(List<Coordinate> coordinates) {
-        int lowestCoordinateIndex = 0;
-        double lowestLatitude = Double.MAX_VALUE;
-        for (int i = 0; i < coordinates.size(); i++) {
-            Coordinate coordinate = coordinates.get(i);
-            if (coordinate.latitude() < lowestLatitude) {
-                lowestLatitude = coordinate.latitude();
-                lowestCoordinateIndex = i;
-            }
-        }
-        return lowestCoordinateIndex;
-    }
-
-    private static boolean isClockwise(List<Coordinate> coordinates, int lowestCoordinateIndex) {
-        int nextIndex = (lowestCoordinateIndex + 1) % (coordinates.size() - 1);
-        return coordinates.get(lowestCoordinateIndex).isRightOf(coordinates.get(nextIndex));
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/CourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CourseParser.java
@@ -6,6 +6,6 @@ import java.util.List;
 public interface CourseParser {
 
     boolean canParse(String fileExtension);
-    
+
     List<Course> parse(InputStream fileStream);
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/LineCourse.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/LineCourse.java
@@ -26,7 +26,10 @@ public class LineCourse extends Course {
         Coordinate first = this.coordinates.getFirst();
         Coordinate last = this.coordinates.getLast();
 
-        if (first.equals(target)) {
+        Meter distanceToFirst = GeoLine.between(first, target).length();
+        Meter distanceToLast = GeoLine.between(last, target).length();
+
+        if (distanceToFirst.value() <= distanceToLast.value()) {
             return first;
         }
 

--- a/backend/src/main/java/coursepick/coursepick/domain/LineCourse.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/LineCourse.java
@@ -1,0 +1,35 @@
+package coursepick.coursepick.domain;
+
+import jakarta.persistence.DiscriminatorValue;
+
+import jakarta.persistence.Entity;
+
+import java.util.List;
+
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("Line")
+@NoArgsConstructor
+public class LineCourse extends Course {
+
+    public LineCourse(String name, RoadType roadType, List<Coordinate> coordinates) {
+        super(name, roadType, coordinates);
+    }
+
+    public LineCourse(String name, List<Coordinate> coordinates) {
+        this(name, RoadType.알수없음, coordinates);
+    }
+
+    @Override
+    public Coordinate closestCoordinateFrom(Coordinate target) {
+        Coordinate first = this.coordinates.getFirst();
+        Coordinate last = this.coordinates.getLast();
+
+        if (first.equals(first)) {
+            return first;
+        }
+
+        return last;
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/domain/LineCourse.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/LineCourse.java
@@ -26,7 +26,7 @@ public class LineCourse extends Course {
         Coordinate first = this.coordinates.getFirst();
         Coordinate last = this.coordinates.getLast();
 
-        if (first.equals(first)) {
+        if (first.equals(target)) {
             return first;
         }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
@@ -39,11 +39,18 @@ public class GpxCourseParser implements CourseParser {
         String trackName = track.getName().orElse("Default");
 
         List<Coordinate> coordinates = getCoordinates(track);
+        validateCoordinatesIsEmpty(coordinates);
         if (coordinates.getFirst().equals(coordinates.getLast())) {
             return new CircleCourse(trackName, RoadType.알수없음, coordinates);
         }
 
         return new LineCourse(trackName, RoadType.알수없음, coordinates);
+    }
+
+    private static void validateCoordinatesIsEmpty(List<Coordinate> coordinates) {
+        if (coordinates.isEmpty()) {
+            throw new IllegalArgumentException("잘못된 GPX 파일입니다.");
+        }
     }
 
     private static List<Coordinate> getCoordinates(Track track) {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
@@ -3,6 +3,9 @@ package coursepick.coursepick.infrastructure;
 import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
 import coursepick.coursepick.domain.CourseParser;
+import coursepick.coursepick.domain.RoadType;
+import coursepick.coursepick.domain.CircleCourse;
+import coursepick.coursepick.domain.LineCourse;
 import io.jenetics.jpx.GPX;
 import io.jenetics.jpx.Length;
 import io.jenetics.jpx.Track;
@@ -25,11 +28,22 @@ public class GpxCourseParser implements CourseParser {
             GPX gpx = GPX.Reader.of(GPX.Reader.Mode.LENIENT).read(fileStream);
 
             return gpx.tracks()
-                    .map(track -> new Course(track.getName().orElse("Default"), getCoordinates(track)))
+                    .map(track -> createCourseBy(track))
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static Course createCourseBy(Track track) {
+        String trackName = track.getName().orElse("Default");
+
+        List<Coordinate> coordinates = getCoordinates(track);
+        if (coordinates.getFirst().equals(coordinates.getLast())) {
+            return new CircleCourse(trackName, RoadType.알수없음, coordinates);
+        }
+
+        return new LineCourse(trackName, RoadType.알수없음, coordinates);
     }
 
     private static List<Coordinate> getCoordinates(Track track) {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
@@ -1,5 +1,6 @@
 package coursepick.coursepick.infrastructure;
 
+import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
 import coursepick.coursepick.domain.CourseParser;
@@ -28,7 +29,7 @@ public class GpxCourseParser implements CourseParser {
             GPX gpx = GPX.Reader.of(GPX.Reader.Mode.LENIENT).read(fileStream);
 
             return gpx.tracks()
-                    .map(track -> createCourseBy(track))
+                    .map(GpxCourseParser::createCourseBy)
                     .toList();
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -40,7 +41,7 @@ public class GpxCourseParser implements CourseParser {
 
         List<Coordinate> coordinates = getCoordinates(track);
         validateCoordinatesIsEmpty(coordinates);
-        if (coordinates.getFirst().equals(coordinates.getLast())) {
+        if (coordinates.getFirst().hasSameLatitudeAndLongitude(coordinates.getLast())) {
             return new CircleCourse(trackName, RoadType.알수없음, coordinates);
         }
 
@@ -49,7 +50,7 @@ public class GpxCourseParser implements CourseParser {
 
     private static void validateCoordinatesIsEmpty(List<Coordinate> coordinates) {
         if (coordinates.isEmpty()) {
-            throw new IllegalArgumentException("잘못된 GPX 파일입니다.");
+            throw new IllegalArgumentException(ErrorType.INVALID_FILE_EXTENSION.message());
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
@@ -63,7 +63,7 @@ public class KmlCourseParser implements CourseParser {
         if (courseName == null || courseName.isBlank()) return null;
         if (coordinates.isEmpty()) return null;
 
-        if (coordinates.getFirst().equals(coordinates.getLast())) {
+        if (coordinates.getFirst().hasSameLatitudeAndLongitude(coordinates.getLast())) {
             return new CircleCourse(courseName, RoadType.알수없음, coordinates);
         }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
@@ -3,6 +3,9 @@ package coursepick.coursepick.infrastructure;
 import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
 import coursepick.coursepick.domain.CourseParser;
+import coursepick.coursepick.domain.RoadType;
+import coursepick.coursepick.domain.CircleCourse;
+import coursepick.coursepick.domain.LineCourse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
@@ -60,7 +63,11 @@ public class KmlCourseParser implements CourseParser {
         if (courseName == null || courseName.isBlank()) return null;
         if (coordinates.isEmpty()) return null;
 
-        return new Course(courseName, coordinates);
+        if (coordinates.getFirst().equals(coordinates.getLast())) {
+            return new CircleCourse(courseName, RoadType.알수없음, coordinates);
+        }
+
+        return new LineCourse(courseName, RoadType.알수없음, coordinates);
     }
 
     private String parseCourseName(Element placemark) {

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -2,8 +2,7 @@ package coursepick.coursepick.application;
 
 import coursepick.coursepick.application.dto.CourseResponse;
 import coursepick.coursepick.application.exception.NotFoundException;
-import coursepick.coursepick.domain.Coordinate;
-import coursepick.coursepick.domain.Course;
+import coursepick.coursepick.domain.*;
 import coursepick.coursepick.test_util.DatabaseCleaner;
 import coursepick.coursepick.test_util.DatabaseInserter;
 import org.assertj.core.api.Assertions;
@@ -35,19 +34,19 @@ class CourseApplicationServiceTest {
 
     @Test
     void 가까운_코스들을_조회한다() {
-        Course course1 = new Course("한강 러닝 코스", List.of(
+        Course course1 = new CircleCourse("한강 러닝 코스", RoadType.트랙, List.of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ));
-        Course course2 = new Course("양재천 산책길", List.of(
+        Course course2 = new CircleCourse("양재천 산책길", RoadType.트랙, List.of(
                 new Coordinate(37.5165, 127.0285),
                 new Coordinate(37.5160, 127.0278),
                 new Coordinate(37.5155, 127.0265),
                 new Coordinate(37.5165, 127.0285)
         ));
-        Course course3 = new Course("북악산 둘레길", List.of(
+        Course course3 = new CircleCourse("북악산 둘레길", RoadType.트레일, List.of(
                 new Coordinate(37.602500, 126.967000),
                 new Coordinate(37.603000, 126.968000),
                 new Coordinate(37.603500, 126.969000),
@@ -71,7 +70,7 @@ class CourseApplicationServiceTest {
 
     @Test
     void 코스의_좌표_중에서_가장_가까운_좌표를_계산한다() {
-        Course course = new Course("한강 러닝 코스", List.of(
+        Course course = new CircleCourse("한강 러닝 코스", List.of(
                 new Coordinate(0, 0),
                 new Coordinate(10, 10),
                 new Coordinate(0, 0)

--- a/backend/src/test/java/coursepick/coursepick/domain/CircleCourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/CircleCourseTest.java
@@ -1,0 +1,43 @@
+package coursepick.coursepick.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CircleCourseTest {
+
+    @Test
+    void 코스_외부_멀리_떨어진_점에서_코스까지의_거리를_계산한다() {
+        var course = new CircleCourse("작은원형코스", List.of(
+                new Coordinate(37.5, 127.0),
+                new Coordinate(37.5001, 127.0),
+                new Coordinate(37.5, 127.0001),
+                new Coordinate(37.4999, 127.0),
+                new Coordinate(37.5, 127.0)
+        ));
+        var target = new Coordinate(37.52, 127.02); // 매우 멀리 떨어진 점
+
+        var distance = course.distanceFrom(target);
+
+        assertThat((int) distance.value()).isEqualTo(2829);
+    }
+
+    @Test
+    void 코스_내부의_점에서_코스까지의_거리를_계산한다() {
+        var course = new CircleCourse("사각형코스", List.of(
+                new Coordinate(37.5, 127.0),
+                new Coordinate(37.501, 127.0),
+                new Coordinate(37.501, 127.001),
+                new Coordinate(37.5, 127.001),
+                new Coordinate(37.5, 127.0)
+        ));
+        var target = new Coordinate(37.5005, 127.0005); // 사각형 중앙
+
+        var distance = course.distanceFrom(target);
+
+        assertThat((int) distance.value()).isEqualTo(44);
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
@@ -28,7 +28,7 @@ class CourseRepositoryTest {
             "600, 1"
     })
     void 거리를_줄여가면서_검색되는_코스_수가_줄어든다(int distance, int expectedSize) {
-        Course course1 = new Course("잠실 한강 산책길", List.of(
+        Course course1 = new CircleCourse("잠실 한강 산책길", List.of(
                 new Coordinate(37.522490, 127.099029),
                 new Coordinate(37.521818, 127.096380),
                 new Coordinate(37.520995, 127.095899),
@@ -45,7 +45,7 @@ class CourseRepositoryTest {
                 new Coordinate(37.522273, 127.099238),
                 new Coordinate(37.522490, 127.099029)
         ));
-        Course course2 = new Course("잠실 종합운동장", List.of(
+        Course course2 = new CircleCourse("잠실 종합운동장", List.of(
                 new Coordinate(37.517802, 127.069576),
                 new Coordinate(37.510638, 127.070661),
                 new Coordinate(37.511926, 127.078170),
@@ -53,7 +53,7 @@ class CourseRepositoryTest {
                 new Coordinate(37.518201, 127.072168),
                 new Coordinate(37.517802, 127.069576)
         ));
-        Course course3 = new Course("잠실제일교회 둘레길", List.of(
+        Course course3 = new CircleCourse("잠실제일교회 둘레길", List.of(
                 new Coordinate(37.517396, 127.092439),
                 new Coordinate(37.512785, 127.094059),
                 new Coordinate(37.513460, 127.097520),

--- a/backend/src/test/java/coursepick/coursepick/domain/CourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/CourseTest.java
@@ -22,13 +22,13 @@ class CourseTest {
 
         @Test
         void 코스를_생성한다() {
-            assertThatCode(() -> new Course("코스이름", getNormalCoordinates()))
+            assertThatCode(() -> new CircleCourse("코스이름", getNormalCoordinates()))
                     .doesNotThrowAnyException();
         }
 
         @Test
         void 앞_뒤_공백을_제거하여_생성한다() {
-            var course = new Course(" 코스이름   ", getNormalCoordinates());
+            var course = new CircleCourse(" 코스이름   ", getNormalCoordinates());
             assertThat(course.name()).isEqualTo("코스이름");
         }
 
@@ -38,7 +38,7 @@ class CourseTest {
                 "짧"
         })
         void 잘못된_길이의_이름으로_코스를_생성하면_예외가_발생한다(String name) {
-            assertThatThrownBy(() -> new Course(name, getNormalCoordinates()))
+            assertThatThrownBy(() -> new CircleCourse(name, getNormalCoordinates()))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -50,19 +50,19 @@ class CourseTest {
                 "코스    이름",
         })
         void 이름의_연속공백을_한_칸으로_변환하여_코스를_생성한다(String name) {
-            var course = new Course(name, getNormalCoordinates());
+            var course = new CircleCourse(name, getNormalCoordinates());
             assertThat(course.name()).isEqualTo("코스 이름");
         }
 
         @Test
         void 코스의_좌표의_개수가_2보다_적으면_예외가_발생한다() {
-            assertThatThrownBy(() -> new Course("코스이름", List.of(new Coordinate(1d, 1d))))
+            assertThatThrownBy(() -> new CircleCourse("코스이름", List.of(new Coordinate(1d, 1d))))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         void 반시계방향이면_그대로_설정된다() {
-            var counter = new Course("코스이름", List.of(
+            var counter = new CircleCourse("코스이름", List.of(
                     new Coordinate(0d, 0d),
                     new Coordinate(5d, 5d),
                     new Coordinate(0d, 10d),
@@ -81,7 +81,7 @@ class CourseTest {
 
         @Test
         void 시계방향이면_반대로_설정된다() {
-            var clockwiseCourse = new Course("코스이름", List.of(
+            var clockwiseCourse = new CircleCourse("코스이름", List.of(
                     new Coordinate(0d, 0d),
                     new Coordinate(5d, -5d),
                     new Coordinate(0d, 10d),
@@ -105,7 +105,7 @@ class CourseTest {
 
     @Test
     void 코스의_총_거리를_계산할_수_있다() {
-        var course = new Course("한강뛰어보자", List.of(
+        var course = new CircleCourse("한강뛰어보자", List.of(
                 new Coordinate(37.518400, 126.995600),
                 new Coordinate(37.518000, 126.996500),
                 new Coordinate(37.517500, 126.998000),
@@ -134,7 +134,7 @@ class CourseTest {
             "37.516678, 126.997065, 46"
     })
     void 특정_좌표에서_코스까지_가장_가까운_거리를_계산할_수_있다(double latitude, double longitude, int expectedDistance) {
-        var course = new Course("한강뛰어보자", List.of(
+        var course = new CircleCourse("한강뛰어보자", List.of(
                 new Coordinate(37.519760, 126.995477),
                 new Coordinate(37.517083, 126.997182),
                 new Coordinate(37.519760, 126.995477)
@@ -148,7 +148,7 @@ class CourseTest {
 
     @Test
     void 코스_위의_점에서_코스까지의_거리는_0에_가깝다() {
-        var course = new Course("직선코스", List.of(
+        var course = new CircleCourse("직선코스", List.of(
                 new Coordinate(37.5, 127.0),
                 new Coordinate(37.5, 127.001),
                 new Coordinate(37.5, 127.0)
@@ -162,7 +162,7 @@ class CourseTest {
 
     @Test
     void 코스_시작점에서_코스까지의_거리는_0이다() {
-        var course = new Course("삼각형코스", List.of(
+        var course = new CircleCourse("삼각형코스", List.of(
                 new Coordinate(37.5, 127.0),
                 new Coordinate(37.501, 127.0),
                 new Coordinate(37.5005, 127.001),
@@ -175,38 +175,6 @@ class CourseTest {
         assertThat(distance.value()).isEqualTo(0.0);
     }
 
-    @Test
-    void 코스_내부의_점에서_코스까지의_거리를_계산한다() {
-        var course = new Course("사각형코스", List.of(
-                new Coordinate(37.5, 127.0),
-                new Coordinate(37.501, 127.0),
-                new Coordinate(37.501, 127.001),
-                new Coordinate(37.5, 127.001),
-                new Coordinate(37.5, 127.0)
-        ));
-        var target = new Coordinate(37.5005, 127.0005); // 사각형 중앙
-
-        var distance = course.distanceFrom(target);
-
-        assertThat((int) distance.value()).isEqualTo(44);
-    }
-
-    @Test
-    void 코스_외부_멀리_떨어진_점에서_코스까지의_거리를_계산한다() {
-        var course = new Course("작은원형코스", List.of(
-                new Coordinate(37.5, 127.0),
-                new Coordinate(37.5001, 127.0),
-                new Coordinate(37.5, 127.0001),
-                new Coordinate(37.4999, 127.0),
-                new Coordinate(37.5, 127.0)
-        ));
-        var target = new Coordinate(37.52, 127.02); // 매우 멀리 떨어진 점
-
-        var distance = course.distanceFrom(target);
-
-        assertThat((int) distance.value()).isEqualTo(2829);
-    }
-
     @ParameterizedTest
     @CsvSource({
             "37.4999, 126.9999, 14",   // 코스 바로 옆
@@ -214,7 +182,7 @@ class CourseTest {
             "37.5, 126.999, 88"        // 코스에서 서쪽으로 100m
     })
     void 코스_주변_다양한_위치에서의_거리를_계산한다(double latitude, double longitude, int expectedDistance) {
-        var course = new Course("정사각형코스", List.of(
+        var course = new CircleCourse("정사각형코스", List.of(
                 new Coordinate(37.5, 127.0),
                 new Coordinate(37.5001, 127.0),
                 new Coordinate(37.5001, 127.0001),
@@ -236,7 +204,7 @@ class CourseTest {
             "5, 0, 2.5, 2.5"
     })
     void 코스의_좌표_중에서_가장_가까운_좌표를_계산한다(double targetLatitude, double targetLongitude, double latitude, double longitude) {
-        Course course = new Course("왕복코스", List.of(
+        Course course = new CircleCourse("왕복코스", List.of(
                 new Coordinate(0, 0),
                 new Coordinate(10, 10.0),
                 new Coordinate(0, 0)
@@ -252,7 +220,7 @@ class CourseTest {
     @ParameterizedTest
     @MethodSource("createArguments")
     void 코스의_난이도를_계산한다(List<Coordinate> coordinates, RoadType roadType, double expectedDifficulty) {
-        var course = new Course("코스", roadType, coordinates);
+        var course = new CircleCourse("코스", roadType, coordinates);
 
         var difficulty = course.difficulty();
 

--- a/backend/src/test/java/coursepick/coursepick/domain/LineCourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/LineCourseTest.java
@@ -1,0 +1,40 @@
+package coursepick.coursepick.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LineCourseTest {
+
+    @Test
+    void 코스_외부_멀리_떨어진_점에서_코스까지의_거리를_계산한다() {
+        var course = new LineCourse("작은원형코스", List.of(
+                new Coordinate(37.5, 127.0),
+                new Coordinate(37.5001, 127.0),
+                new Coordinate(37.5, 127.0001),
+                new Coordinate(37.4999, 127.0)
+        ));
+        var target = new Coordinate(37.52, 127.02); // 매우 멀리 떨어진 점
+
+        var distance = course.distanceFrom(target);
+
+        assertThat((int) distance.value()).isEqualTo(2838);
+    }
+
+    @Test
+    void 코스_내부의_점에서_코스까지의_거리를_계산한다() {
+        var course = new LineCourse("사각형코스", List.of(
+                new Coordinate(37.5, 127.0),
+                new Coordinate(37.501, 127.0),
+                new Coordinate(37.501, 127.001),
+                new Coordinate(37.5, 127.001)
+        ));
+        var target = new Coordinate(37.501, 127.0);
+
+        var distance = course.distanceFrom(target);
+
+        assertThat((int) distance.value()).isEqualTo(111);
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
@@ -19,39 +19,18 @@ class GpxCourseParserTest {
         String text = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd" creator="StravaGPX" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
-                 <metadata>
-                  <time>2025-07-20T23:36:00Z</time>
-                 </metadata>
                  <trk>
                   <name>test-course</name>
                   <type>running</type>
                   <trkseg>
                    <trkpt lat="37.4869510" lon="126.9230870">
                     <ele>27.8</ele>
-                    <time>2025-07-20T23:36:00Z</time>
-                    <extensions>
-                     <gpxtpx:TrackPointExtension>
-                      <gpxtpx:cad>129</gpxtpx:cad>
-                     </gpxtpx:TrackPointExtension>
-                    </extensions>
                    </trkpt>
                    <trkpt lat="37.4869510" lon="126.9230870">
                     <ele>27.8</ele>
-                    <time>2025-07-20T23:36:01Z</time>
-                    <extensions>
-                     <gpxtpx:TrackPointExtension>
-                      <gpxtpx:cad>129</gpxtpx:cad>
-                     </gpxtpx:TrackPointExtension>
-                    </extensions>
                    </trkpt>
                    <trkpt lat="37.4845100" lon="126.9255380">
                     <ele>29.2</ele>
-                    <time>2025-07-20T23:38:03Z</time>
-                    <extensions>
-                     <gpxtpx:TrackPointExtension>
-                      <gpxtpx:cad>93</gpxtpx:cad>
-                     </gpxtpx:TrackPointExtension>
-                    </extensions>
                    </trkpt>
                   </trkseg>
                  </trk>
@@ -67,12 +46,11 @@ class GpxCourseParserTest {
         assertThat(courses).extracting(course -> course.name())
                 .contains("test-course");
         assertThat(courses).extracting(course -> course.coordinates().size())
-                .contains(3);
+                .contains(2);
         assertThat(courses).extracting(course -> course.coordinates())
                 .containsExactly(List.of(
                         new Coordinate(37.4869510, 126.9230870, 27.8),
-                        new Coordinate(37.4845100, 126.9255380, 29.2),
-                        new Coordinate(37.4869510, 126.9230870, 27.8)
+                        new Coordinate(37.4845100, 126.9255380, 29.2)
                 ));
     }
 }


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- Course를 추상화하여 LineCourse, CircleCourse로 나눔
- GPX, KML 파일 파싱 시 첫 좌표, 마지막 좌표에 따라 Cirlce, Line 생성하도록 리팩터링

- gpx, kml 파일의 코스를 어떻게 파싱하나?
1. GPX, KML 등 파일에 `<type>` 태그를 통해 원형 또는 선형임을 나타낸다.
	- GPX, KML 파일은 여러 개의 코스를 가질 수 있는데, 데이터를 넣을 때 한 파일 속 각각 코스마다 어떤 코스인지 판별하는 방법이 크게 2개가 있다고 생각했음.
		1. import.html에서 코스 유형을 지정한다.
		-> 해당 방법은 하나의 코스에 대해서는 가능하나, 여러 개 코스 대응 불가
		2. `<type>` 같은 태그를 추가하는 방식으로 구현한다.
		-> 코스 별로 타입을 지정할 수 있다. 다만 xml 구조 자체가 변한다는 단점이 생김.
2. GPX, KML 등 파일을 선보정한다.
	- 코스 유형에 따라 첫 좌표를 마지막에 넣는 보정 작업을 거치고 데이터를 넣어준다. ✅ (디랙과의 얘기를 통해 해당 방법으로 결정했다.)
		이유?
		- 넣는 주체는 당장 '어드민(코스픽 팀)'이다. 넣는 데이터가 어떻게 생겼을지는 알고있을 것.
---

1. 원형 코스는 시작점이 유동적이다.
	-> 유동적이면서 모든 점이 시작점이 될 수 있다.
2. 선형 코스는 시작점이 첫 좌표와 끝 좌표 둘 중 하나여야 한다.
	-> 처음엔 시작점을 첫 좌표로 고정했지만, 사용자에게 가까운 지점을 돌려주도록 사용자 경험에 일관성을 주려면 첫 좌표와 끝 좌표 둘 중 가까운 지점을 주는 것이 타당해보임.
	-> 다만, 오르막/내리막을 어떤 식으로 표현할지는 고민해봐야 할 문제!
<img width="780" height="330" alt="스크린샷 2025-07-30 10 22 51" src="https://github.com/user-attachments/assets/726011ef-43d9-4386-9452-71cb88e85285" />

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 원형 코스(CircleCourse)와 선형 코스(LineCourse) 유형이 도입되어 코스 유형을 구분할 수 있습니다.

* **버그 수정**
  * 오류 메시지가 더 명확하게 개선되었습니다.

* **테스트**
  * 원형 및 선형 코스에 대한 거리 계산 등 새로운 단위 테스트가 추가되었습니다.
  * 기존 테스트가 새로운 코스 유형에 맞게 수정되었습니다.

* **리팩터링**
  * GPX/KML 파일 파싱 시 코스 유형을 자동으로 판별하여 생성하도록 개선되었습니다.
  * 코스 관련 클래스 구조가 추상화 및 상속 구조로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->