### PR TITLE
[HOTFIX] osrm 라우팅 버그 해결

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteService.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/OsrmWalkingRouteService.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.springframework.http.HttpHeaders.ACCEPT_ENCODING;
-
 @Slf4j
 @Component
 @Profile({"dev", "prod"})
@@ -40,7 +38,6 @@ public class OsrmWalkingRouteService implements WalkingRouteService {
                             .queryParam("generate_hints", "false")
                             .build(origin.longitude(), origin.latitude(), destination.longitude(), destination.latitude())
                     )
-                    .header(ACCEPT_ENCODING, "gzip")
                     .retrieve()
                     .body(new ParameterizedTypeReference<>() {
                     });


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- RestClient는 기본적으로 gzip 인코딩을 자체 사용하는데, 제가 추가적으로 설정하면서 그 설정값이 꼬인 것 같습니다.
- gzip 인코딩 수동 설정 부분을 아예 제거했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 코스까지의 도보 경로 조회 API 추가(시작 위도/경도 → 코스 경로 좌표 반환).
  - 즐겨찾는 코스 조회 API 추가(코스 ID 목록으로 상세 정보 반환).
  - 응답 압축 활성화로 API 응답 속도 개선.
  - 신규 엔드포인트 접근 허용 범위 확대.

- 문서
  - OpenAPI에 신규 엔드포인트와 예시(문자열 ID 등) 추가/개선.

- 작업
  - OSRM URL 환경변수/설정 추가 및 개발·운영 Compose에 반영.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->