### PR TITLE
Osrm 요청시 타임아웃 설정

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteService.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteService.java
@@ -27,7 +27,7 @@ public class OsrmWalkingRouteService implements WalkingRouteService {
     public OsrmWalkingRouteService(@Value("${osrm.url}") String osrmUrl) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(Duration.ofSeconds(1));
-        requestFactory.setReadTimeout(Duration.ofSeconds(2));
+        requestFactory.setReadTimeout(Duration.ofSeconds(5));
 
         this.restClient = RestClient.builder()
                 .requestFactory(requestFactory)

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteService.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteService.java
@@ -7,9 +7,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +25,12 @@ public class OsrmWalkingRouteService implements WalkingRouteService {
     private final RestClient restClient;
 
     public OsrmWalkingRouteService(@Value("${osrm.url}") String osrmUrl) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(1));
+        requestFactory.setReadTimeout(Duration.ofSeconds(2));
+
         this.restClient = RestClient.builder()
+                .requestFactory(requestFactory)
                 .baseUrl(osrmUrl)
                 .build();
     }

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -5,7 +5,7 @@ import coursepick.coursepick.application.exception.NotFoundException;
 import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
 import coursepick.coursepick.domain.RoadType;
-import coursepick.coursepick.test_util.IntegrationTest;
+import coursepick.coursepick.test_util.AbstractIntegrationTest;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CourseApplicationServiceTest extends IntegrationTest {
+class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Autowired
     CourseApplicationService sut;

--- a/backend/src/test/java/coursepick/coursepick/application/CourseSyncServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseSyncServiceTest.java
@@ -3,7 +3,7 @@ package coursepick.coursepick.application;
 import coursepick.coursepick.application.dto.CourseFile;
 import coursepick.coursepick.application.dto.CourseFileExtension;
 import coursepick.coursepick.domain.Coordinate;
-import coursepick.coursepick.test_util.IntegrationTest;
+import coursepick.coursepick.test_util.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
 
-class CourseSyncServiceTest extends IntegrationTest {
+class CourseSyncServiceTest extends AbstractIntegrationTest {
 
     @Autowired
     CourseSyncService sut;

--- a/backend/src/test/java/coursepick/coursepick/batch/CourseBatchTest.java
+++ b/backend/src/test/java/coursepick/coursepick/batch/CourseBatchTest.java
@@ -4,7 +4,7 @@ import coursepick.coursepick.application.dto.CourseFile;
 import coursepick.coursepick.application.dto.CourseFileExtension;
 import coursepick.coursepick.domain.Coordinate;
 import coursepick.coursepick.domain.Course;
-import coursepick.coursepick.test_util.IntegrationTest;
+import coursepick.coursepick.test_util.AbstractIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.BatchStatus;
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @SpringBatchTest
-class CourseBatchTest extends IntegrationTest {
+class CourseBatchTest extends AbstractIntegrationTest {
 
     @Autowired
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")

--- a/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
@@ -1,6 +1,6 @@
 package coursepick.coursepick.domain;
 
-import coursepick.coursepick.test_util.IntegrationTest;
+import coursepick.coursepick.test_util.AbstractIntegrationTest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,7 +9,7 @@ import static coursepick.coursepick.test_util.CoordinateTestUtil.square;
 import static coursepick.coursepick.test_util.CoordinateTestUtil.upright;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class CourseRepositoryTest extends IntegrationTest {
+class CourseRepositoryTest extends AbstractIntegrationTest {
 
     @Autowired
     CourseRepository sut;

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteServiceTest.java
@@ -26,7 +26,7 @@ class OsrmWalkingRouteServiceTest extends AbstractMockServerTest {
 
     @Test
     void 응답이_오래걸리면_타임아웃이_발생한다() {
-        mock(ormsResponse(), 3000);
+        mock(ormsResponse(), 6000);
         var sut = new OsrmWalkingRouteService(url());
 
         assertThatThrownBy(() -> sut.route(new Coordinate(0, 0), new Coordinate(0, 0)))

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteServiceTest.java
@@ -5,8 +5,10 @@ import coursepick.coursepick.test_util.SimpleMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class OsrmWalkingRouteServiceTest {
 
@@ -21,6 +23,16 @@ class OsrmWalkingRouteServiceTest {
             );
 
             assertThat(result.size()).isEqualTo(10);
+        }
+    }
+
+    @Test
+    void 응답이_오래걸리면_타임아웃이_발생한다() throws IOException {
+        try (var mockServer = new SimpleMockServer(ormsResponse(), 3000)) {
+            var sut = new OsrmWalkingRouteService(mockServer.url());
+
+            assertThatThrownBy(() -> sut.route(new Coordinate(0, 0), new Coordinate(0, 0)))
+                    .hasRootCauseExactlyInstanceOf(SocketTimeoutException.class);
         }
     }
 

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteServiceTest.java
@@ -1,39 +1,36 @@
 package coursepick.coursepick.infrastructure;
 
 import coursepick.coursepick.domain.Coordinate;
-import coursepick.coursepick.test_util.SimpleMockServer;
+import coursepick.coursepick.test_util.AbstractMockServerTest;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.net.SocketTimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class OsrmWalkingRouteServiceTest {
+class OsrmWalkingRouteServiceTest extends AbstractMockServerTest {
 
     @Test
-    void 두_좌표_사이의_걷기_경로를_조회할_수_있다() throws IOException {
-        try (var mockServer = new SimpleMockServer(ormsResponse())) {
-            var sut = new OsrmWalkingRouteService(mockServer.url());
+    void 두_좌표_사이의_걷기_경로를_조회할_수_있다() {
+        mock(ormsResponse());
+        var sut = new OsrmWalkingRouteService(url());
 
-            var result = sut.route(
-                    new Coordinate(37.5045224, 127.048996),
-                    new Coordinate(37.5113001, 127.0392855)
-            );
+        var result = sut.route(
+                new Coordinate(37.5045224, 127.048996),
+                new Coordinate(37.5113001, 127.0392855)
+        );
 
-            assertThat(result.size()).isEqualTo(10);
-        }
+        assertThat(result.size()).isEqualTo(10);
     }
 
     @Test
-    void 응답이_오래걸리면_타임아웃이_발생한다() throws IOException {
-        try (var mockServer = new SimpleMockServer(ormsResponse(), 3000)) {
-            var sut = new OsrmWalkingRouteService(mockServer.url());
+    void 응답이_오래걸리면_타임아웃이_발생한다() {
+        mock(ormsResponse(), 3000);
+        var sut = new OsrmWalkingRouteService(url());
 
-            assertThatThrownBy(() -> sut.route(new Coordinate(0, 0), new Coordinate(0, 0)))
-                    .hasRootCauseExactlyInstanceOf(SocketTimeoutException.class);
-        }
+        assertThatThrownBy(() -> sut.route(new Coordinate(0, 0), new Coordinate(0, 0)))
+                .hasRootCauseExactlyInstanceOf(SocketTimeoutException.class);
     }
 
     private static String ormsResponse() {

--- a/backend/src/test/java/coursepick/coursepick/test_util/AbstractIntegrationTest.java
+++ b/backend/src/test/java/coursepick/coursepick/test_util/AbstractIntegrationTest.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @Import({GpxTestUtil.class, DatabaseTestUtil.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-public abstract class IntegrationTest {
+public abstract class AbstractIntegrationTest {
 
     @Autowired
     protected DatabaseTestUtil dbUtil;

--- a/backend/src/test/java/coursepick/coursepick/test_util/AbstractMockServerTest.java
+++ b/backend/src/test/java/coursepick/coursepick/test_util/AbstractMockServerTest.java
@@ -1,0 +1,42 @@
+package coursepick.coursepick.test_util;
+
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractMockServerTest {
+
+    MockWebServer mockWebServer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockWebServer.close();
+    }
+
+    protected void mock(String responseBody) {
+        mock(responseBody, 0);
+    }
+
+    protected void mock(String responseBody, long delayMillis) {
+        MockResponse mockResponse = new MockResponse.Builder()
+                .body(responseBody)
+                .bodyDelay(delayMillis, TimeUnit.MILLISECONDS)
+                .addHeader("Content-Type", "application/json")
+                .build();
+        mockWebServer.enqueue(mockResponse);
+    }
+
+    protected String url() {
+        return mockWebServer.url("").toString();
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/test_util/SimpleMockServer.java
+++ b/backend/src/test/java/coursepick/coursepick/test_util/SimpleMockServer.java
@@ -4,16 +4,22 @@ import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 public class SimpleMockServer implements AutoCloseable {
 
     MockWebServer server;
 
     public SimpleMockServer(String responseBody) throws IOException {
+        this(responseBody, 0);
+    }
+
+    public SimpleMockServer(String responseBody, long delayMillis) throws IOException {
         server = new MockWebServer();
         server.start();
         MockResponse mockResponse = new MockResponse.Builder()
                 .body(responseBody)
+                .bodyDelay(delayMillis, TimeUnit.MILLISECONDS)
                 .addHeader("Content-Type", "application/json")
                 .build();
         server.enqueue(mockResponse);


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 기존에는 타임아웃이 설정되지 않았기 때문에, 문제 발생시 무한 블로킹에 걸릴 수 있었습니다.
- `SimpleClientHttpRequestFactory`를 통한 타임아웃 설정으로 해당 문제를 해결하였습니다.
  - connect 타임아웃을 1초로 설정하였습니다.
  - read 타임아웃을 5초로 설정하였습니다.
  - 타임아웃에 대한 테스트를 추가했습니다.

## 🔗 관련 이슈
- closes #418 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 도보 경로 조회에 연결(1초)·응답(5초) 타임아웃을 적용해 지연·무응답 상황에서 빠르게 실패 처리되며 앱 응답성이 향상되었습니다.
- 테스트
  - 통합 테스트 기반을 통합·정비하고 모의 서버 유틸을 도입해 네트워크 동작을 모킹하도록 변경했습니다.
  - 타임아웃 발생 시 예외 동작을 검증하는 테스트를 추가했습니다.
- 리팩터링
  - 테스트 공통 기반의 명칭과 구조를 정리해 유지보수성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->