### PR TITLE
주변 코스 조회 API에 페이징 적용

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -7,6 +7,9 @@ import coursepick.coursepick.domain.CourseRepository;
 import coursepick.coursepick.domain.Meter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,15 +22,18 @@ import static coursepick.coursepick.application.exception.ErrorType.NOT_EXIST_CO
 @RequiredArgsConstructor
 public class CourseApplicationService {
 
+    private static final PageRequest DEFAULT_PAGE_REQUEST = PageRequest.of(0, 10);
+
     private final CourseRepository courseRepository;
     private final WalkingRouteService walkingRouteService;
 
     @Transactional(readOnly = true)
-    public List<CourseResponse> findNearbyCourses(double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude, int scope) {
+    public List<CourseResponse> findNearbyCourses(double mapLatitude, double mapLongitude, Double userLatitude, Double userLongitude, int scope, Integer page) {
         final Coordinate mapPosition = new Coordinate(mapLatitude, mapLongitude);
-        Meter meter = new Meter(scope).clamp(1000, 3000);
+        final Meter meter = new Meter(scope).clamp(1000, 3000);
+        Pageable pageable = page == null ? DEFAULT_PAGE_REQUEST : PageRequest.of(page, 10);
 
-        List<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, meter);
+        Page<Course> coursesWithinScope = courseRepository.findAllHasDistanceWithin(mapPosition, meter, pageable);
 
         if (userLatitude == null || userLongitude == null) {
             return coursesWithinScope

--- a/backend/src/main/java/coursepick/coursepick/domain/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/Course.java
@@ -13,7 +13,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.util.List;
 
 @Document
-@AllArgsConstructor(access = AccessLevel.PROTECTED, onConstructor_ = @PersistenceCreator)
+@AllArgsConstructor(access = AccessLevel.PUBLIC, onConstructor_ = @PersistenceCreator)
 @Getter
 @Accessors(fluent = true)
 public class Course {

--- a/backend/src/main/java/coursepick/coursepick/domain/CourseRepository.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/CourseRepository.java
@@ -1,13 +1,18 @@
 package coursepick.coursepick.domain;
 
-import com.mongodb.client.model.geojson.Point;
-import com.mongodb.client.model.geojson.Position;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
 import java.util.List;
 
 public interface CourseRepository extends MongoRepository<Course, String> {
+
+    default Page<Course> findAllHasDistanceWithin(Coordinate target, Meter distance, Pageable pageable) {
+        return findAllHasDistanceWithin(new GeoJsonPoint(target.longitude(), target.latitude()), distance.value(), pageable);
+    }
 
     @Query("""
             {
@@ -19,13 +24,9 @@ public interface CourseRepository extends MongoRepository<Course, String> {
               }
             }
             """)
-    List<Course> findAllHasDistanceWithin(Point target, double radius);
-
-    default List<Course> findAllHasDistanceWithin(Coordinate target, Meter distance) {
-        return findAllHasDistanceWithin(new Point(new Position(target.longitude(), target.latitude())), distance.value());
-    }
+    Page<Course> findAllHasDistanceWithin(GeoJsonPoint target, double radius, Pageable pageable);
 
     List<Course> findByIdIn(List<String> ids);
 
-    boolean existsByName(CourseName courseName);
+    boolean existsByName(CourseName name);
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseConverter.java
@@ -1,0 +1,51 @@
+package coursepick.coursepick.infrastructure.converter;
+
+import coursepick.coursepick.domain.Course;
+import coursepick.coursepick.domain.Difficulty;
+import coursepick.coursepick.domain.InclineSummary;
+import coursepick.coursepick.domain.RoadType;
+import org.bson.Document;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+
+public class CourseConverter {
+
+    private static final SegmentListConverter.Reader SEGMENTS_READER = new SegmentListConverter.Reader();
+    private static final SegmentListConverter.Writer SEGMENTS_WRITER = new SegmentListConverter.Writer();
+    private static final CourseNameConverter.Reader COURSENAME_READER = new CourseNameConverter.Reader();
+    private static final CourseNameConverter.Writer COURSENAME_WRITER = new CourseNameConverter.Writer();
+    private static final MeterConverter.Reader METER_READER = new MeterConverter.Reader();
+    private static final MeterConverter.Writer METER_WRITER = new MeterConverter.Writer();
+
+    @WritingConverter
+    public static class Writer implements Converter<Course, Document> {
+        @Override
+        public Document convert(Course source) {
+            Document document = new Document();
+            document.put("name", COURSENAME_WRITER.convert(source.name()));
+            document.put("road_type", source.roadType().name());
+            document.put("incline_summary", source.inclineSummary().name());
+            document.put("segments", SEGMENTS_WRITER.convert(source.segments()));
+            document.put("length", METER_WRITER.convert(source.length()));
+            document.put("difficulty", source.difficulty().name());
+            return document;
+        }
+    }
+
+    @ReadingConverter
+    public static class Reader implements Converter<Document, Course> {
+        @Override
+        public Course convert(Document source) {
+            return new Course(
+                    source.getObjectId("_id").toHexString(),
+                    COURSENAME_READER.convert(source.getString("name")),
+                    RoadType.valueOf(source.getString("road_type")),
+                    InclineSummary.valueOf(source.getString("incline_summary")),
+                    SEGMENTS_READER.convert(source.get("segments", Document.class)),
+                    METER_READER.convert(source.getDouble("length")),
+                    Difficulty.valueOf(source.getString("difficulty"))
+            );
+        }
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseConverter.java
@@ -9,7 +9,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
-public class CourseConverter {
+public abstract class CourseConverter {
 
     private static final SegmentListConverter.Reader SEGMENTS_READER = new SegmentListConverter.Reader();
     private static final SegmentListConverter.Writer SEGMENTS_WRITER = new SegmentListConverter.Writer();

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseNameConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseNameConverter.java
@@ -5,7 +5,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
-public class CourseNameConverter {
+public abstract class CourseNameConverter {
 
     @WritingConverter
     public static class Writer implements Converter<CourseName, String> {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/MeterConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/MeterConverter.java
@@ -5,7 +5,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
-public class MeterConverter {
+public abstract class MeterConverter {
 
     @WritingConverter
     public static class Writer implements Converter<Meter, Double> {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/MongoConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/MongoConfig.java
@@ -12,8 +12,8 @@ public class MongoConfig {
     @Bean
     public MongoCustomConversions mongoCustomConversions() {
         return new MongoCustomConversions(List.of(
-                new SegmentListConverter.Reader(),
-                new SegmentListConverter.Writer(),
+                new CourseConverter.Reader(),
+                new CourseConverter.Writer(),
                 new CourseNameConverter.Reader(),
                 new CourseNameConverter.Writer(),
                 new MeterConverter.Reader(),

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/SegmentListConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/SegmentListConverter.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Slf4j
-public class SegmentListConverter {
+public abstract class SegmentListConverter {
 
     @WritingConverter
     public static class Writer implements Converter<List<Segment>, Document> {

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseWebController.java
@@ -40,9 +40,10 @@ public class CourseWebController implements CourseWebApi {
             @RequestParam("mapLng") double mapLongitude,
             @RequestParam(value = "userLat", required = false) Double userLatitude,
             @RequestParam(value = "userLng", required = false) Double userLongitude,
-            @RequestParam("scope") int scope
+            @RequestParam("scope") int scope,
+            @RequestParam(value = "page", required = false) Integer page
     ) {
-        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude, scope);
+        List<CourseResponse> responses = courseApplicationService.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude, scope, page);
         return CourseWebResponse.from(responses);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -38,7 +38,8 @@ public interface CourseWebApi {
             @Parameter(example = "127.1040109", required = true) double mapLongitude,
             @Parameter(example = "38.5165004") Double userLatitude,
             @Parameter(example = "126.1040109") Double userLongitude,
-            @Parameter(example = "1000", required = true) int scope
+            @Parameter(example = "1000", required = true) int scope,
+            @Parameter(example = "1") Integer page
     );
 
     @Operation(summary = "좌표에서 가장 가까운 코스 위 좌표 조회")
@@ -92,7 +93,7 @@ public interface CourseWebApi {
             @Parameter(example = "37.5165004", required = true) double latitude,
             @Parameter(example = "127.1040109", required = true) double longitude
     );
-    
+
     @Operation(summary = "즐겨찾기 코스 조회")
     @ApiResponse(responseCode = "200")
     List<CourseWebResponse> findFavoriteCourses(

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -48,7 +48,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         var latitude = 37.5122;
         var longitude = 127.0276;
 
-        var nearbyCourses = sut.findNearbyCourses(latitude, longitude, null, null, 300);
+        var nearbyCourses = sut.findNearbyCourses(latitude, longitude, null, null, 300, null);
 
         assertThat(nearbyCourses).hasSize(2)
                 .extracting(CourseResponse::name)
@@ -78,7 +78,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         var latitude = 37.5122;
         var longitude = 127.0276;
 
-        var nearbyCourses = sut.findNearbyCourses(latitude, longitude, null, null, 15000);
+        var nearbyCourses = sut.findNearbyCourses(latitude, longitude, null, null, 15000, null);
 
         assertThat(nearbyCourses).hasSize(1)
                 .extracting(CourseResponse::name)
@@ -113,7 +113,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         var latitude = 37.5172;
         var longitude = 127.0276;
 
-        var courses = sut.findNearbyCourses(latitude, longitude, null, null, 1000);
+        var courses = sut.findNearbyCourses(latitude, longitude, null, null, 1000, null);
 
         assertThat(courses).hasSize(2)
                 .extracting(CourseResponse::name)
@@ -151,7 +151,7 @@ class CourseApplicationServiceTest extends IntegrationTest {
         var userLatitude = 37.5153291;
         var userLongitude = 127.1031347;
 
-        var courses = sut.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude, 1000);
+        var courses = sut.findNearbyCourses(mapLatitude, mapLongitude, userLatitude, userLongitude, 1000, null);
 
         assertThat(course1.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);
         assertThat(course2.distanceFrom(new Coordinate(mapLatitude, mapLongitude)).value()).isLessThan(1000.0);

--- a/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
@@ -1,6 +1,7 @@
 package coursepick.coursepick.domain;
 
 import coursepick.coursepick.test_util.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -16,6 +17,20 @@ class CourseRepositoryTest extends IntegrationTest {
     @Autowired
     CourseRepository sut;
 
+    final Coordinate target = new Coordinate(37.514647, 127.086592);
+
+    @BeforeEach
+    void setUp() {
+        var course1 = new Course("코스1", square(upright(target, 300), 1000, 1000));
+        var course2 = new Course("코스2", square(upright(target, 500), 1000, 1000));
+        var course3 = new Course("코스3", square(upright(target, 700), 1000, 1000));
+        var course4 = new Course("코스4", square(upright(target, 900), 1000, 1000));
+        dbUtil.saveCourse(course1);
+        dbUtil.saveCourse(course2);
+        dbUtil.saveCourse(course3);
+        dbUtil.saveCourse(course4);
+    }
+
     @ParameterizedTest
     @CsvSource({
             "1300, 4",
@@ -24,17 +39,6 @@ class CourseRepositoryTest extends IntegrationTest {
             "700, 1"
     })
     void 거리를_줄여가면서_검색되는_코스_수가_줄어든다(int distance, int expectedSize) {
-        var target = new Coordinate(37.514647, 127.086592);
-
-        var course1 = new Course("코스1", square(upright(target, 300), 1000, 1000));
-        var course2 = new Course("코스2", square(upright(target, 500), 1000, 1000));
-        var course3 = new Course("코스3", square(upright(target, 700), 1000, 1000));
-        var course4 = new Course("코스4", square(upright(target, 900), 1000, 1000));
-        dbUtil.saveCourse(course1);
-        dbUtil.saveCourse(course2);
-        dbUtil.saveCourse(course3);
-        dbUtil.saveCourse(course4);
-
         var courses = sut.findAllHasDistanceWithin(target, new Meter(distance), PageRequest.of(0, 100));
 
         assertThat(courses).hasSize(expectedSize);
@@ -42,17 +46,6 @@ class CourseRepositoryTest extends IntegrationTest {
 
     @Test
     void 검색하는_코스를_페이징한다() {
-        var target = new Coordinate(37.514647, 127.086592);
-
-        var course1 = new Course("코스1", square(upright(target, 300), 1000, 1000));
-        var course2 = new Course("코스2", square(upright(target, 500), 1000, 1000));
-        var course3 = new Course("코스3", square(upright(target, 700), 1000, 1000));
-        var course4 = new Course("코스4", square(upright(target, 900), 1000, 1000));
-        dbUtil.saveCourse(course1);
-        dbUtil.saveCourse(course2);
-        dbUtil.saveCourse(course3);
-        dbUtil.saveCourse(course4);
-
         var courses = sut.findAllHasDistanceWithin(target, new Meter(1500), PageRequest.of(1, 2));
 
         assertThat(courses).hasSize(2);
@@ -60,17 +53,6 @@ class CourseRepositoryTest extends IntegrationTest {
 
     @Test
     void PageRequest가_널이면_페이징하지_않는다() {
-        var target = new Coordinate(37.514647, 127.086592);
-
-        var course1 = new Course("코스1", square(upright(target, 300), 1000, 1000));
-        var course2 = new Course("코스2", square(upright(target, 500), 1000, 1000));
-        var course3 = new Course("코스3", square(upright(target, 700), 1000, 1000));
-        var course4 = new Course("코스4", square(upright(target, 900), 1000, 1000));
-        dbUtil.saveCourse(course1);
-        dbUtil.saveCourse(course2);
-        dbUtil.saveCourse(course3);
-        dbUtil.saveCourse(course4);
-
         var courses = sut.findAllHasDistanceWithin(target, new Meter(1500), null);
 
         assertThat(courses).hasSize(4);

--- a/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/CourseRepositoryTest.java
@@ -1,9 +1,11 @@
 package coursepick.coursepick.domain;
 
 import coursepick.coursepick.test_util.IntegrationTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import static coursepick.coursepick.test_util.CoordinateTestUtil.square;
 import static coursepick.coursepick.test_util.CoordinateTestUtil.upright;
@@ -33,8 +35,44 @@ class CourseRepositoryTest extends IntegrationTest {
         dbUtil.saveCourse(course3);
         dbUtil.saveCourse(course4);
 
-        var courses = sut.findAllHasDistanceWithin(target, new Meter(distance));
+        var courses = sut.findAllHasDistanceWithin(target, new Meter(distance), PageRequest.of(0, 100));
 
         assertThat(courses).hasSize(expectedSize);
+    }
+
+    @Test
+    void 검색하는_코스를_페이징한다() {
+        var target = new Coordinate(37.514647, 127.086592);
+
+        var course1 = new Course("코스1", square(upright(target, 300), 1000, 1000));
+        var course2 = new Course("코스2", square(upright(target, 500), 1000, 1000));
+        var course3 = new Course("코스3", square(upright(target, 700), 1000, 1000));
+        var course4 = new Course("코스4", square(upright(target, 900), 1000, 1000));
+        dbUtil.saveCourse(course1);
+        dbUtil.saveCourse(course2);
+        dbUtil.saveCourse(course3);
+        dbUtil.saveCourse(course4);
+
+        var courses = sut.findAllHasDistanceWithin(target, new Meter(1500), PageRequest.of(1, 2));
+
+        assertThat(courses).hasSize(2);
+    }
+
+    @Test
+    void PageRequest가_널이면_페이징하지_않는다() {
+        var target = new Coordinate(37.514647, 127.086592);
+
+        var course1 = new Course("코스1", square(upright(target, 300), 1000, 1000));
+        var course2 = new Course("코스2", square(upright(target, 500), 1000, 1000));
+        var course3 = new Course("코스3", square(upright(target, 700), 1000, 1000));
+        var course4 = new Course("코스4", square(upright(target, 900), 1000, 1000));
+        dbUtil.saveCourse(course1);
+        dbUtil.saveCourse(course2);
+        dbUtil.saveCourse(course3);
+        dbUtil.saveCourse(course4);
+
+        var courses = sut.findAllHasDistanceWithin(target, new Meter(1500), null);
+
+        assertThat(courses).hasSize(4);
     }
 }


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- `CourseRepository#findAllHasDistanceWithin` 메서드 파라미터에 Pageable을 추가하여 페이징 기능을 적용했습니다.
- 서비스, 컨트롤러 코드도 수정하여 API로 페이지 번호를 넘길 수 있도록 하였습니다.
- `Pageable` 을 추가하니, `Course`를 또 mongodb에 재대로 매핑하지 못하는 상황이 발생하여 `CourseConverter`를 구현하였습니다.
  - 기존의 `Converter`들을 사용하는 형태로 구현하여, 추후의 변경에 유연할 수 있도록 유지했습니다.
  - 추후에 SchemaVersion 등이 도입되어도, 해당 Converter를 그대로 사용할 수 있다는 것도 장점입니다.

## 🔗 관련 이슈
- closes #451 
