### PR TITLE
코스 겹쳤을 때 순서에 의존하는 문제 해결

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapDrawer.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapDrawer.kt
@@ -29,7 +29,12 @@ class KakaoMapDrawer(
         layer.removeAll()
         courses.forEach { course: CourseItem ->
             val options: RouteLineOptions = routeLineOptionsFactory.routeLineOptions(course)
-            layer.addRouteLine(options)
+            layer.addRouteLine(
+                options.apply {
+                    zOrder =
+                        if (course.selected) SELECTED_COURSE_Z_ORDER else UNSELECTED_COURSE_Z_ORDER
+                },
+            )
         }
     }
 
@@ -94,5 +99,7 @@ class KakaoMapDrawer(
 
     companion object {
         private const val LABEL_MOVE_ANIMATION_DURATION = 500
+        private const val SELECTED_COURSE_Z_ORDER = 1
+        private const val UNSELECTED_COURSE_Z_ORDER = 0
     }
 }


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
선택된 코스가 가장 위에 그려지도록 변경됩니다.

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경사항이 있다면 변경 전후 스크린샷을 첨부해주세요 -->

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #319 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 지도에서 코스를 선택하면 해당 경로가 다른 경로 위에 표시되도록 레이어 순서를 조정했습니다. 선택되지 않은 경로는 뒤로 배치되어 겹침 상황에서 가독성과 시각적 구분이 개선됩니다. 코스를 전환할 때 선택 상태가 즉시 드러나며, 업데이트 후 별도의 설정이나 추가 조작 없이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->