### PR TITLE
코스 경로 조회 API 개발

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -52,8 +52,8 @@ public class CourseApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public List<Coordinate> routesTo(String id, double latitude, double longitude) {
-        Coordinate destination = findClosestCoordinate(id, latitude, longitude);
-        return walkingRouteService.route(new Coordinate(latitude, longitude), destination);
+    public List<Coordinate> routesToCourse(String id, double originLatitude, double originLongitude) {
+        Coordinate destination = findClosestCoordinate(id, originLatitude, originLongitude);
+        return walkingRouteService.route(new Coordinate(originLatitude, originLongitude), destination);
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -20,6 +20,7 @@ import static coursepick.coursepick.application.exception.ErrorType.NOT_EXIST_CO
 public class CourseApplicationService {
 
     private final CourseRepository courseRepository;
+    private final WalkingRouteService walkingRouteService;
 
     @Transactional(readOnly = true)
     public List<CourseResponse> findNearbyCourses(double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude, int scope) {
@@ -48,5 +49,11 @@ public class CourseApplicationService {
                 .orElseThrow(() -> NOT_EXIST_COURSE.create(id));
 
         return course.closestCoordinateFrom(new Coordinate(latitude, longitude));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Coordinate> routesTo(String id, double latitude, double longitude) {
+        Coordinate destination = findClosestCoordinate(id, latitude, longitude);
+        return walkingRouteService.route(new Coordinate(latitude, longitude), destination);
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -64,7 +64,7 @@ public class CourseWebController implements CourseWebApi {
             @RequestParam("startLat") double latitude,
             @RequestParam("startLng") double longitude
     ) {
-        List<Coordinate> responses = courseApplicationService.routesTo(id, latitude, longitude);
+        List<Coordinate> responses = courseApplicationService.routesToCourse(id, latitude, longitude);
         return CoordinateWebResponse.from(responses);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -57,6 +57,17 @@ public class CourseWebController implements CourseWebApi {
         return CoordinateWebResponse.from(coordinate);
     }
 
+    @Override
+    @GetMapping("/routes/{id}")
+    public List<CoordinateWebResponse> routeToCourse(
+            @PathVariable("id") String id,
+            @RequestParam("startLat") double latitude,
+            @RequestParam("startLng") double longitude
+    ) {
+        List<Coordinate> responses = courseApplicationService.routesTo(id, latitude, longitude);
+        return CoordinateWebResponse.from(responses);
+    }
+
     private void validateAdminToken(String token) {
         if (adminToken.isEmpty() || !adminToken.equals(token)) {
             throw INVALID_ADMIN_TOKEN.create();

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -58,7 +58,7 @@ public class CourseWebController implements CourseWebApi {
     }
 
     @Override
-    @GetMapping("/routes/{id}")
+    @GetMapping("/courses/{id}/route")
     public List<CoordinateWebResponse> routeToCourse(
             @PathVariable("id") String id,
             @RequestParam("startLat") double latitude,

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -65,4 +65,30 @@ public interface CourseWebApi {
             @Parameter(example = "37.5165004", required = true) double latitude,
             @Parameter(example = "127.1040109", required = true) double longitude
     );
+
+    @Operation(summary = "특정 코스까지의 길찾기")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "위도가 범위 외인 경우",
+                            ref = "#/components/examples/INVALID_LATITUDE_RANGE"
+                    ),
+                    @ExampleObject(
+                            name = "경도가 범위 외인 경우",
+                            ref = "#/components/examples/INVALID_LONGITUDE_RANGE"
+                    ),
+            })),
+            @ApiResponse(responseCode = "404", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "코스가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                    )
+            })),
+    })
+    List<CoordinateWebResponse> routeToCourse(
+            @Parameter(example = "689c3143182cecc6353cca7b", required = true) String id,
+            @Parameter(example = "37.5165004", required = true) double latitude,
+            @Parameter(example = "127.1040109", required = true) double longitude
+    );
 }

--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -23,6 +23,7 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
             Pattern.compile("^/admin/courses/sync$"),
             Pattern.compile("^/courses$"),
             Pattern.compile("^/courses/[^/]+/closest-coordinate$"),
+            Pattern.compile("^/courses/[^/]+/route$"),
             Pattern.compile("^/import$"),
             Pattern.compile("^/actuator/health$"),
             Pattern.compile("^/api-docs.html$"),


### PR DESCRIPTION
# 실수로 기존 PR을 닫아서 짱구는 여기서 리뷰해도 될 것 같습니다~ (내용은 동일합니다)
https://github.com/woowacourse-teams/2025-course-pick/pull/426

## 🛠️ 주요 변경 사항
- 기존 코스 경로 기능을 API로 사용
- API 문서 추가

## 📸 스크린샷
<img width="1308" height="505" alt="image" src="https://github.com/user-attachments/assets/9021a141-0115-487b-9700-bf470922de42" />
<img width="1305" height="428" alt="image" src="https://github.com/user-attachments/assets/5e3c53a6-d9ac-47d7-9253-693c5a153870" />


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #425 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 사용자의 시작 위치(쿼리: startLat, startLng)에서 지정한 코스까지의 보행 경로를 조회하는 새 엔드포인트를 추가했습니다: GET /courses/{id}/route. 경로 좌표 목록을 반환합니다.
  - 존재하지 않는 코스는 404, 위도/경도 범위 유효성 실패는 400을 반환합니다.

- **문서**
  - 새 경로 조회 엔드포인트에 대한 OpenAPI 문서를 추가해 성공 및 오류 응답을 명시했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->