### PR TITLE
JVM 메모리 관련 매트릭 설정 추가

### DIFF
--- a/backend/src/main/resources/monitoring-config.yml
+++ b/backend/src/main/resources/monitoring-config.yml
@@ -16,7 +16,7 @@ management:
       http.server.requests: true
       system.cpu.usage: true
       spring.data.repository.invocations: true
-      jvm.memory.used: true
+      jvm.memory: true
       tomcat.threads: true
       mongodb.driver:
         commands: true


### PR DESCRIPTION
## 📋 변경 사항 요약
JVM 메모리 관련 매트릭 설정 추가

## 🛠️ 주요 변경 사항
- 기존 jvm.memory.used 매트릭만으로 메모리 사용 현황을 파악하기 어려웠습니다. 
- jvm.memory.max, jvm.memory.committed, jvm.memory.usage.after.gc 항목을 추가해봤습니다.

## 🔍 리뷰 요청사항
<!-- 리뷰어에게 특별히 확인을 요청하고 싶은 부분이 있다면 작성해주세요 -->

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #448 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 작업(Chores)
  * 모니터링 설정을 업데이트하여 JVM 메모리 지표를 jvm.memory.used에서 jvm.memory로 전환했습니다. 더 포괄적인 JVM 메모리 지표가 활성화되며, 대시보드/알림에서 해당 지표명을 사용하는 경우 이름 변경에 유의하세요. 애플리케이션 동작에는 영향이 없지만, 모니터링 쿼리와 패널은 필요 시 지표명을 업데이트해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->