### PR TITLE
다른 위치에서도 현위치 기준으로 거리를 응답하도록 주변 코스 조회 API 수정

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -48,10 +48,20 @@ public class CourseApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public List<CourseResponse> findNearbyCourses(double latitude, double longitude) {
-        final Coordinate target = new Coordinate(latitude, longitude);
-        return courseRepository.findAllHasDistanceWithin(target, new Meter(1000)).stream()
-                .map(course -> CourseResponse.from(course, target))
+    public List<CourseResponse> findNearbyCourses(double mapLatitude, double mapLongitude) {
+        final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
+        return courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(1000)).stream()
+                .map(CourseResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<CourseResponse> findNearbyCourses(double mapLatitude, double mapLongitude, double userLatitude, double userLongitude) {
+        final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
+        final Coordinate userPosition = new Coordinate(userLatitude, userLongitude);
+
+        return courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(1000)).stream()
+                .map(course -> CourseResponse.from(course, userPosition))
                 .toList();
     }
 

--- a/backend/src/main/java/coursepick/coursepick/application/dto/CourseResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/CourseResponse.java
@@ -4,18 +4,26 @@ import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
 import coursepick.coursepick.domain.Meter;
 import coursepick.coursepick.domain.RoadType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 
 import java.util.List;
+import java.util.Optional;
 
-public record CourseResponse(
-        Long id,
-        String name,
-        Meter distance,
-        Meter length,
-        RoadType roadType,
-        double difficulty,
-        List<SegmentResponse> segments
-) {
+@RequiredArgsConstructor
+@Getter
+@Accessors(fluent = true)
+public class CourseResponse {
+
+    private final Long id;
+    private final String name;
+    private final Meter distance;
+    private final Meter length;
+    private final RoadType roadType;
+    private final double difficulty;
+    private final List<SegmentResponse> segments;
+
     public static CourseResponse from(Course course, Coordinate target) {
         return new CourseResponse(
                 course.id(),
@@ -26,5 +34,21 @@ public record CourseResponse(
                 course.difficulty(),
                 SegmentResponse.from(course.segments())
         );
+    }
+
+    public static CourseResponse from(Course course) {
+        return new CourseResponse(
+                course.id(),
+                course.name(),
+                null,
+                course.length(),
+                course.roadType(),
+                course.difficulty(),
+                SegmentResponse.from(course.segments())
+        );
+    }
+
+    public Optional<Meter> distance() {
+        return Optional.ofNullable(distance);
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -9,7 +9,6 @@ import coursepick.coursepick.presentation.dto.CourseWebResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,10 +42,12 @@ public class CourseWebController implements CourseWebApi {
     @Override
     @GetMapping("/courses")
     public List<CourseWebResponse> findNearbyCourses(
-            @RequestParam("lat") double latitude,
-            @RequestParam("lng") double longitude
+            @RequestParam("mapLat") double mapLatitude,
+            @RequestParam("mapLng") double mapLongitude,
+            @RequestParam(value = "userLat", required = false) Double userLatitude,
+            @RequestParam(value = "userLng", required = false) Double userLongitude
     ) {
-        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(latitude, longitude);
+        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude);
         return CourseWebResponse.from(responses);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -47,7 +47,12 @@ public class CourseWebController implements CourseWebApi {
             @RequestParam(value = "userLat", required = false) Double userLatitude,
             @RequestParam(value = "userLng", required = false) Double userLongitude
     ) {
-        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude);
+        if (userLatitude == null || userLongitude == null) {
+            List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude);
+            return CourseWebResponse.from(responses);
+        }
+
+        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude);
         return CourseWebResponse.from(responses);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -31,8 +31,10 @@ public interface CourseWebApi {
             })),
     })
     List<CourseWebResponse> findNearbyCourses(
-            @Parameter(example = "37.5165004", required = true) double latitude,
-            @Parameter(example = "127.1040109", required = true) double longitude
+            @Parameter(example = "37.5165004", required = true) double mapLatitude,
+            @Parameter(example = "127.1040109", required = true) double mapLongitude,
+            @Parameter(example = "38.5165004") Double userLatitude,
+            @Parameter(example = "126.1040109") Double userLongitude
     );
 
     @Operation(summary = "좌표에서 가장 가까운 코스 위 좌표 조회")

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
@@ -1,6 +1,7 @@
 package coursepick.coursepick.presentation.dto;
 
 import coursepick.coursepick.application.dto.CourseResponse;
+import coursepick.coursepick.domain.Meter;
 import coursepick.coursepick.domain.RoadType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -12,7 +13,7 @@ public record CourseWebResponse(
         @Schema(example = "석촌호수")
         String name,
         @Schema(example = "200.123")
-        double distance,
+        Double distance,
         @Schema(example = "2146.123")
         double length,
         @Schema(example = "트랙")
@@ -26,7 +27,9 @@ public record CourseWebResponse(
                 .map(courseResponse -> new CourseWebResponse(
                         courseResponse.id(),
                         courseResponse.name(),
-                        courseResponse.distance().value(),
+                        courseResponse.distance()
+                                .map(Meter::value)
+                                .orElse(null),
                         courseResponse.length().value(),
                         courseResponse.roadType(),
                         courseResponse.difficulty(),

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -7,12 +7,14 @@ import coursepick.coursepick.test_util.DatabaseCleaner;
 import coursepick.coursepick.test_util.DatabaseInserter;
 import jakarta.persistence.EntityNotFoundException;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,6 +69,49 @@ class CourseApplicationServiceTest {
         assertThat(course1.distanceFrom(new Coordinate(latitude, longitude)).value()).isLessThan(1000.0);
         assertThat(course2.distanceFrom(new Coordinate(latitude, longitude)).value()).isLessThan(1000.0);
         assertThat(course3.distanceFrom(new Coordinate(latitude, longitude)).value()).isGreaterThan(1000.0);
+    }
+
+    @Test
+    void 가까운_코스들을_조회하고_현위치에서_거리를_계산한다() {
+        Course course1 = new Course("한강 러닝 코스", List.of(
+                new Coordinate(37.5180, 127.0280),
+                new Coordinate(37.5175, 127.0270),
+                new Coordinate(37.5170, 127.0265),
+                new Coordinate(37.5180, 127.0280)
+        ));
+        Course course2 = new Course("양재천 산책길", List.of(
+                new Coordinate(37.5165, 127.0285),
+                new Coordinate(37.5160, 127.0278),
+                new Coordinate(37.5155, 127.0265),
+                new Coordinate(37.5165, 127.0285)
+        ));
+        Course course3 = new Course("북악산 둘레길", List.of(
+                new Coordinate(37.602500, 126.967000),
+                new Coordinate(37.603000, 126.968000),
+                new Coordinate(37.603500, 126.969000),
+                new Coordinate(37.602500, 126.967000)
+        ));
+        databaseInserter.saveCourse(course1);
+        databaseInserter.saveCourse(course2);
+        databaseInserter.saveCourse(course3);
+        double mapLatitude = 37.5172;
+        double mapLongitude = 127.0276;
+        double userLatitude = 37.5153291;
+        double userLongitude = 127.1031347;
+
+        List<CourseResponse> courses = sut.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude);
+
+        assertThat(course1.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);
+        assertThat(course2.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);
+        assertThat(course3.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isGreaterThan(1000.0);
+
+        assertThat(courses).hasSize(2)
+                .extracting(CourseResponse::name)
+                .containsExactlyInAnyOrder(course1.name(), course2.name());
+
+        assertThat(courses).extracting(CourseResponse::distance).allMatch(Optional::isPresent);
+        assertThat(courses.get(0).distance().get().value()).isCloseTo(6640, Percentage.withPercentage(1));
+        assertThat(courses.get(1).distance().get().value()).isCloseTo(6583, Percentage.withPercentage(1));
     }
 
     @Test


### PR DESCRIPTION
## 📋 변경 사항 요약
다른 위치에서도 현위치 기준으로 거리를 응답하도록 주변 코스 조회 API를 수정했습니다.

## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- 기존 코스 조회 API 요청에 사용되는 쿼리 파라미터가 추가되었습니다.
- 현위치에 대한 쿼리 파라미터가 존재하는 경우 거리를 계산하여 응답하고, 아닌 경우 null로 응답하도록 구현했습니다.
- 통합 테스트를 작성했습니다. 

## 🔍 리뷰 요청사항
- 기능이 추가되면서 DTO의 distance가 null을 가질 수도 있게 되었습니다. 새로운 DTO로 분리하기에는 변경이 크지 않다고 생각해서 재사용 했는데 관련 코드 리뷰해주시면 좋겠습니다!

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #179 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지도 중심 좌표와 사용자 위치를 각각 전달하여 주변 코스를 조회할 수 있도록 기능이 확장되었습니다.
  * 거리 정보가 없는 경우에도 코스 정보가 정상적으로 반환됩니다.

* **버그 수정**
  * 거리 정보가 없는 경우 null로 안전하게 처리되도록 개선되었습니다.

* **테스트**
  * 지도 중심과 사용자 위치를 다르게 지정할 때의 코스 거리 계산 및 반환 결과에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->