### PR TITLE
코스이름 파싱을 제대로 하지 못하던 문제 해결

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/dto/CourseFile.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/CourseFile.java
@@ -22,9 +22,10 @@ public record CourseFile(
     }
 
     public static CourseFile from(MultipartFile file) throws IOException {
-        String[] fileFullName = file.getOriginalFilename().split("\\.");
-        String fileName = fileFullName[0];
-        String extension = fileFullName[1];
+        String originalFilename = file.getOriginalFilename();
+        int dotIndex = originalFilename.lastIndexOf(".");
+        String fileName = originalFilename.substring(0, dotIndex);
+        String extension = originalFilename.substring(dotIndex + 1);
 
         return new CourseFile(fileName, CourseFileExtension.from(extension), file.getInputStream());
     }

--- a/backend/src/test/java/coursepick/coursepick/application/dto/CourseFileTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/dto/CourseFileTest.java
@@ -20,6 +20,18 @@ class CourseFileTest {
 
     @ParameterizedTest
     @CsvSource({
+            ".file.gpx, .file",
+            "_file.gpx, _file",
+    })
+    void 복잡한_특수문자로_이루어진_코스이름도_정상적으로_파싱한다(String filename, String expectedFileName) {
+        var result = new CourseFile(filename, CourseFileExtension.GPX, null);
+
+        assertThat(result.name()).isEqualTo(expectedFileName);
+        assertThat(result.extension()).isEqualTo(CourseFileExtension.GPX);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
             "코스.gpx, 2",
             "코스이.gpx, 3",
             "코스이름.gpx, 4"


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- `보라매 공원 크게 한바퀴 1.1km.gpx` 파일을 파싱시 버그가 발생했습니다.
- 이유를 찾아보니 처음 등장하는 `.`을 기준으로 파일 이름을 나누고 있었기 때문에, 파일 이름 중간에 `.`이 달리면 버그가 발생했습니다.
- 이제 `.`이 등장하는 마지막 인덱스를 기준으로 나누기 때문에, 문제가 발생하지 않습니다.

## 🔗 관련 이슈
- closes #350 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 코스 동기화 배치 도입 및 관리자 동기화 엔드포인트(/admin/courses/sync) 추가
  * 로컬/개발 환경에서 코스 파일(GPX/KML) 업로드 도구 제공
  * 근처 코스 조회에 가변 범위(scope) 파라미터 추가
  * 헬스체크, 구조화 로깅, 클라이언트 ID 추적 강화
* Breaking Changes
  * 코스 ID가 숫자에서 문자열로 변경(API 응답/경로 변수 영향)
  * 데이터 저장소를 MongoDB로 전환
* Chores
  * Docker 이미지/Compose 기반 배포로 전환(Dev/Prod), 이중 서버 롤링 및 Nginx 전환 자동화
  * 테스트·모니터링 구성 개선, GCP 연동, 보안 허용 경로 필터 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->