### PR TITLE
API 문서에서 URI 정보 제거, 운영서버에서 API 문서 제거

### DIFF
--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -82,6 +82,8 @@ jobs:
           ADMIN_TOKEN: ${{ secrets.DEV_ADMIN_TOKEN }}
           GCP_DRIVE_FOLDER_ID: ${{ secrets.GCP_DRIVE_FOLDER_ID }}
           GCP_CREDENTIALS_PATH: ${{ secrets.GCP_CREDENTIALS_PATH }}
+          DEV_SERVER_URL: ${{ secrets.DEV_SERVER_URL }}
+          PROD_SERVER_URL: ${{ secrets.PROD_SERVER_URL }}
         run: |
           JAR_FILE=$(find ./artifacts -name "*.jar" | head -n 1)
           echo "서버 시작 중... =$JAR_FILE"

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
@@ -4,11 +4,14 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 import static coursepick.coursepick.application.exception.ErrorType.*;
@@ -20,8 +23,23 @@ public class OpenApiConfig {
     private static final String TIMESTAMP = LocalDateTime.now().toString();
 
     @Bean
-    public OpenApiCustomizer exampleInjector() {
+    public OpenApiCustomizer customize(
+            @Value("${springdoc.dev-server-url:http://localhost:8080}") String devServerUrl,
+            @Value("${springdoc.prod-server-url:http://localhost:8080}") String prodServerUrl
+    ) {
         return openApi -> {
+            openApi.setServers(List.of(
+                    new Server()
+                            .url("http://localhost:8080")
+                            .description("로컬 서버"),
+                    new Server()
+                            .url(devServerUrl)
+                            .description("개발 서버"),
+                    new Server()
+                            .url(prodServerUrl)
+                            .description("운영 서버")
+            ));
+
             Components components = openApi.getComponents();
 
             Example example = new Example()

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
@@ -2,7 +2,6 @@ package coursepick.coursepick.presentation.api;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.examples.Example;
 import org.springdoc.core.customizers.OpenApiCustomizer;
@@ -14,10 +13,7 @@ import java.util.Map;
 
 import static coursepick.coursepick.application.exception.ErrorType.*;
 
-@OpenAPIDefinition(
-        info = @Info(title = "코스픽 API", version = "1.0.0"),
-        servers = @Server(url = "http://54.180.213.93", description = "개발 서버")
-)
+@OpenAPIDefinition(info = @Info(title = "코스픽 API", version = "1.0.0"))
 @Configuration
 public class OpenApiConfig {
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
@@ -9,6 +9,7 @@ import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Map;
 
 import static coursepick.coursepick.application.exception.ErrorType.*;
 
+@Profile("!prod")
 @OpenAPIDefinition(info = @Info(title = "코스픽 API", version = "1.0.0"))
 @Configuration
 public class OpenApiConfig {

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -37,6 +37,10 @@ management:
         namespace: EC2/coursepick/dev
         batch-size: 20
 
+springdoc:
+  dev-server-url: ${DEV_SERVER_URL}
+  prod-server-url: ${PROD_SERVER_URL}
+
 gcp:
   drive.folder-id: ${GCP_DRIVE_FOLDER_ID}
   credentials.path: ${GCP_CREDENTIALS_PATH}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -9,8 +9,8 @@ spring:
     password: ${DB_PASSWORD}
 
 springdoc:
-  dev-server-url: ${DEV_SERVER_URL}
-  prod-server-url: ${PROD_SERVER_URL}
+  api-docs.enabled: false
+  swagger-ui.enabled: false
 
 gcp:
   drive.folder-id: ${GCP_DRIVE_FOLDER_ID}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -8,6 +8,10 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 
+springdoc:
+  dev-server-url: ${DEV_SERVER_URL}
+  prod-server-url: ${PROD_SERVER_URL}
+
 gcp:
   drive.folder-id: ${GCP_DRIVE_FOLDER_ID}
   credentials.path: ${GCP_CREDENTIALS_PATH}


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- API 문서의 개발서버/운영서버 URI 정보를 주입받아서 사용하도록 수정했습니다. 덕분에 외부에 URI 정보가 유출되지 않습니다.
- 운영서버에서는 API 문서를 생성하지 않습니다.

## 🔗 관련 이슈
- closes #281 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - OpenAPI 문서에 로컬/개발/운영 서버 주소가 환경에 따라 동적으로 반영됩니다.
  - 운영 환경에서 Swagger UI 및 API 문서가 비활성화됩니다.
- Refactor
  - OpenAPI 서버 설정을 어노테이션 기반에서 런타임 커스터마이징 방식으로 전환했습니다.
- Chores
  - 배포 워크플로에 서버 URL 비밀 변수를 연동하여 실행 환경 구성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->