### PR TITLE
로그, gcp인증정보 파일들의 경로를 절대 경로로 수정

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <property name="LOG_FILE_PATH" value="./logs"/>
+    <property name="LOG_FILE_PATH" value="/etc/coursepick/log"/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE_PATH}/coursepick.log</file>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <property name="LOG_FILE_PATH" value="/etc/coursepick/log"/>
+    <property name="LOG_FILE_PATH" value="/var/lib/coursepick/logs"/>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE_PATH}/coursepick.log</file>

--- a/backend/src/test/resources/logback-test.xml
+++ b/backend/src/test/resources/logback-test.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 기존은 파일 위치가 항상 상대적이었는데, 이러니까 github action / docker 등 여러 배포 방식에 의해 위치가 계속 달라졌습니다.
- 결정적이지 않다보니까 헷갈리는 상황이 발생했습니다.
- 따라서 모든 경로를 절대경로로 명시해서, 이런 일이 발생하지 않도록 했습니다.

- 로그를 /var/lib/coursepick/logs/ 내부에 남기도록 했습니다.
  - 이 디렉토리에 대한 권한을 풀어줘야 하는데, 모두 세팅해놨습니다.
- GCP 파일을 /var/lib/coursepick/ 에 두도록 github secret을 설정했습니다.
  - 개발서버/운영서버1/운영서버2 옮겨놨습니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #238 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Chores**
  * 로그 파일 저장 경로가 상대 경로에서 절대 경로(`/var/lib/coursepick/logs`)로 변경되었습니다.
  * 테스트 환경용 로그 설정이 추가되어 테스트 시 콘솔에 로그가 출력됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->