### PR TITLE
몽고 디비에서 세그먼트 파싱 중 예외가 발생한 경우 처리

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/SegmentListConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/SegmentListConverter.java
@@ -4,14 +4,18 @@ import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.GeoLine;
 import coursepick.coursepick.domain.GeoLineBuilder;
 import coursepick.coursepick.domain.Segment;
+import coursepick.coursepick.logging.LogContent;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+@Slf4j
 public class SegmentListConverter {
 
     @WritingConverter
@@ -47,12 +51,17 @@ public class SegmentListConverter {
     public static class Reader implements Converter<Document, List<Segment>> {
         @Override
         public List<Segment> convert(Document source) {
-            if (source == null) return null;
-            List<List<List<Double>>> segmentsData = (List<List<List<Double>>>) source.get("coordinates");
+            try {
+                if (source == null) return null;
+                List<List<List<Double>>> segmentsData = (List<List<List<Double>>>) source.get("coordinates");
 
-            return segmentsData.stream()
-                    .map(Reader::parseSegment)
-                    .toList();
+                return segmentsData.stream()
+                        .map(Reader::parseSegment)
+                        .toList();
+            } catch (Exception e) {
+                log.warn("[EXCEPTION] 세그먼트 파싱 중 예외 발생", LogContent.exception(source, e));
+                return Collections.emptyList();
+            }
         }
 
         private static Segment parseSegment(List<List<Double>> lineStringCoordinates) {

--- a/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
@@ -1,5 +1,6 @@
 package coursepick.coursepick.logging;
 
+import org.bson.Document;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
@@ -27,6 +28,15 @@ public class LogContent {
                 kv("req_headers", headers),
                 kv("req_body", left(requestBody, 100)),
                 kv("res_body", left(responseBody, 100))
+        };
+    }
+
+    public static Object[] exception(Document document, Exception e) {
+        return new Object[]{
+                kv("document", document),
+                kv("exception_class", e.getClass().getName()),
+                kv("exception_message", e.getMessage()),
+                e
         };
     }
 


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- QA 중에 데이터 파싱 중 예외가 발생하였으나, 정확한 이유를 몰랐던 문제가 있었습니다.
- 또한 하나의 도큐먼트 때문에 다른 모든 도큐먼트도 불러오지 못했습니다.
  - 이제 로그를 찍습니다.
  - 하나의 도큐먼트만 불완전한 상태로 응답합니다.

## 🔗 관련 이슈
- closes #381 
