### PR TITLE
CI 빌드 debug만 수행하도록 수정

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -46,6 +46,6 @@ jobs:
         run: ./gradlew testDebugUnitTest --stacktrace
         working-directory: android
 
-      - name: Build with Gradle
-        run: ./gradlew build
+      - name: Build Debug APK only
+        run: ./gradlew assembleDebug --stacktrace
         working-directory: android


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->

## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- CD 구축 과정에서 release 빌드에서 keystore.jks를 사용하고 있음.
- CI의 ./gradlew build는 디버그 빌드, 릴리즈 빌드를 하고 있음.
- 현재 CI에서 release를 위한 keystore.jks가 없어서 CI의 ./gradlew build에서 터짐.
- 해결 방법 1) CI를 통과하기 위해 release를 위한 keystore.jks를 넣어서 관리한다
- 해결 방법 2) CI에서 ./gradlew build -> ./gradlew assembleDebug --stacktrace로 변경한다

해결 방법 1의 장점
- CI에서 릴리즈까지 모두 빌드 가능
- 실제 배포 빌드와 CI 빌드가 동일하게 검증됨

해결 방법 1의 단점
- 보안 부담
- CI 빌드 속도 느려짐
- PR마다 릴리즈 빌드가 돌기 때문에 불필요한 에러 가능성

해결 방법 2의 장점
- keystore.jks를 CI에 추가하지 않아도 됨
- debug 빌드만 하므로, 빌드 속도 빠름

해결 방법 2의 단점
- PR에서 릴리즈 빌드 검증 불가
- 브랜치에서 발견하지 못하고 main에서 CD 빌드 시 터질 수 있음

PR에서는 debug만, main/CD에서 release 검증 구조를 가지고 가는 게 효율적이라고 판단됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Android CI에서 전체 Gradle 빌드 대신 디버그 APK만 빌드하도록 워크플로우가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->