### PR TITLE
휴유 서버 탐침 스크립트 버그 해결

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test:
+    name: 프로젝트 빌드
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/backend-dev-cd.yml
+++ b/.github/workflows/backend-dev-cd.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: 도커 이미지 빌드 & 푸시
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -49,6 +50,7 @@ jobs:
             .
 
   deploy:
+    name: 개발서버 배포
     needs: build
     runs-on: [ self-hosted, dev-app ]
     defaults:

--- a/.github/workflows/backend-prod-app-cd.yml
+++ b/.github/workflows/backend-prod-app-cd.yml
@@ -1,4 +1,5 @@
-name: Prod App CD
+name: Backend Prod App CD
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/backend-prod-app-cd.yml
+++ b/.github/workflows/backend-prod-app-cd.yml
@@ -82,5 +82,5 @@ jobs:
       - name: 기존 서버 내리기
         working-directory: /home/ssm-user/coursepick
         run: |
-          docker compose down
-          docker image prune -a -f
+          sudo docker compose down
+          sudo docker image prune -a -f

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -88,8 +88,8 @@ jobs:
             echo "One server is idle, idle=$idle"
             echo "idle=$idle" >> $GITHUB_OUTPUT
           else
-            echo "None servers are idle – as default, deploy to server1, idle=$idle"
             idle="prod-app-1"
+            echo "None servers are idle – as default, deploy to server1, idle=$idle"
             echo "idle=$idle" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -101,7 +101,7 @@ jobs:
     name: prod-app-1 서버에 배포
     needs: detect-idle
     if: needs.detect-idle.outputs.idle-server == 'prod-app-1'
-    uses: ./.github/workflows/backend-prod-app.cd.yml
+    uses: ./.github/workflows/backend-prod-app-cd.yml
     with:
       run_id: ${{ github.run_id }}
       main_runner: prod-app-1
@@ -112,7 +112,7 @@ jobs:
     name: prod-app-2 서버에 배포
     needs: detect-idle
     if: needs.detect-idle.outputs.idle-server == 'prod-app-2'
-    uses: ./.github/workflows/backend-prod-app.cd.yml
+    uses: ./.github/workflows/backend-prod-app-cd.yml
     with:
       run_id: ${{ github.run_id }}
       main_runner: prod-app-2

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -90,7 +90,7 @@ jobs:
     name: prod-app-1 서버에 배포
     needs: detect-idle
     if: needs.detect-idle.outputs.idle-server == 'prod-app-1'
-    uses: ./.github/workflows/prod-app-cd.yml
+    uses: backend-prod-app-cd.yml
     with:
       run_id: ${{ github.run_id }}
       main_runner: prod-app-1
@@ -101,7 +101,7 @@ jobs:
     name: prod-app-2 서버에 배포
     needs: detect-idle
     if: needs.detect-idle.outputs.idle-server == 'prod-app-2'
-    uses: ./.github/workflows/prod-app-cd.yml
+    uses: backend-prod-app-cd.yml
     with:
       run_id: ${{ github.run_id }}
       main_runner: prod-app-2

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -63,29 +63,28 @@ jobs:
       - name: 탐침 스크립트 실행
         id: find
         run: |
-          # health 체크할 서버 목록
           declare -A servers=(
             [prod-app-1]="${{ secrets.PROD_APP_1_HEALTH_URL }}"
             [prod-app-2]="${{ secrets.PROD_APP_2_HEALTH_URL }}"
           )
           
-          ok_servers=()
+          idle_servers=()
           
           for name in "${!servers[@]}"; do
             url="${servers[$name]}"
             code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "")
             if [[ "$code" -eq 200 ]]; then
               echo "$name 응답 성공"
-              ok_servers+=("$name")
             else
               echo "$name 응답 실패"
+              idle_servers+=("$name")
             fi
           done
           
-          if [[ ${#ok_servers[@]} -eq 2 ]]; then
+          if [[ ${#idle_servers[0]} -eq 0 ]]; then
             echo "Both servers are healthy – cannot find idle server"
-          elif [[ ${#ok_servers[@]} -eq 1 ]]; then
-            idle="${ok_servers[0]}"
+          elif [[ ${#idle_servers[0]} -eq 1 ]]; then
+            idle="${idle_servers[0]}"
             echo "One server is idle, idle=$idle"
             echo "idle=$idle" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -68,19 +68,30 @@ jobs:
             [prod-app-1]="${{ secrets.PROD_APP_1_HEALTH_URL }}"
             [prod-app-2]="${{ secrets.PROD_APP_2_HEALTH_URL }}"
           )
-
-          idle=""
+          
+          ok_servers=()
+          
           for name in "${!servers[@]}"; do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "${servers[$name]}" || echo "")
-            if [[ "$code" -ne 200 ]]; then
-              idle=$name
-              break
+            url="${servers[$name]}"
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$url" || echo "")
+            if [[ "$code" -eq 200 ]]; then
+              echo "$name 응답 성공"
+              ok_servers+=("$name")
+            else
+              echo "$name 응답 실패"
             fi
           done
-
-          if [[ -z "$idle" ]]; then
-            echo "Both servers are healthy – cannot find idle server" >&2
-            exit 1
+          
+          if [[ ${#ok_servers[@]} -eq 2 ]]; then
+            echo "Both servers are healthy – cannot find idle server"
+          elif [[ ${#ok_servers[@]} -eq 1 ]]; then
+            idle="${ok_servers[0]}"
+            echo "One server is idle, idle=$idle"
+            echo "idle=$idle" >> $GITHUB_OUTPUT
+          else
+            echo "None servers are idle – as default, deploy to server1, idle=$idle"
+            idle="prod-app-1"
+            echo "idle=$idle" >> $GITHUB_OUTPUT
           fi
 
           echo "idle=$idle" >> $GITHUB_OUTPUT

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -81,9 +81,9 @@ jobs:
             fi
           done
           
-          if [[ ${#idle_servers[0]} -eq 0 ]]; then
+          if [[ ${#idle_servers[@]} -eq 0 ]]; then
             echo "Both servers are healthy – cannot find idle server"
-          elif [[ ${#idle_servers[0]} -eq 1 ]]; then
+          elif [[ ${#idle_servers[@]} -eq 1 ]]; then
             idle="${idle_servers[0]}"
             echo "One server is idle, idle=$idle"
             echo "idle=$idle" >> $GITHUB_OUTPUT

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,8 +1,8 @@
 name: Backend Prod Server CD
 
 on:
-  pull_request:
-    branches: [ backend ]
+  push:
+    branches: [ main ]
     paths:
       - 'backend/**'
       - '.github/workflows/backend-prod-cd.yml'

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -101,7 +101,7 @@ jobs:
     name: prod-app-1 서버에 배포
     needs: detect-idle
     if: needs.detect-idle.outputs.idle-server == 'prod-app-1'
-    uses: backend-prod-app-cd.yml
+    uses: ./.github/workflows/backend-prod-app.cd.yml
     with:
       run_id: ${{ github.run_id }}
       main_runner: prod-app-1
@@ -112,7 +112,7 @@ jobs:
     name: prod-app-2 서버에 배포
     needs: detect-idle
     if: needs.detect-idle.outputs.idle-server == 'prod-app-2'
-    uses: backend-prod-app-cd.yml
+    uses: ./.github/workflows/backend-prod-app.cd.yml
     with:
       run_id: ${{ github.run_id }}
       main_runner: prod-app-2

--- a/.github/workflows/backend-prod-cd.yml
+++ b/.github/workflows/backend-prod-cd.yml
@@ -1,8 +1,8 @@
 name: Backend Prod Server CD
 
 on:
-  push:
-    branches: [ main ]
+  pull_request:
+    branches: [ backend ]
     paths:
       - 'backend/**'
       - '.github/workflows/backend-prod-cd.yml'


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 양 서버 모두 응답/0 서버 응답 상황에 대해서 좀 더 명확하게 예외 처리하였습니다.
  - 2서버 응답 : 실패
  - 1서버 응답 : 정상 진행
  - 0서버 응답 : 첫번째 서버로 진행
- 한국어 이름이 없던 job들에 이름을 부여했습니다.

ex)
<img width="536" height="145" alt="image" src="https://github.com/user-attachments/assets/eabc491c-7f1b-450a-b623-3f375fda394e" />

## 🔗 관련 이슈
- closes #339 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- CI
  - 배포 트리거를 main 푸시에서 backend 대상 PR로 변경(경로 필터 유지).
  - 두 배포 작업이 공용 워크플로로 통합되고 각 작업에 보조 러너(sub_runner) 매개변수 추가.
- Refactor
  - 유휴 서버 판별 로직 개선: 복수 서버 검사·idle_servers 배열 도입, 결과에 따른 기본 동작(기본 서버로 배포) 및 항상 출력(export) 처리.
  - 헬스 체크 상태 메시지를 한국어("응답 성공"/"응답 실패")로 일원화.
- Chores
  - 워크플로 표시 이름을 "Backend Prod App CD"로 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->