### PR TITLE
선택된 코스를 선택되지 않은 코스보다 강조

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/RouteLineOptionsFactory.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/RouteLineOptionsFactory.kt
@@ -2,6 +2,7 @@ package io.coursepick.coursepick.presentation.map.kakao
 
 import android.content.Context
 import androidx.annotation.ColorRes
+import androidx.annotation.DimenRes
 import com.kakao.vectormap.LatLng
 import com.kakao.vectormap.route.RouteLineOptions
 import com.kakao.vectormap.route.RouteLinePattern
@@ -17,16 +18,21 @@ import io.coursepick.coursepick.presentation.course.CourseItem
 class RouteLineOptionsFactory(
     private val context: Context,
 ) {
-    private val lineWidth: Float = context.resources.getDimension(R.dimen.course_route_width)
     private val patternDistance: Float =
         context.resources.getDimension(R.dimen.course_pattern_between_distance)
 
-    private val uphillStyle = RouteLineStyles((R.color.course_uphill), true)
-    private val flatStyle = RouteLineStyles((R.color.course_flat), true)
-    private val downhillStyle = RouteLineStyles((R.color.course_downhill), true)
-    private val unknownStyle = RouteLineStyles((R.color.course_unknown), true)
-    private val unselectedStyle = RouteLineStyles(R.color.course_unselected, false)
-    private val routeStyle = RouteLineStyles(R.color.course_route, false)
+    private val uphillStyle =
+        RouteLineStyles(R.color.course_uphill, R.dimen.selected_course_width, true)
+    private val flatStyle =
+        RouteLineStyles(R.color.course_flat, R.dimen.selected_course_width, true)
+    private val downhillStyle =
+        RouteLineStyles(R.color.course_downhill, R.dimen.selected_course_width, true)
+    private val unknownStyle =
+        RouteLineStyles(R.color.course_unknown, R.dimen.selected_course_width, true)
+    private val unselectedStyle =
+        RouteLineStyles(R.color.course_unselected, R.dimen.unselected_course_width, false)
+    private val routeStyle =
+        RouteLineStyles(R.color.course_route, R.dimen.course_route_width, false)
 
     fun routeLineOptions(route: List<Coordinate>): RouteLineOptions =
         RouteLineOptions.from(
@@ -49,11 +55,12 @@ class RouteLineOptionsFactory(
 
     private fun RouteLineStyles(
         @ColorRes colorRes: Int,
+        @DimenRes dimenRes: Int,
         withPattern: Boolean,
     ): RouteLineStyles {
         val baseStyle =
             RouteLineStyle
-                .from(lineWidth, context.getColor(colorRes))
+                .from(context.resources.getDimension(dimenRes), context.getColor(colorRes))
                 .apply {
                     if (withPattern) {
                         setPattern(RouteLinePattern.from(R.drawable.image_arrow, patternDistance))

--- a/android/app/src/main/res/values/dimens.xml
+++ b/android/app/src/main/res/values/dimens.xml
@@ -4,6 +4,8 @@
     <dimen name="main_bottom_sheet_expanded_offset">80dp</dimen>
     <dimen name="map_logo_position_offset">10dp</dimen>
     <dimen name="course_route_padding">80dp</dimen>
+    <dimen name="selected_course_width">4dp</dimen>
+    <dimen name="unselected_course_width">3dp</dimen>
     <dimen name="course_route_width">4dp</dimen>
     <dimen name="course_pattern_between_distance">12dp</dimen>
 </resources>


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
선택된 코스가 선택되지 않은 코스보다 더 강조되도록 UI가 변경됩니다.

## 🛠️ 주요 변경 사항
<!-- 구체적인 변경 내용을 나열해주세요 -->
- 선택되지 않은 코스의 굵기가 얇아집니다(`4dp` →`3dp`).

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경사항이 있다면 변경 전후 스크린샷을 첨부해주세요 -->
|As-is|To-be|
|-|-|
|<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/f668f8fb-efe7-4b81-8820-3abf4bdb8fb2" />|<img width="1080" height="2424" alt="image" src="https://github.com/user-attachments/assets/d3012bc3-7a35-46fd-b436-89d3d248fdff" />|


## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #470 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 지도 경로 라인의 두께가 화면 밀도에 맞는 리소스 기반으로 적용되어 일관성이 향상되었습니다.
  - 선택/비선택 코스의 선 굵기를 구분해 가시성을 개선했습니다(선택 약 4dp, 비선택 약 3dp).
  - 오르막·내리막·평지·미확인 구간 및 전체 경로 스타일에 동일한 규칙이 반영되어 화면 전반의 시각적 통일성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->