### PR TITLE
요청에서 clientId를 추출하여 로깅

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseSyncService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseSyncService.java
@@ -31,7 +31,7 @@ public class CourseSyncService {
         }
     }
 
-    @Async
+    @Async("asyncExecutor")
     public void runCourseSyncJob() {
         log.info("CourseSyncJob 수동 시작");
         try {

--- a/backend/src/main/java/coursepick/coursepick/logging/AsyncConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/AsyncConfig.java
@@ -14,9 +14,9 @@ public class AsyncConfig {
 
     /**
      * MDC를 전파하는 TaskDecorator가 등록된 Executor를 반환합니다.
-     * <p>
+     * <br>
      * MDC를 전파받아야 하는 비동기 작업에서 주입받아 사용하면 됩니다.
-     * <p>
+     * <br>
      * 자세한 Executor 설정은 <a href="https://docs.spring.io/spring-framework/reference/integration/scheduling.html">스프링 공식문서</a>를 참고했습니다.
      */
     @Bean(name = "asyncExecutor")
@@ -30,6 +30,14 @@ public class AsyncConfig {
         return executor;
     }
 
+    /**
+     * 작업 스레드의 MDC를 백업한 후에,
+     * 현재 스레드의 MDC를 작업 스레드에 전파하고,
+     * 작업 스레드의 작업을 실행합니다.
+     * 작업이 끝난 후에는 작업 스레드의 MDC를 기존으로 복구시킵니다.
+     * <br>
+     * 위 로직을 통해서 작업 스레드가 스레드풀에 반환되더라도 문제가 발생하지 않습니다.
+     */
     private static class MdcTaskDecorator implements TaskDecorator {
 
         @Override

--- a/backend/src/main/java/coursepick/coursepick/logging/ClientIdLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/ClientIdLoggingFilter.java
@@ -23,12 +23,13 @@ public class ClientIdLoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String clientId = request.getHeader(HEADER_NAME);
-        if (clientId != null && !clientId.isBlank()) {
+        if (clientId == null || clientId.isBlank()) {
             clientId = "Unknown";
         }
 
         try {
             MDC.put(MDC_KEY, clientId);
+            filterChain.doFilter(request, response);
         } finally {
             MDC.remove(MDC_KEY);
         }

--- a/backend/src/main/java/coursepick/coursepick/logging/ClientIdLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/ClientIdLoggingFilter.java
@@ -23,14 +23,12 @@ public class ClientIdLoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String clientId = request.getHeader(HEADER_NAME);
+        if (clientId != null && !clientId.isBlank()) {
+            clientId = "Unknown";
+        }
 
         try {
-            if (clientId != null && !clientId.isBlank()) {
-                MDC.put(MDC_KEY, clientId);
-            } else {
-                MDC.put(MDC_KEY, "Unknown");
-            }
-            filterChain.doFilter(request, response);
+            MDC.put(MDC_KEY, clientId);
         } finally {
             MDC.remove(MDC_KEY);
         }

--- a/backend/src/main/java/coursepick/coursepick/logging/ClientIdLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/ClientIdLoggingFilter.java
@@ -1,0 +1,38 @@
+package coursepick.coursepick.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+
+@Component
+@Order(HIGHEST_PRECEDENCE)
+public class ClientIdLoggingFilter extends OncePerRequestFilter {
+
+    private static final String HEADER_NAME = "X-Client-Id";
+    private static final String MDC_KEY = "client_id";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String clientId = request.getHeader(HEADER_NAME);
+
+        try {
+            if (clientId != null && !clientId.isBlank()) {
+                MDC.put(MDC_KEY, clientId);
+            } else {
+                MDC.put(MDC_KEY, "Unknown");
+            }
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_KEY);
+        }
+    }
+}


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 요청의 헤더에서 Client-Id를 추출하여 MDC로 로그에 세팅합니다.
- 비동기 작업에서 작업 스레드는 기존 Client-Id를 사용하지 못하는 문제가 있습니다. MDC는 스레드로컬 기반이기 때문입니다.
- 따라서 비동기 설정을 추가했고, 이를 통해 작업 스레드는 MDC를 전파받아 사용합니다.

```json
{
"@timestamp":"2025-08-11T22:00:15.749969+09:00",
"@version":"1",
"message":"CourseSyncJob 수동 시작",
"logger_name":"coursepick.coursepick.application.CourseSyncService",
"thread_name":"asyncExecutor-2",
"level":"INFO",
"level_value":20000,
"client_id":"dompoo123"
}
{
"@timestamp":"2025-08-11T22:00:15.752286+09:00",
"@version":"1",
"message":"...",
"logger_name":"coursepick.coursepick.logging.HttpLoggingFilter",
"thread_name":"http-nio-8080-exec-4",
"level":"INFO",
"level_value":20000,
"client_id":"dompoo123"
}
{
"@timestamp":"2025-08-11T22:00:15.784639+09:00",
"message":"...",
"logger_name":"org.springframework.batch.core.launch.support.TaskExecutorJobLauncher",
"thread_name":"asyncExecutor-2",
"level":"INFO",
"level_value":20000,
"client_id":"dompoo123"
}
```

## 🔗 관련 이슈
- closes #256 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 요청 헤더의 클라이언트 ID를 수집해 로그에 포함시키고, 누락 시 기본값으로 표시하여 요청 추적성이 향상되었습니다.
- Chores
  - 백그라운드 작업에 전용 비동기 실행기를 도입해 동시 처리 안정성과 성능을 개선했습니다.
  - 비동기 실행 환경에서도 요청 관련 로그 문맥(MDC)이 올바르게 전파·복원되어 로그 일관성과 진단 품질이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->