### PR TITLE
즐겨찾기 기능을 위한 여러 코스 id 조회 기능 구현

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -49,4 +49,11 @@ public class CourseApplicationService {
 
         return course.closestCoordinateFrom(new Coordinate(latitude, longitude));
     }
+
+    public CourseResponse findById(String id) {
+        Course course = courseRepository.findById(id)
+                .orElseThrow(() -> NOT_EXIST_COURSE.create(id));
+
+        return CourseResponse.from(course);
+    }
 }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -1,6 +1,7 @@
 package coursepick.coursepick.application;
 
 import coursepick.coursepick.application.dto.CourseResponse;
+import coursepick.coursepick.application.exception.NotFoundException;
 import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
 import coursepick.coursepick.domain.CourseRepository;
@@ -53,6 +54,10 @@ public class CourseApplicationService {
     @Transactional(readOnly = true)
     public List<CourseResponse> findFavoriteCourses(List<String> ids) {
         List<Course> courses = courseRepository.findByIdIn(ids);
+        if (courses == null || courses.isEmpty()) {
+            throw NOT_EXIST_COURSE.create(ids);
+        }
+
         return courses.stream()
                 .map(CourseResponse::from)
                 .toList();

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -50,10 +50,11 @@ public class CourseApplicationService {
         return course.closestCoordinateFrom(new Coordinate(latitude, longitude));
     }
 
-    public CourseResponse findById(String id) {
-        Course course = courseRepository.findById(id)
-                .orElseThrow(() -> NOT_EXIST_COURSE.create(id));
-
-        return CourseResponse.from(course);
+    @Transactional(readOnly = true)
+    public List<CourseResponse> findFavoriteCourses(List<String> ids) {
+        List<Course> courses = courseRepository.findByIdIn(ids);
+        return courses.stream()
+                .map(CourseResponse::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -1,7 +1,6 @@
 package coursepick.coursepick.application;
 
 import coursepick.coursepick.application.dto.CourseResponse;
-import coursepick.coursepick.application.exception.NotFoundException;
 import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
 import coursepick.coursepick.domain.CourseRepository;
@@ -54,12 +53,18 @@ public class CourseApplicationService {
     @Transactional(readOnly = true)
     public List<CourseResponse> findFavoriteCourses(List<String> ids) {
         List<Course> courses = courseRepository.findByIdIn(ids);
-        if (courses == null || courses.isEmpty()) {
-            throw NOT_EXIST_COURSE.create(ids);
-        }
+        loggingForNotExistsCourse(ids, courses);
 
         return courses.stream()
                 .map(CourseResponse::from)
                 .toList();
+    }
+
+    private void loggingForNotExistsCourse(List<String> ids, List<Course> courses) {
+        for (Course course : courses) {
+            if (!ids.contains(course.id())) {
+                log.warn("존재하지 않는 코스에 대한 조회: {}", course.id());
+            }
+        }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/CourseRepository.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CourseRepository.java
@@ -25,5 +25,7 @@ public interface CourseRepository extends MongoRepository<Course, String> {
         return findAllHasDistanceWithin(new Point(new Position(target.longitude(), target.latitude())), distance.value());
     }
 
+    List<Course> findByIdIn(List<String> ids);
+
     boolean existsByName(CourseName courseName);
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -58,9 +58,11 @@ public class CourseWebController implements CourseWebApi {
     }
 
     @Override
-    @GetMapping("/courses/{id}")
-    public CourseWebResponse findCourseById(@PathVariable("id") String id) {
-        return CourseWebResponse.from(courseApplicationService.findById(id));
+    @GetMapping("/user/favorite-courses")
+    public List<CourseWebResponse> findFavoriteCourses(@RequestParam("courseIds") List<String> ids) {
+        return courseApplicationService.findFavoriteCourses(ids).stream()
+                .map(CourseWebResponse::from)
+                .toList();
     }
 
     private void validateAdminToken(String token) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -57,6 +57,12 @@ public class CourseWebController implements CourseWebApi {
         return CoordinateWebResponse.from(coordinate);
     }
 
+    @Override
+    @GetMapping("/courses/{id}")
+    public CourseWebResponse findCourseById(@PathVariable("id") String id) {
+        return CourseWebResponse.from(courseApplicationService.findById(id));
+    }
+
     private void validateAdminToken(String token) {
         if (adminToken.isEmpty() || !adminToken.equals(token)) {
             throw INVALID_ADMIN_TOKEN.create();

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -58,7 +58,7 @@ public class CourseWebController implements CourseWebApi {
     }
 
     @Override
-    @GetMapping("/user/favorite-courses")
+    @GetMapping("/courses/favorites")
     public List<CourseWebResponse> findFavoriteCourses(@RequestParam("courseIds") List<String> ids) {
         return courseApplicationService.findFavoriteCourses(ids).stream()
                 .map(CourseWebResponse::from)

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -65,4 +65,6 @@ public interface CourseWebApi {
             @Parameter(example = "37.5165004", required = true) double latitude,
             @Parameter(example = "127.1040109", required = true) double longitude
     );
+
+    CourseWebResponse findCourseById(String id);
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -66,5 +66,17 @@ public interface CourseWebApi {
             @Parameter(example = "127.1040109", required = true) double longitude
     );
 
-    CourseWebResponse findCourseById(String id);
+    @Operation(summary = "특정 코스 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "코스가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                    )
+            }))
+    })
+    CourseWebResponse findCourseById(
+            @Parameter(example = "689c3143182cecc6353cca7b", required = true) String id
+    );
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -66,7 +67,7 @@ public interface CourseWebApi {
             @Parameter(example = "127.1040109", required = true) double longitude
     );
 
-    @Operation(summary = "특정 코스 조회")
+    @Operation(summary = "즐겨찾기 코스 조회")
     @ApiResponses({
             @ApiResponse(responseCode = "200"),
             @ApiResponse(responseCode = "404", content = @Content(examples = {
@@ -76,7 +77,13 @@ public interface CourseWebApi {
                     )
             }))
     })
-    CourseWebResponse findCourseById(
-            @Parameter(example = "689c3143182cecc6353cca7b", required = true) String id
+    List<CourseWebResponse> findFavoriteCourses(
+            @Parameter(
+                    description = "조회할 코스 ID 목록",
+                    required = true,
+                    example = "689c3143182cecc6353cca7b,689c3143182cecc6353cca7c,689c3143182cecc6353cca7d",
+                    schema = @Schema(type = "array", implementation = String.class)
+            )
+            List<String> coursesId
     );
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -68,15 +68,7 @@ public interface CourseWebApi {
     );
 
     @Operation(summary = "즐겨찾기 코스 조회")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    )
-            }))
-    })
+    @ApiResponse(responseCode = "200")
     List<CourseWebResponse> findFavoriteCourses(
             @Parameter(
                     description = "조회할 코스 ID 목록",

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
@@ -60,7 +60,7 @@ public class OpenApiConfig {
 
             example = new Example()
                     .value(Map.of(
-                            "message", NOT_EXIST_COURSE.message(99999),
+                            "message", NOT_EXIST_COURSE.message("689c3143182cecc6353cca2b"),
                             "timestamp", TIMESTAMP
                     ));
             components.addExamples(NOT_EXIST_COURSE.name(), example);

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
 public record CourseWebResponse(
-        @Schema(example = "1")
+        @Schema(example = "689c3143182cecc6353cca7b")
         String id,
         @Schema(example = "석촌호수")
         String name,

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseWebResponse.java
@@ -40,4 +40,19 @@ public record CourseWebResponse(
                         SegmentWebResponse.from(courseResponse.segments())
                 )).toList();
     }
+
+    public static CourseWebResponse from(CourseResponse courseResponse) {
+        return new CourseWebResponse(
+                courseResponse.id(),
+                courseResponse.name(),
+                courseResponse.distance()
+                        .map(Meter::value)
+                        .orElse(null),
+                courseResponse.length().value(),
+                courseResponse.roadType(),
+                courseResponse.inclineSummary(),
+                courseResponse.difficulty().name(),
+                SegmentWebResponse.from(courseResponse.segments())
+        );
+    }
 }

--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -22,7 +22,7 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
     private static final Set<Pattern> ALLOW_URI_PATTERNS = Set.of(
             Pattern.compile("^/admin/courses/sync$"),
             Pattern.compile("^/courses$"),
-            Pattern.compile("^/user/favorite-courses$"),
+            Pattern.compile("^/courses/favorites$"),
             Pattern.compile("^/courses/[^/]+/closest-coordinate$"),
             Pattern.compile("^/import$"),
             Pattern.compile("^/actuator/health$"),

--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -22,7 +22,7 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
     private static final Set<Pattern> ALLOW_URI_PATTERNS = Set.of(
             Pattern.compile("^/admin/courses/sync$"),
             Pattern.compile("^/courses$"),
-            Pattern.compile("^/courses/[0-9a-fA-F]{24}$"),
+            Pattern.compile("^/user/favorite-courses$"),
             Pattern.compile("^/courses/[^/]+/closest-coordinate$"),
             Pattern.compile("^/import$"),
             Pattern.compile("^/actuator/health$"),

--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -22,6 +22,7 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
     private static final Set<Pattern> ALLOW_URI_PATTERNS = Set.of(
             Pattern.compile("^/admin/courses/sync$"),
             Pattern.compile("^/courses$"),
+            Pattern.compile("^/courses/[0-9a-fA-F]{24}$"),
             Pattern.compile("^/courses/[^/]+/closest-coordinate$"),
             Pattern.compile("^/import$"),
             Pattern.compile("^/actuator/health$"),


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 즐겨찾기 기능을 위해 여러 코스 id를 받아 조회하는 기능을 구현했습니다.

### 즐겨찾기 기능
현재 즐겨찾기 기능을 위해 사용자의 deviceId, courseId를 로컬 스토리지에 저장해두고 즐겨찾기 코스 조회가 필요한 경우에 안드로이드에서 해당 api를 호출하도록 설계했습니다. 해당 API 도입 계기는 다음과 같습니다.

처음 해당 기능을 설계할 때 사용자의 즐겨찾기 목록을 어떻게 관리할지 다음 3가지를 생각했습니다.
1. deviceId, courseId 로컬 스토리지 저장
2. deviceId, courseId 서버 저장
3. 로그인 기능

하지만 2번의 경우 deviceId, courseId 별로 데이터베이스에 저장하는 것은 재설치, 삭제 시 없어지는 deviceId이기에 추적이 어렵다는 단점이 존재했습니다. 3번의 경우에는 즐겨찾기를 위해 로그인 하는 것은 하지 않을 가능성이 높다고 생각했습니다. 그래서 2번의 단점을 상쇄하고, 가볍게 만들어볼 수 있는 1번으로 선택했습니다.

<img width="402" height="821" alt="image" src="https://github.com/user-attachments/assets/02566095-37b4-434d-bd1a-454cac195fc4" />

그리고 이처럼 즐겨찾기도 내 주변 코스 조회처럼 바텀시트에 표시되도록 구현하였습니다. 그래서, 현재 deviceId가 가진 courseIds를 모두 조회하는 기능이 필요했고 해당 API를 개발하게 되었습니다. 페이징도 고려했지만 아직 주변 코스 조회의 페이징 기능이 존재하지 않아서 어떤식으로 페이징을 풀어갈지 의논이 필요할 것으로 판단되어 도입하지 않았습니다.


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #391 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 즐겨찾기 코스 조회 API 추가: 여러 코스 ID로 한 번에 코스 목록을 조회할 수 있습니다.
  - /courses/favorites 엔드포인트 접근 허용 추가로 이용 편의성 향상.

- Improvements
  - 단일/목록 응답 변환 일관성 강화로 출력 필드 매핑 정확성 향상.
  - 오류 예시 및 응답 식별자 타입을 문자열로 통일해 문서·응답 일관성 개선.

- Documentation
  - OpenAPI 문서에 즐겨찾기 엔드포인트 및 코스 ID 목록 파라미터, 오류 예시 업데이트.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->