### PR TITLE
파일로 코스 생성시 파일 이름을 코스 이름으로 설정

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -22,7 +22,7 @@ public class CourseApplicationService {
     private final List<CourseParser> courseParsers;
 
     @Transactional
-    public void parseInputStreamAndSave(InputStream fileStream, String fileExtension) {
+    public void parseInputStreamAndSave(InputStream fileStream, String filename, String fileExtension) {
         log.info("코스 데이터 가져오기 시작");
 
         CourseParser courseParser = courseParsers.stream()
@@ -30,21 +30,11 @@ public class CourseApplicationService {
                 .findAny()
                 .orElseThrow(INVALID_FILE_EXTENSION::create);
 
-        List<Course> courses = parseCoursesFromFile(fileStream, courseParser);
-        saveCourses(courses);
-    }
-
-    private void saveCourses(List<Course> courses) {
-        List<Course> savedCourses = courseRepository.saveAll(courses);
-
-        log.info("DB에 {} 개의 코스를 저장했습니다", savedCourses.size());
-    }
-
-    private static List<Course> parseCoursesFromFile(InputStream fileStream, CourseParser courseParser) {
-        List<Course> courses = courseParser.parse(fileStream);
-
+        List<Course> courses = courseParser.parse(filename, fileStream);
         log.info("{} 개의 코스를 파싱했습니다", courses.size());
-        return courses;
+
+        List<Course> savedCourses = courseRepository.saveAll(courses);
+        log.info("DB에 {} 개의 코스를 저장했습니다", savedCourses.size());
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -30,7 +30,7 @@ public class CourseApplicationService {
                 .findAny()
                 .orElseThrow(INVALID_FILE_EXTENSION::create);
 
-        List<Course> courses = courseParser.parse(filename, fileStream);
+        List<Course> courses = courseParser.parse(filename.replace("." + fileExtension, ""), fileStream);
         log.info("{} 개의 코스를 파싱했습니다", courses.size());
 
         List<Course> savedCourses = courseRepository.saveAll(courses);

--- a/backend/src/main/java/coursepick/coursepick/domain/CourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CourseParser.java
@@ -6,6 +6,6 @@ import java.util.List;
 public interface CourseParser {
 
     boolean canParse(String fileExtension);
-    
-    List<Course> parse(InputStream fileStream);
+
+    List<Course> parse(String filename, InputStream fileStream);
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/GpxCourseParser.java
@@ -22,7 +22,7 @@ public class GpxCourseParser implements CourseParser {
     }
 
     @Override
-    public List<Course> parse(InputStream fileStream) {
+    public List<Course> parse(String filename, InputStream fileStream) {
         GPX gpx;
 
         try {
@@ -32,7 +32,7 @@ public class GpxCourseParser implements CourseParser {
         }
 
         return gpx.tracks()
-                .map(track -> new Course(track.getName().orElse("Default"), getCoordinates(track)))
+                .map(track -> new Course(filename, getCoordinates(track)))
                 .toList();
     }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
@@ -47,7 +47,7 @@ public class KmlCourseParser implements CourseParser {
             Node placemark = placemarks.item(i);
             if (placemark.getNodeType() == Node.ELEMENT_NODE) {
                 Element placemarkElement = (Element) placemark;
-                Course course = parseCourse(filename, placemarkElement);
+                Course course = parseCourse(placemarkElement);
                 if (course != null) {
                     courses.add(course);
                 }
@@ -56,10 +56,22 @@ public class KmlCourseParser implements CourseParser {
         return courses;
     }
 
-    private Course parseCourse(String filename, Element placemark) {
+    private Course parseCourse(Element placemark) {
+        String courseName = parseCourseName(placemark);
         List<Coordinate> coordinates = parseCoordinates(placemark);
+
+        if (courseName == null || courseName.isBlank()) return null;
         if (coordinates.isEmpty()) return null;
-        return new Course(filename, coordinates);
+
+        return new Course(courseName, coordinates);
+    }
+
+    private String parseCourseName(Element placemark) {
+        NodeList nodeList = placemark.getElementsByTagName("name");
+        if (nodeList.getLength() > 0) {
+            return nodeList.item(0).getTextContent().trim();
+        }
+        return null;
     }
 
     private List<Coordinate> parseCoordinates(Element placemark) {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/KmlCourseParser.java
@@ -30,7 +30,7 @@ public class KmlCourseParser implements CourseParser {
     }
 
     @Override
-    public List<Course> parse(InputStream fileStream) {
+    public List<Course> parse(String filename, InputStream fileStream) {
         List<Course> courses = new ArrayList<>();
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         NodeList placemarks;
@@ -47,7 +47,7 @@ public class KmlCourseParser implements CourseParser {
             Node placemark = placemarks.item(i);
             if (placemark.getNodeType() == Node.ELEMENT_NODE) {
                 Element placemarkElement = (Element) placemark;
-                Course course = parseCourse(placemarkElement);
+                Course course = parseCourse(filename, placemarkElement);
                 if (course != null) {
                     courses.add(course);
                 }
@@ -56,22 +56,10 @@ public class KmlCourseParser implements CourseParser {
         return courses;
     }
 
-    private Course parseCourse(Element placemark) {
-        String courseName = parseCourseName(placemark);
+    private Course parseCourse(String filename, Element placemark) {
         List<Coordinate> coordinates = parseCoordinates(placemark);
-
-        if (courseName == null || courseName.isBlank()) return null;
         if (coordinates.isEmpty()) return null;
-
-        return new Course(courseName, coordinates);
-    }
-
-    private String parseCourseName(Element placemark) {
-        NodeList nodeList = placemark.getElementsByTagName("name");
-        if (nodeList.getLength() > 0) {
-            return nodeList.item(0).getTextContent().trim();
-        }
-        return null;
+        return new Course(filename, coordinates);
     }
 
     private List<Coordinate> parseCoordinates(Element placemark) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.text.Normalizer;
 import java.util.List;
 
 import static coursepick.coursepick.application.exception.ErrorType.INVALID_ADMIN_TOKEN;
@@ -36,7 +37,7 @@ public class CourseWebController implements CourseWebApi {
         validateAdminToken(token);
 
         for (MultipartFile file : files) {
-            String filename = file.getOriginalFilename();
+            String filename = Normalizer.normalize(file.getOriginalFilename(), Normalizer.Form.NFC);
             String fileExtension = StringUtils.getFilenameExtension(file.getOriginalFilename());
             courseApplicationService.parseInputStreamAndSave(file.getInputStream(), filename, fileExtension);
         }

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -31,13 +31,15 @@ public class CourseWebController implements CourseWebApi {
     @PostMapping("/admin/courses/import")
     public void importCourses(
             @RequestParam("adminToken") String token,
-            @RequestParam("file") MultipartFile file
+            @RequestParam("file") List<MultipartFile> files
     ) {
         validateAdminToken(token);
 
-        String filename = file.getOriginalFilename();
-        String fileExtension = StringUtils.getFilenameExtension(file.getOriginalFilename());
-        courseApplicationService.parseInputStreamAndSave(file.getInputStream(), filename, fileExtension);
+        for (MultipartFile file : files) {
+            String filename = file.getOriginalFilename();
+            String fileExtension = StringUtils.getFilenameExtension(file.getOriginalFilename());
+            courseApplicationService.parseInputStreamAndSave(file.getInputStream(), filename, fileExtension);
+        }
     }
 
     @Override

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -9,7 +9,6 @@ import coursepick.coursepick.presentation.dto.CourseWebResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,8 +35,9 @@ public class CourseWebController implements CourseWebApi {
     ) {
         validateAdminToken(token);
 
+        String filename = file.getOriginalFilename();
         String fileExtension = StringUtils.getFilenameExtension(file.getOriginalFilename());
-        courseApplicationService.parseInputStreamAndSave(file.getInputStream(), fileExtension);
+        courseApplicationService.parseInputStreamAndSave(file.getInputStream(), filename, fileExtension);
     }
 
     @Override

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -62,5 +62,5 @@ public interface CourseWebApi {
     );
 
     @Operation(hidden = true)
-    void importCourses(String token, MultipartFile file);
+    void importCourses(String token, List<MultipartFile> files);
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
         jdbc.batch_size: 50 # 한 번에 처리할 배치 크기
         order_inserts: true  # INSERT 순서 최적화
         order_updates: true  # UPDATE 순서 최적화
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 100MB
 
 springdoc:
   default-consumes-media-type: application/json

--- a/backend/src/main/resources/static/import.html
+++ b/backend/src/main/resources/static/import.html
@@ -8,8 +8,8 @@
 <h1>파일 업로드 폼</h1>
 <form action="/admin/courses/import" method="post" enctype="multipart/form-data">
     <p>admin token = <input type="text" name="adminToken"></p>
-    <label for="file">파싱할 파일 전송:</label>
-    <input type="file" id="file" name="file" required/>
+    <label for="file">파싱할 파일 전송 (다중 선택 가능):</label>
+    <input type="file" id="file" name="file" multiple required/>
 
     <button type="submit">전송</button>
 </form>

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GpxCourseParserTest {
@@ -61,11 +60,11 @@ class GpxCourseParserTest {
         InputStream inputStream = new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8));
         GpxCourseParser gpxCourseParser = new GpxCourseParser();
 
-        List<Course> courses = gpxCourseParser.parse(inputStream);
+        List<Course> courses = gpxCourseParser.parse("테스트코스", inputStream);
 
         assertThat(courses.size()).isEqualTo(1);
         assertThat(courses).extracting(course -> course.name())
-                .contains("test-course");
+                .contains("테스트코스");
         assertThat(courses).extracting(course -> course.coordinates().size())
                 .contains(3);
         assertThat(courses).extracting(course -> course.coordinates())

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/KmlCourseParserTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/KmlCourseParserTest.java
@@ -43,44 +43,17 @@ class KmlCourseParserTest {
 
         InputStream inputStream = new ByteArrayInputStream(kmlContent.getBytes(StandardCharsets.UTF_8));
 
-        List<Course> courses = sut.parse(inputStream);
+        List<Course> courses = sut.parse("테스트코스", inputStream);
 
         assertThat(courses).hasSize(1);
 
         Course course = courses.getFirst();
-        assertThat(course.name()).isEqualTo("테스트 코스");
+        assertThat(course.name()).isEqualTo("테스트코스");
         assertThat(course.coordinates()).hasSize(3);
 
         Coordinate firstCoordinate = course.coordinates().getFirst();
         assertThat(firstCoordinate.latitude()).isEqualTo(37.522489);
         assertThat(firstCoordinate.longitude()).isEqualTo(127.099029);
-    }
-
-    @Test
-    void 이름이_없는_Placemark는_무시한다(@TempDir Path tempDir) throws IOException {
-        String kmlContent = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <kml xmlns="http://www.opengis.net/kml/2.2">
-                <Document>
-                    <Placemark>
-                        <Polygon>
-                            <outerBoundaryIs>
-                                <LinearRing>
-                                    <coordinates>
-                                        127.0990294928381,37.52248985670181,0 127.0963796423111,37.52181839278625,0
-                                    </coordinates>
-                                </LinearRing>
-                            </outerBoundaryIs>
-                        </Polygon>
-                    </Placemark>
-                </Document>
-                </kml>
-                """;
-        InputStream inputStream = new ByteArrayInputStream(kmlContent.getBytes(StandardCharsets.UTF_8));
-
-        List<Course> courses = sut.parse(inputStream);
-
-        assertThat(courses).isEmpty();
     }
 
     @Test
@@ -97,7 +70,7 @@ class KmlCourseParserTest {
                 """;
         InputStream inputStream = new ByteArrayInputStream(kmlContent.getBytes(StandardCharsets.UTF_8));
 
-        List<Course> courses = sut.parse(inputStream);
+        List<Course> courses = sut.parse("테스트코스", inputStream);
 
         assertThat(courses).isEmpty();
     }

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/KmlCourseParserTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/KmlCourseParserTest.java
@@ -26,7 +26,7 @@ class KmlCourseParserTest {
                 <kml xmlns="http://www.opengis.net/kml/2.2">
                 <Document>
                     <Placemark>
-                        <name>테스트 코스</name>
+                        <name>테스트코스</name>
                         <Polygon>
                             <outerBoundaryIs>
                                 <LinearRing>


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 파일 전송에서 파일 이름을 추출하는 코드 추가
- 해당 파일 이름을 코스 이름으로 사용하도록 수정

## 🔗 관련 이슈
- closes #187 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 다중 코스 파일 업로드를 지원하도록 기능이 확장되었습니다.
  * 코스 파일 업로드 시 코스 이름이 파일명으로 자동 지정됩니다.

* **버그 수정**
  * KML 및 GPX 파일에서 더 이상 내부 이름이 아닌 업로드한 파일명이 코스 이름으로 사용됩니다.

* **테스트**
  * 코스 파서 관련 테스트가 파일명을 인자로 받아 올바르게 동작하도록 수정되었습니다.
  * 이름이 없는 Placemark를 무시하는 테스트가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->