### PR TITLE
GCP에 타임아웃 설정, 예외 처리 리팩터링

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/batch/CourseFileFetcher.java
+++ b/backend/src/main/java/coursepick/coursepick/batch/CourseFileFetcher.java
@@ -2,6 +2,7 @@ package coursepick.coursepick.batch;
 
 import coursepick.coursepick.application.dto.CourseFile;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface CourseFileFetcher {
@@ -9,5 +10,5 @@ public interface CourseFileFetcher {
     /**
      * @return 다음 페이지의 코스 파일들, 다음 페이지가 없다면 빈 리스트를 응답한다.
      */
-    List<CourseFile> fetchNextPage();
+    List<CourseFile> fetchNextPage() throws IOException;
 }

--- a/backend/src/main/java/coursepick/coursepick/batch/CourseSyncJobConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/batch/CourseSyncJobConfig.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 @Configuration
 public class CourseSyncJobConfig {
@@ -48,6 +49,7 @@ public class CourseSyncJobConfig {
                 .retry(OptimisticLockingFailureException.class)
                 .retry(PessimisticLockingFailureException.class)
                 .retry(IOException.class)
+                .retry(UncheckedIOException.class)
                 .skipLimit(15)
                 .skip(ParseException.class)
                 .skip(XMLStreamException.class)

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/GoogleDriveCourseFileFetcher.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/GoogleDriveCourseFileFetcher.java
@@ -114,11 +114,20 @@ public class GoogleDriveCourseFileFetcher implements CourseFileFetcher {
                     .createScoped(Collections.singleton(DriveScopes.DRIVE_READONLY));
 
             NetHttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-            return new Drive.Builder(httpTransport, JSON_FACTORY, new HttpCredentialsAdapter(credentials))
+            return new Drive.Builder(httpTransport, JSON_FACTORY, setHttpTimeout(new HttpCredentialsAdapter(credentials)))
                     .setApplicationName(APPLICATION_NAME)
                     .build();
         } catch (GeneralSecurityException | IOException e) {
             throw new IllegalStateException("구글 드라이브 서비스 초기화에 실패했습니다.", e);
         }
+    }
+
+    @SuppressWarnings("PointlessArithmeticExpression")
+    private static HttpRequestInitializer setHttpTimeout(final HttpRequestInitializer requestInitializer) {
+        return httpRequest -> {
+            requestInitializer.initialize(httpRequest);
+            httpRequest.setConnectTimeout(3 * 60 * 1000);
+            httpRequest.setReadTimeout(1 * 60 * 1000);
+        };
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/GoogleDriveCourseFileFetcher.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/GoogleDriveCourseFileFetcher.java
@@ -1,6 +1,7 @@
 package coursepick.coursepick.infrastructure;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;

--- a/backend/src/test/java/coursepick/coursepick/application/CourseSyncServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseSyncServiceTest.java
@@ -7,6 +7,7 @@ import coursepick.coursepick.test_util.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 
@@ -21,7 +22,7 @@ class CourseSyncServiceTest extends AbstractIntegrationTest {
     CourseSyncService sut;
 
     @Test
-    void 코스의_싱크를_맞춘다() {
+    void 코스의_싱크를_맞춘다() throws IOException {
         var gpxInputStream1 = createGpxInputStreamOf(new Coordinate(1, 1, 1), new Coordinate(2, 2, 2), new Coordinate(3, 3, 3));
         var gpxInputStream2 = createGpxInputStreamOf(new Coordinate(1, 1, 1), new Coordinate(2, 2, 2), new Coordinate(3, 3, 3), new Coordinate(1, 1, 1));
         when(courseFileFetcher.fetchNextPage())


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 파일 읽는 작업의 타임아웃을 설정하였습니다.
- 배치잡이다보니 여유롭게 설정하여, 예외가 터지는 경우를 제외하면 통과할 수 있도록 하였습니다.
  - 연결 타임아웃 3분
  - 읽기 타임아웃 1분
- `CourseFileFetcher`가 IOException을 그대로 던지도록 설계하여 batch 잡 수준에서 재시도할 수 있도록 설계하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 네트워크 타임아웃을 설정해 느린 연결에서도 코스 파일 가져오기가 더 안정적으로 동작합니다.
- 버그 수정
  - 일시적인 I/O/네트워크 오류 발생 시 코스 동기화 작업이 자동으로 재시도되어 실패 확률이 낮아졌습니다.
  - 파일 다운로드 중 발생하는 예외 처리를 개선해 드물게 발생하던 동기화 중단 이슈를 완화했습니다.
- 테스트
  - I/O 상황을 반영하도록 테스트를 보강해 실제 환경과의 일치도를 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->