### PR TITLE
검색 결과로 코스 탐색 시 지도의 줌 상태를 지정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -211,6 +211,7 @@ class CoursesActivity :
         val latitude = Latitude(latitudeValue)
         val longitude = Longitude(longitudeValue)
 
+        mapManager.resetZoomLevel()
         mapManager.moveTo(latitude, longitude)
         fetchCourses(Coordinate(latitude, longitude), Scope.default())
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapCameraController.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapCameraController.kt
@@ -36,6 +36,11 @@ class KakaoMapCameraController(
         fitTo(coordinates, map)
     }
 
+    fun resetZoomLevel(map: KakaoMap) {
+        val cameraUpdate: CameraUpdate = CameraUpdateFactory.zoomTo(DEFAULT_ZOOM_LEVEL)
+        map.moveCamera(cameraUpdate)
+    }
+
     private fun fitTo(
         coordinates: List<Coordinate>,
         map: KakaoMap,
@@ -49,5 +54,6 @@ class KakaoMapCameraController(
 
     companion object {
         private const val MOVE_ANIMATION_DURATION = 750
+        private const val DEFAULT_ZOOM_LEVEL = 15
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
@@ -117,6 +117,12 @@ class KakaoMapManager(
         }
     }
 
+    fun resetZoomLevel() {
+        kakaoMap?.let { map: KakaoMap ->
+            cameraController.resetZoomLevel(map)
+        }
+    }
+
     fun showSearchLocation(
         latitude: Latitude,
         longitude: Longitude,


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
장소 검색 결과를 선택해 지도 화면으로 돌아올 시, 지도의 줌 상태가 일정 레벨로 지정됩니다.

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경사항이 있다면 변경 전후 스크린샷을 첨부해주세요 -->
### As-is
[feat_301_asis_resized.webm](https://github.com/user-attachments/assets/b85f90b4-d314-4060-a266-2b43cfade25c)

### To-be
[feat_301_tobe_resized.webm](https://github.com/user-attachments/assets/e2283d02-5bb0-4124-b97e-b1eab718a262)

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #301 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 지도에서 현재 위치나 검색 결과로 이동할 때, 화면이 기본 줌 레벨로 자동 초기화됩니다. 이동 직후 동일한 확대 비율을 보장해 위치 전환이 자연스럽고, 코스 목록 확인 시 시야가 과도하게 확대/축소되는 상황을 줄입니다. 사용자는 매번 손으로 줌을 재조정할 필요가 줄어 편의성이 향상됩니다. 다양한 해상도·기기에서도 균일한 가시성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->