### PR TITLE
코스 탐색 시 탐색 범위를 받도록 API 수정

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -22,7 +22,7 @@ public class CourseApplicationService {
     private final CourseRepository courseRepository;
 
     @Transactional(readOnly = true)
-    public List<CourseResponse> findNearbyCourses(int scope, double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
+    public List<CourseResponse> findNearbyCourses(double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude, int scope) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
         Meter meter = new Meter(scope).clamp(1000, 3000);
 

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -24,11 +24,12 @@ public class CourseApplicationService {
     @Transactional(readOnly = true)
     public List<CourseResponse> findNearbyCourses(int scope, double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
-        if (scope < 1000 || scope > 3000) {
-            scope = 1000;
+        Meter meter = new Meter(scope);
+        if (!meter.isAtLeast(new Meter(1000)) || !meter.isWithin(new Meter(3000))) {
+            meter = new Meter(1000);
         }
 
-        List<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(scope));
+        List<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, meter);
 
         if (userLatitude == null || userLongitude == null) {
             return coursesWithinScope

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -24,13 +24,7 @@ public class CourseApplicationService {
     @Transactional(readOnly = true)
     public List<CourseResponse> findNearbyCourses(int scope, double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
-        Meter meter = new Meter(scope);
-        if (!meter.isAtLeast(new Meter(1000))) {
-            meter = new Meter(1000);
-        }
-        if (!meter.isWithin(new Meter(3000))) {
-            meter = new Meter(3000);
-        }
+        Meter meter = clampScope(new Meter(scope));
 
         List<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, meter);
 
@@ -54,5 +48,15 @@ public class CourseApplicationService {
                 .orElseThrow(() -> NOT_EXIST_COURSE.create(id));
 
         return course.closestCoordinateFrom(new Coordinate(latitude, longitude));
+    }
+
+    private static Meter clampScope(Meter meter) {
+        if (!meter.isAtLeast(new Meter(1000))) {
+            meter = new Meter(1000);
+        }
+        if (!meter.isWithin(new Meter(3000))) {
+            meter = new Meter(3000);
+        }
+        return meter;
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -24,7 +24,7 @@ public class CourseApplicationService {
     @Transactional(readOnly = true)
     public List<CourseResponse> findNearbyCourses(int scope, double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
-        Meter meter = clampScope(new Meter(scope));
+        Meter meter = new Meter(scope).clamp(1000, 3000);
 
         List<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, meter);
 
@@ -48,15 +48,5 @@ public class CourseApplicationService {
                 .orElseThrow(() -> NOT_EXIST_COURSE.create(id));
 
         return course.closestCoordinateFrom(new Coordinate(latitude, longitude));
-    }
-
-    private static Meter clampScope(Meter meter) {
-        if (!meter.isAtLeast(new Meter(1000))) {
-            meter = new Meter(1000);
-        }
-        if (!meter.isWithin(new Meter(3000))) {
-            meter = new Meter(3000);
-        }
-        return meter;
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -24,15 +24,21 @@ public class CourseApplicationService {
     @Transactional(readOnly = true)
     public List<CourseResponse> findNearbyCourses(int scope, double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
+        if (scope < 1000 || scope > 3000) {
+            scope = 1000;
+        }
+
+        List<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(scope));
+
         if (userLatitude == null || userLongitude == null) {
-            return courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(scope))
+            return coursesWithinScope
                     .stream()
                     .map(CourseResponse::from)
                     .toList();
         }
 
         final Coordinate userPosition = new Coordinate(userLatitude, userLongitude);
-        return courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(scope))
+        return coursesWithinScope
                 .stream()
                 .map(course -> CourseResponse.from(course, userPosition))
                 .toList();

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -25,8 +25,11 @@ public class CourseApplicationService {
     public List<CourseResponse> findNearbyCourses(int scope, double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
         Meter meter = new Meter(scope);
-        if (!meter.isAtLeast(new Meter(1000)) || !meter.isWithin(new Meter(3000))) {
+        if (!meter.isAtLeast(new Meter(1000))) {
             meter = new Meter(1000);
+        }
+        if (!meter.isWithin(new Meter(3000))) {
+            meter = new Meter(3000);
         }
 
         List<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, meter);

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -19,22 +19,20 @@ import static coursepick.coursepick.application.exception.ErrorType.NOT_EXIST_CO
 @RequiredArgsConstructor
 public class CourseApplicationService {
 
-    private static final Meter SEARCH_RADIUS = new Meter(1000);
-
     private final CourseRepository courseRepository;
-    
+
     @Transactional(readOnly = true)
-    public List<CourseResponse> findNearbyCourses(double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
+    public List<CourseResponse> findNearbyCourses(int scope, double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
         if (userLatitude == null || userLongitude == null) {
-            return courseRepository.findAllHasDistanceWithin(mapPosition, SEARCH_RADIUS)
+            return courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(scope))
                     .stream()
                     .map(CourseResponse::from)
                     .toList();
         }
 
         final Coordinate userPosition = new Coordinate(userLatitude, userLongitude);
-        return courseRepository.findAllHasDistanceWithin(mapPosition, SEARCH_RADIUS)
+        return courseRepository.findAllHasDistanceWithin(mapPosition, new Meter(scope))
                 .stream()
                 .map(course -> CourseResponse.from(course, userPosition))
                 .toList();

--- a/backend/src/main/java/coursepick/coursepick/domain/Coordinate.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Coordinate.java
@@ -50,8 +50,7 @@ public record Coordinate(
     }
 
     private static double truncated(double value) {
-        final int SCALE = 7;
-        return BigDecimal.valueOf(value).setScale(SCALE, RoundingMode.DOWN).doubleValue();
+        return BigDecimal.valueOf(value).setScale(7, RoundingMode.DOWN).doubleValue();
     }
 
     private static void validateLatitudeRange(double roundedLatitude) {

--- a/backend/src/main/java/coursepick/coursepick/domain/Meter.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Meter.java
@@ -18,16 +18,11 @@ public record Meter(
         return new Meter(this.value() + other.value());
     }
 
-    public Meter minimum(Meter other) {
-        return this.value() <= other.value() ? this : other;
+    public Meter clamp(double min, double max) {
+        return new Meter(Math.clamp(this.value, min, max));
     }
 
     public boolean isWithin(Meter other) {
         return this.value() <= other.value();
     }
-
-    public boolean isAtLeast(Meter other) {
-        return this.value() >= other.value();
-    }
-
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/Meter.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Meter.java
@@ -19,7 +19,7 @@ public record Meter(
     }
 
     public Meter clamp(double min, double max) {
-        return new Meter(Math.clamp(this.value, min, max));
+        return new Meter(Math.clamp(this.value(), min, max));
     }
 
     public boolean isWithin(Meter other) {

--- a/backend/src/main/java/coursepick/coursepick/domain/Meter.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Meter.java
@@ -25,4 +25,9 @@ public record Meter(
     public boolean isWithin(Meter other) {
         return this.value() <= other.value();
     }
+
+    public boolean isAtLeast(Meter other) {
+        return this.value() >= other.value();
+    }
+
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -36,13 +36,13 @@ public class CourseWebController implements CourseWebApi {
     @Override
     @GetMapping("/courses")
     public List<CourseWebResponse> findNearbyCourses(
-            @RequestParam("scope") int scope,
             @RequestParam("mapLat") double mapLatitude,
             @RequestParam("mapLng") double mapLongitude,
             @RequestParam(value = "userLat", required = false) Double userLatitude,
-            @RequestParam(value = "userLng", required = false) Double userLongitude
+            @RequestParam(value = "userLng", required = false) Double userLongitude,
+            @RequestParam("scope") int scope
     ) {
-        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(scope, mapLatitude, mapLongitude, userLatitude, userLongitude);
+        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude, scope);
         return CourseWebResponse.from(responses);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -36,12 +36,13 @@ public class CourseWebController implements CourseWebApi {
     @Override
     @GetMapping("/courses")
     public List<CourseWebResponse> findNearbyCourses(
+            @RequestParam("scope") int scope,
             @RequestParam("mapLat") double mapLatitude,
             @RequestParam("mapLng") double mapLongitude,
             @RequestParam(value = "userLat", required = false) Double userLatitude,
             @RequestParam(value = "userLng", required = false) Double userLongitude
     ) {
-        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude);
+        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(scope, mapLatitude, mapLongitude, userLatitude, userLongitude);
         return CourseWebResponse.from(responses);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -33,6 +33,7 @@ public interface CourseWebApi {
             })),
     })
     List<CourseWebResponse> findNearbyCourses(
+            @Parameter(example = "1000", required = true) int scope,
             @Parameter(example = "37.5165004", required = true) double mapLatitude,
             @Parameter(example = "127.1040109", required = true) double mapLongitude,
             @Parameter(example = "38.5165004") Double userLatitude,

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -33,11 +33,11 @@ public interface CourseWebApi {
             })),
     })
     List<CourseWebResponse> findNearbyCourses(
-            @Parameter(example = "1000", required = true) int scope,
             @Parameter(example = "37.5165004", required = true) double mapLatitude,
             @Parameter(example = "127.1040109", required = true) double mapLongitude,
             @Parameter(example = "38.5165004") Double userLatitude,
-            @Parameter(example = "126.1040109") Double userLongitude
+            @Parameter(example = "126.1040109") Double userLongitude,
+            @Parameter(example = "1000", required = true) int scope
     );
 
     @Operation(summary = "좌표에서 가장 가까운 코스 위 좌표 조회")

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -47,7 +47,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         double latitude = 37.5172;
         double longitude = 127.0276;
 
-        List<CourseResponse> courses = sut.findNearbyCourses(latitude, longitude, null, null);
+        List<CourseResponse> courses = sut.findNearbyCourses(1000, latitude, longitude, null, null);
 
         assertThat(courses).hasSize(2)
                 .extracting(CourseResponse::name)
@@ -85,7 +85,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         double userLatitude = 37.5153291;
         double userLongitude = 127.1031347;
 
-        List<CourseResponse> courses = sut.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude);
+        List<CourseResponse> courses = sut.findNearbyCourses(1000, mapLatitude, mapLongitude, userLatitude, userLongitude);
 
         assertThat(course1.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);
         assertThat(course2.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -22,6 +22,72 @@ class CourseApplicationServiceTest extends IntegrationTest {
     CourseApplicationService sut;
 
     @Test
+    void 코스는_최소_1KM부터_탐색할_수_있다() {
+        Course course1 = new Course("한강 러닝 코스", RoadType.트랙, List.of(
+                new Coordinate(37.5180, 127.0280),
+                new Coordinate(37.5175, 127.0270),
+                new Coordinate(37.5170, 127.0265),
+                new Coordinate(37.5180, 127.0280)
+        ));
+        Course course2 = new Course("양재천 산책길", RoadType.트랙, List.of(
+                new Coordinate(37.5165, 127.0285),
+                new Coordinate(37.5160, 127.0278),
+                new Coordinate(37.5155, 127.0265),
+                new Coordinate(37.5165, 127.0285)
+        ));
+        Course course3 = new Course("북악산 둘레길", RoadType.트레일, List.of(
+                new Coordinate(37.602500, 126.967000),
+                new Coordinate(37.603000, 126.968000),
+                new Coordinate(37.603500, 126.969000),
+                new Coordinate(37.602500, 126.967000)
+        ));
+        dbUtil.saveCourse(course1);
+        dbUtil.saveCourse(course2);
+        dbUtil.saveCourse(course3);
+
+        double latitude = 37.5122;
+        double longitude = 127.0276;
+
+        List<CourseResponse> nearbyCourses = sut.findNearbyCourses(300, latitude, longitude, null, null);
+
+        assertThat(nearbyCourses).hasSize(2)
+                .extracting(CourseResponse::name)
+                .containsExactlyInAnyOrder(course1.name().value(), course2.name().value());
+        assertThat(course1.distanceFrom(new Coordinate(latitude, longitude)).value()).isGreaterThan(300);
+        assertThat(course2.distanceFrom(new Coordinate(latitude, longitude)).value()).isGreaterThan(300);
+        assertThat(course3.distanceFrom(new Coordinate(latitude, longitude)).value()).isGreaterThan(1000.0);
+    }
+
+    @Test
+    void 코스는_최대_3KM까지_탐색할_수_있다() {
+        Course course1 = new Course("한강 러닝 코스", RoadType.트랙, List.of(
+                new Coordinate(37.5180, 127.0280),
+                new Coordinate(37.5175, 127.0270),
+                new Coordinate(37.5170, 127.0265),
+                new Coordinate(37.5180, 127.0280)
+        ));
+        Course course2 = new Course("북악산 둘레길", RoadType.트레일, List.of(
+                new Coordinate(38.602500, 126.967000),
+                new Coordinate(38.603000, 126.968000),
+                new Coordinate(38.603500, 126.969000),
+                new Coordinate(38.602500, 126.967000)
+        ));
+        dbUtil.saveCourse(course1);
+        dbUtil.saveCourse(course2);
+
+        double latitude = 37.5122;
+        double longitude = 127.0276;
+
+        List<CourseResponse> nearbyCourses = sut.findNearbyCourses(15000, latitude, longitude, null, null);
+
+        assertThat(nearbyCourses).hasSize(1)
+                .extracting(CourseResponse::name)
+                .containsExactlyInAnyOrder(course1.name().value());
+        assertThat(course1.distanceFrom(new Coordinate(latitude, longitude)).value()).isLessThan(3000);
+        assertThat(course2.distanceFrom(new Coordinate(latitude, longitude)).value()).isGreaterThan(3000);
+    }
+
+    @Test
     void 가까운_코스들을_조회한다() {
         Course course1 = new Course("한강 러닝 코스", RoadType.트랙, List.of(
                 new Coordinate(37.5180, 127.0280),

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -48,7 +48,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         double latitude = 37.5122;
         double longitude = 127.0276;
 
-        List<CourseResponse> nearbyCourses = sut.findNearbyCourses(300, latitude, longitude, null, null);
+        List<CourseResponse> nearbyCourses = sut.findNearbyCourses(latitude, longitude, null, null, 300);
 
         assertThat(nearbyCourses).hasSize(2)
                 .extracting(CourseResponse::name)
@@ -78,7 +78,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         double latitude = 37.5122;
         double longitude = 127.0276;
 
-        List<CourseResponse> nearbyCourses = sut.findNearbyCourses(15000, latitude, longitude, null, null);
+        List<CourseResponse> nearbyCourses = sut.findNearbyCourses(latitude, longitude, null, null, 15000);
 
         assertThat(nearbyCourses).hasSize(1)
                 .extracting(CourseResponse::name)
@@ -113,7 +113,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         double latitude = 37.5172;
         double longitude = 127.0276;
 
-        List<CourseResponse> courses = sut.findNearbyCourses(1000, latitude, longitude, null, null);
+        List<CourseResponse> courses = sut.findNearbyCourses(latitude, longitude, null, null, 1000);
 
         assertThat(courses).hasSize(2)
                 .extracting(CourseResponse::name)
@@ -151,7 +151,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         double userLatitude = 37.5153291;
         double userLongitude = 127.1031347;
 
-        List<CourseResponse> courses = sut.findNearbyCourses(1000, mapLatitude, mapLongitude, userLatitude, userLongitude);
+        List<CourseResponse> courses = sut.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude, 1000);
 
         assertThat(course1.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);
         assertThat(course2.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 탐색 범위는 최소 1km, 최대 3km로 잡았습니다.
  - 해당 범위를 벗어날 경우 최소보다 작으면 1km, 최대보다 크면 3km로 검색 범위를 변경하도록 했습니다.

<br/>

- 탐색 범위에 대한 검증을 서비스에서 진행하도록 만들었습니다.
- 하지만, 서비스가 아닌 리포지토리에 scope 검증 로직을 넣는 것도 좋다는 생각입니다. 왜냐하면 현재 Repository가 Domain에 속해있으며 인터페이스에 default 메서드를 선언했으므로 충분히 비즈니스 로직이 포함되어 있어도 된다고 생각하기 때문입니다.
  - 다만 현재는 findAll()로 찾아 stream을 돌리고 있어 Repository에서 meter를 동적으로 변경할 수 없는 상태입니다. 근데 이걸 위해서 final 변수를 하나 더 두는건 별로라고 생각해서 applicaiton service에 두었습니다.
  - 추후 쿼리로 풀어낸다면 이를 repository로 넣어도 괜찮을 것 같아요.

<br/>

- Service에서 모든 값을 원시값으로 받자는 컨벤션이 존재함을 알고 있습니다.
  - 그러나, 인자가 5개가 넘어가는 지금같은 상황에서 이를 유지해야 하는지 의견을 듣고싶습니다.

<br/>

- 추가로 다른 상수와의 통일성을 위해 Coordinate에 SCALE 상수를 제거했습니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #251 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 지도 주변 코스 조회에 범위(scope) 설정을 지원합니다(입력값은 1km~3km로 자동 제한).
  * 사용자 위치 제공 여부와 무관하게 동일한 범위 기준으로 결과를 반환합니다.
* API 변경
  * GET /courses에 scope(int, 미터) 파라미터가 필수로 추가되었습니다.
* 리팩터
  * 중복 조회를 제거해 주변 코스 검색 응답 성능이 개선되었습니다.
* 테스트
  * 최소/최대 탐색 범위 동작을 검증하는 테스트를 추가하고 기존 테스트를 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->