### PR TITLE
액츄에이터 uri는 로그 안남기도록 수정

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
@@ -25,7 +25,9 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
         filterChain.doFilter(requestWrapper, responseWrapper);
         long duration = System.currentTimeMillis() - startTime;
 
-        log.info("[HTTP]", LogContent.http(requestWrapper, responseWrapper, duration));
+        if (!request.getRequestURI().startsWith("/actuator")) {
+            log.info("[HTTP]", LogContent.http(requestWrapper, responseWrapper, duration));
+        }
 
         responseWrapper.copyBodyToResponse();
     }


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 모니터링에 로그를 붙여봤는데, 5초 간격으로 프로메테우스 로그가 계속 찍힙니다.
- 프로메테우스 관련해서는 로그를 안찍는게 도움이 될 것 같아 `HttpLoggingFilter` 수준에서 필터링했습니다.

## 📸 스크린샷
<img width="908" height="240" alt="image" src="https://github.com/user-attachments/assets/163386f8-30fc-4947-be98-4814e66ea1a3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

**버그 수정**
* Actuator 엔드포인트에 대한 HTTP 로깅을 조건부로 처리하여 불필요한 로그 생성을 감소시켰습니다. 요청 처리 및 응답 동작에는 영향을 주지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->