### PR TITLE
프래그먼트 교체 및 인스턴스 생성 관련 오류 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -131,6 +131,8 @@ class CoursesActivity :
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     override fun onCreate(savedInstanceState: Bundle?) {
+        setUpFragmentFactory()
+
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(binding.root)
@@ -362,27 +364,6 @@ class CoursesActivity :
                 CoursesContent.FAVORITES -> getString(R.string.main_empty_favorites_description)
             }
 
-        supportFragmentManager.fragmentFactory =
-            object : FragmentFactory() {
-                override fun instantiate(
-                    classLoader: ClassLoader,
-                    className: String,
-                ): Fragment =
-                    when (className) {
-                        ExploreCoursesFragment::class.java.name -> {
-                            ExploreCoursesFragment(courseItemListener)
-                        }
-
-                        FavoriteCoursesFragment::class.java.name -> {
-                            FavoriteCoursesFragment(courseItemListener)
-                        }
-
-                        else -> {
-                            super.instantiate(classLoader, className)
-                        }
-                    }
-            }
-
         supportFragmentManager.commit {
             setReorderingAllowed(true)
             supportFragmentManager.fragments.forEach { fragment: Fragment ->
@@ -560,6 +541,29 @@ class CoursesActivity :
                 )
             }
         }
+    }
+
+    private fun setUpFragmentFactory() {
+        supportFragmentManager.fragmentFactory =
+            object : FragmentFactory() {
+                override fun instantiate(
+                    classLoader: ClassLoader,
+                    className: String,
+                ): Fragment =
+                    when (className) {
+                        ExploreCoursesFragment::class.java.name -> {
+                            ExploreCoursesFragment(courseItemListener)
+                        }
+
+                        FavoriteCoursesFragment::class.java.name -> {
+                            FavoriteCoursesFragment(courseItemListener)
+                        }
+
+                        else -> {
+                            super.instantiate(classLoader, className)
+                        }
+                    }
+            }
     }
 
     private fun setUpNavigation(systemBars: Insets) {


### PR DESCRIPTION
<!--
## 🧪 테스트 완료 사항
- [ ] 로컬 환경에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 코드 리뷰 요청사항 반영

## 📋 체크리스트
- [ ] 코드가 프로젝트 스타일 가이드를 준수합니다
- [ ] 자체 코드 리뷰를 완료했습니다
- [ ] 변경사항에 대한 테스트를 추가했습니다
- [ ] 새로운 테스트와 기존 테스트가 모두 통과합니다
- [ ] 문서를 업데이트했습니다 (필요한 경우)
- [ ] 종속성 변경사항이 문서화되었습니다
-->
## 📋 변경 사항 요약
<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
### 메인 화면의 프래그먼트가 정상적으로 교체되지 않는 버그가 수정됩니다.

프래그먼트 추가/조회 시 태그로 `프래그먼트의 클래스명`을 사용해야 하는데, `프래그먼트의 클래스의 클래스명`을 사용하고 있어 항상 `"java.lang.Class"` 태그로 추가/조회되고 있었습니다.

이로 인해 메뉴를 바꿀 때마다 다른 프래그먼트가 보여야 하지만, 항상 같은 프래그먼트가 보이고 있었던 버그가 수정됩니다.

### Configuration change 발생 시 앱이 종료되는 버그가 수정됩니다.

프래그먼트가 생성자를 통해 리스너를 주입받을 수 있도록 액티비티의 `supportFragmentManager`에 커스텀 `fragmentFactory`를 설정해주고 있었으나, 액티비티의 `super.onCreate()` 호출보다 늦게 설정했기 때문에 여전히 configuration change가 발생하면 프래그먼트의 no-arg constructor를 찾을 수 없다는 오류와 함께 앱이 종료되고 있었습니다.

액티비티의 `super.onCreate()`보다 먼저 fragmentFactory를 설정하도록 수정했습니다.

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #488 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 프래그먼트 생성 로직을 중앙화하여 초기화 시 공통 팩토리를 설정했습니다.
  - 코스 선택·즐겨찾기 전환·상세 이동을 단일 리스너로 처리하도록 어댑터와 화면 전환 흐름을 정리했습니다.
  - 프래그먼트 태그 사용을 일관되게 수정하고, 탐색/즐겨찾기 화면 생성 경로를 통일했습니다.
  - 사용자 영향: 화면 전환과 즐겨찾기 동작의 일관성·안정성이 향상되고, 탐색에서 상세 이동 흐름이 더 매끄러워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->