### PR TITLE
find 페이지에서 코스 목록 제대로 출력되지 않는 문제 해결

### DIFF
--- a/backend/src/main/resources/static/admin/find.html
+++ b/backend/src/main/resources/static/admin/find.html
@@ -535,7 +535,7 @@
                     withCredentials: true
                 });
 
-                courses = response.data;
+                courses = response.data.courses || [];
                 currentPage = page;
 
                 try {


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
<img width="487" height="191" alt="스크린샷 2025-12-13 13 09 29" src="https://github.com/user-attachments/assets/7dc9a11a-e003-4ce3-b57d-0e99b86b86da" />

- 기존 어드민 find 페이지에서 코스 목록이 제대로 조회되지 않는 문제를 발견했습니다.
- 해당 문제가 dev 서버에 그대로 있는 상태라서 먼저 fix PR을 제출합니다.
- 이유는 모니터링으로 인해 버전업이 제가 match PR 올리기 전에 이뤄질 거 같아서 ㅎㅎ 
  - 그대로 두면 프로덕션 서버에도 문제가 생길 거 같아 수정이 급해보여서입니다~

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 링크를 첨부해주세요 -->
- closes #600 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 페이지 매김된 강좌 로딩에서 API의 중첩 응답 구조(response.data.courses)를 올바르게 처리하도록 수정했습니다. 중첩된 데이터 형식을 지원하여 강좌 목록 표시와 페이지 매김이 더 안정적으로 동작하고, 잘못된 렌더링/오류 발생 가능성을 줄입니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->