### PR TITLE
[HOTFIX] 변환시 파라미터 이름을 카멜케이스로 변경

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/converter/CourseConverter.java
@@ -27,8 +27,8 @@ public abstract class CourseConverter {
                 document.put("_id", new ObjectId(source.id()));
             }
             document.put("name", source.name().value());
-            document.put("road_type", source.roadType().name());
-            document.put("incline_summary", source.inclineSummary().name());
+            document.put("roadType", source.roadType().name());
+            document.put("inclineSummary", source.inclineSummary().name());
             document.put("segments", SEGMENTS_WRITER.convert(source.segments()));
             document.put("length", source.length().value());
             document.put("difficulty", source.difficulty().name());
@@ -43,8 +43,8 @@ public abstract class CourseConverter {
             return new Course(
                     source.getObjectId("_id").toHexString(),
                     new CourseName(source.getString("name")),
-                    RoadType.valueOf(source.getString("road_type")),
-                    InclineSummary.valueOf(source.getString("incline_summary")),
+                    RoadType.valueOf(source.getString("roadType")),
+                    InclineSummary.valueOf(source.getString("inclineSummary")),
                     SEGMENTS_READER.convert(source.get("segments", Document.class)),
                     new Meter(source.getDouble("length")),
                     Difficulty.valueOf(source.getString("difficulty"))


### PR DESCRIPTION
## 📋 변경 사항 요약

실제 db는 카멜케이스인데, 변환을 스네이크케이스로 해서 변환 오류가 발생하고 있었습니다.
<img width="551" height="161" alt="image" src="https://github.com/user-attachments/assets/122cd5d0-2055-4557-a638-904f3d1ec98d" />
<img width="662" height="162" alt="image" src="https://github.com/user-attachments/assets/7dfa04f5-19e2-4d26-a4e1-8c43555daa70" />

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * 직렬화/역직렬화 시 일부 필드명을 스네이크케이스에서 카멜케이스로 정리했습니다(road_type→roadType, incline_summary→inclineSummary).
  * 이 변경은 해당 필드가 노출되는 API 요청/응답에도 반영될 수 있으므로, 클라이언트는 새로운 키에 맞춰 확인이 필요합니다.
  * 그 외 필드와 변환 동작은 동일하며, 기능적 동작이나 예외 처리 흐름에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->