### PR TITLE
앱 처음 시작 시 `이 지역 검색` 버튼이 표시되지 않도록 변경

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
@@ -49,6 +49,7 @@ class KakaoMapEventHandler {
         onCameraMove: () -> Unit,
     ) {
         map.setOnCameraMoveStartListener { _, gestureType: GestureType ->
+            if (gestureType == GestureType.Unknown) return@setOnCameraMoveStartListener
             val cameraPosition: CameraPosition? = map.cameraPosition
             Logger.log(
                 Logger.Event.MapMoveStart("map"),
@@ -64,6 +65,7 @@ class KakaoMapEventHandler {
         }
 
         map.setOnCameraMoveEndListener { _, cameraPosition: CameraPosition, gestureType: GestureType ->
+            if (gestureType == GestureType.Unknown) return@setOnCameraMoveEndListener
             Logger.log(
                 Logger.Event.MapMoveEnd("map"),
                 "gesture_type" to gestureType.name,

--- a/android/app/src/main/res/layout/activity_courses.xml
+++ b/android/app/src/main/res/layout/activity_courses.xml
@@ -77,6 +77,7 @@
                 android:orientation="horizontal"
                 android:padding="10dp"
                 android:translationY="50dp"
+                android:visibility="gone"
                 app:layout_anchor="@id/mainToolBar"
                 app:layout_anchorGravity="bottom|center_horizontal"
                 app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
앱이 처음으로 시작될 때 `이 지역 검색` 버튼이 표시되지 않도록 변경됩니다.

## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- 코스 화면에 처음으로 진입할 시 `이 지역 검색` 버튼이 표시되지 않습니다.
- 유저가 지도를 직접 움직일 때만 지도 이동 이벤트 리스너가 작동합니다.

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경사항이 있다면 변경 전후 스크린샷을 첨부해주세요 -->

### As-is
https://github.com/user-attachments/assets/4e695a34-8382-4e68-a793-949259ae3ba4

### To-be
https://github.com/user-attachments/assets/1d3cd567-61cc-4c4f-898e-2db81228b2e9

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #333 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kakao 지도 카메라 이동 시작/종료 리스너에서 GestureType.Unknown을 즉시 무시해 불필요한 로그와 부수 동작(시작 리스너의 추가 onCameraMove 호출)을 방지합니다. 기존 제스처 동작에는 영향이 없으며 안정성을 개선합니다.
  * 코스 화면의 “이 영역 검색” 버튼을 기본적으로 숨김 처리하여 초기 진입 시 불필요한 버튼 노출을 막고 화면을 깔끔하게 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->