### PR TITLE
현위치 정보가 없는 경우 '이 위치 검색' 버튼 소멸 버그 해결

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -86,11 +86,13 @@ class CoursesActivity :
         setUpDoubleBackPress()
         requestLocationPermissions()
 
-        mapManager.start { coordinate: Coordinate ->
+        mapManager.start {
             mapManager.setOnCameraMoveListener {
                 binding.mainSearchThisAreaButton.visibility = View.VISIBLE
             }
-            fetchCourses(coordinate, Scope.default())
+            mapManager.cameraPosition?.let { cameraPosition: LatLng ->
+                fetchCourses(cameraPosition.toCoordinate(), Scope.default())
+            }
         }
 
         searchLauncher = searchActivityResultLauncher()

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
@@ -29,7 +29,7 @@ class KakaoMapManager(
     val cameraPosition get(): LatLng? = kakaoMap?.cameraPosition?.position
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
-    fun start(onMapReady: (Coordinate) -> Unit) {
+    fun start(onMapReady: () -> Unit) {
         val offsetPx: Float =
             mapView.context.resources.getDimension(R.dimen.map_logo_position_offset)
         lifecycleHandler.start { map: KakaoMap ->
@@ -40,17 +40,7 @@ class KakaoMapManager(
                 offsetPx,
             )
             showCurrentLocation()
-            locationProvider.fetchCurrentLocation(
-                onSuccess = { location: Location ->
-                    onMapReady(
-                        Coordinate(
-                            Latitude(location.latitude),
-                            Longitude(location.longitude),
-                        ),
-                    )
-                },
-                onFailure = {},
-            )
+            onMapReady()
         }
     }
 


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
현 위치 정보를 얻을 수 없을 경우, `이 위치 재검색` 버튼을 눌러서 사라지게 한 뒤 지도를 움직여도 버튼이 다시 표시되지 않는 현상이 수정됩니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #317 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 지도 초기 구동 시 현재 위치 정보를 즉시 활용하지 못해 코스 목록이 잘못 표시되거나 비어 보이던 현상을 개선했습니다.
  * 지도 카메라 위치가 준비되지 않은 경우 초기 불필요한 데이터 요청을 방지하여 오류와 빈 화면 발생을 줄였습니다.
  * 위치 정보 가용성에 따라 초기 로딩 동작을 더 안정적으로 처리해, 앱 실행 직후 지도와 코스 표시의 신뢰성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->