### PR TITLE
화이트리스트를 제외하고는 404 응답하는 필터 추가

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -22,7 +22,8 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
     private static final Set<Pattern> ALLOW_URI_PATTERNS = Set.of(
             Pattern.compile("^/admin/courses/sync$"),
             Pattern.compile("^/courses$"),
-            Pattern.compile("^/courses/[^/]+/closest-coordinate$")
+            Pattern.compile("^/courses/[^/]+/closest-coordinate$"),
+            Pattern.compile("^/import.html$")
     );
 
     @Override

--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -23,7 +23,8 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
             Pattern.compile("^/admin/courses/sync$"),
             Pattern.compile("^/courses$"),
             Pattern.compile("^/courses/[^/]+/closest-coordinate$"),
-            Pattern.compile("^/import.html$")
+            Pattern.compile("^/import.html$"),
+            Pattern.compile("^/actuator/health$")
     );
 
     @Override

--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+@Slf4j
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class PathAllowlistFilter extends OncePerRequestFilter {
@@ -28,6 +30,7 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
         boolean allowed = ALLOW_URI_PATTERNS.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
         if (!allowed) {
+            log.warn("[SECURITY] 화이트리스트가 아닌 경로로 요청이 들어왔습니다. uri={}", uri);
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             return;
         }

--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -1,0 +1,36 @@
+package coursepick.coursepick.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class PathAllowlistFilter extends OncePerRequestFilter {
+
+    private static final Set<Pattern> ALLOW_URI_PATTERNS = Set.of(
+            Pattern.compile("^/admin/courses/sync$"),
+            Pattern.compile("^/courses$"),
+            Pattern.compile("^/courses/[^/]+/closest-coordinate$")
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String uri = request.getRequestURI();
+        boolean allowed = ALLOW_URI_PATTERNS.stream().anyMatch(pattern -> pattern.matcher(uri).matches());
+        if (!allowed) {
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: "health, info, metrics"
+        include: "health"
   metrics:
     enable:
       all: false


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 모니터링 대시보드에 계속 수상한 접근들이 확인되었습니다.
  - 첫번째로 필요한 로그를 바로 확인하지 못해서 불편했고,
  - 두번째로 gcp 관련된 정보가 유출될 수 있을 것 같았습니다.
- 따라서 `OncePerRequestFilter`를 구현하여 특정 URI가 아니면 404 응답을 바로 반환하는 필터를 구현했습니다.

<img width="402" height="97" alt="image" src="https://github.com/user-attachments/assets/30a20f19-09a3-4a2a-8fa2-dfe770042f20" />

## 🔗 관련 이슈
- closes #267 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 요청 경로 허용 목록 기반 필터를 도입해 공개된 API 경로만 처리합니다.
  * 허용된 경로(예: /admin/courses/sync, /courses, /courses/{id}/closest-coordinate, /import.html, /actuator/health) 외의 호출은 404로 응답하고 추가 처리를 중단합니다.

* **Chores**
  * 개발 환경의 공개 Actuator 항목을 /actuator/health로 축소(기존의 info·metrics 제거).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->