### PR TITLE
HTTP 응답 압축 기능 추가

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -11,7 +11,7 @@ server:
   forward-headers-strategy: framework
   compression:
     enabled: true
-    mime-types: application/json,text/plain
+    mime-types: application/json
     min-response-size: 2KB
 
 springdoc:


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- `application.yml` 에 설정정보를 포함시켰습니다.
- 요청 헤더에 `Accept-Encoding` 을 포함시키면 이제 응답이 자동으로 압축됩니다.

### gzip 압축률
- 기존 요청과 gzip압축을 추가한 요청을 모두 해보고, ResponseBody를 저장해보았습니다.
- 약 85%의 응답 크기 개선이 있었습니다.

**요청1**
```bash
curl -v \
		-X GET "http://localhoㅇst:8080/courses?mapLat=37.510022&mapLng=127.102617&scope=1000" \
		-o response_plain
```
**요청2**
```bash
curl -v \
		-X GET "http://localhost:8080/courses?mapLat=37.510022&mapLng=127.102617&scope=1000" \
		-H "Accept-Encoding: gzip" \
		-o response_gzip
```

<img width="583" height="49" alt="image" src="https://github.com/user-attachments/assets/a0d041ae-3f17-46cd-85ae-b15c26965847" />

### 응답 속도
- k6로 테스트 해본 결과 약 30%의 속도 개선이 있었습니다.

## 🔗 관련 이슈
- closes #406 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * HTTP 응답 압축이 활성화되어 대용량 JSON 응답(application/json, 2KB 이상)에 대해 전송 효율이 향상됩니다.
  * 기대 효과: 네트워크 사용량 감소와 로딩 시간 단축으로 응답 체감 속도 개선.
  * 사용자는 별도 설정 없이 자동으로 혜택을 받습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->