### PR TITLE
자신에게 Discord 알림 가는 문제 해결

### DIFF
--- a/.github/workflows/discord-alert.yml
+++ b/.github/workflows/discord-alert.yml
@@ -45,10 +45,10 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
-            ―――――――――――――――――――――――――
             🙇‍♂️ **리뷰 요청**
             🎯 {{ EVENT_PAYLOAD.sender.login }} → ${{ env.MENTION_TARGET }}
             🔗 [{{ EVENT_PAYLOAD.pull_request.title }}](<{{ EVENT_PAYLOAD.pull_request.html_url }}>)
+            ―――――――――――――――――――――――――
 
       - name: 리뷰 완료 알림
         if: env.SHOULD_NOTIFY == 'true' && github.event_name == 'pull_request_review'
@@ -57,7 +57,7 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
           args: |
-            ―――――――――――――――――――――――――
             ✅ **리뷰 등록**
             🎯 {{ EVENT_PAYLOAD.sender.login }} → ${{ env.MENTION_TARGET }}
             🔗 [{{ EVENT_PAYLOAD.pull_request.title }}](<{{ EVENT_PAYLOAD.review.html_url }}>)
+            ―――――――――――――――――――――――――


### PR DESCRIPTION
## 🛠️ 주요 변경 사항
- 리뷰에 답변을 남길 때, 스스로에게 알림이 가는 현상이 있었습니다.
  action 발신자와 수신자를 확인하여 같은 경우 패스하도록 수정하여 해결했습니다.
- 추가적으로 구분자가 맨 위에 있어서 모바일에서 확인이 어려운 문제가 있었습니다.
  구분자를 아래로 내려서 더 수월하게 확인하도록 하였습니다.

## 📸 스크린샷 (UI 변경 시)
<img width="254" height="82" alt="image" src="https://github.com/user-attachments/assets/1b6530ea-5a4e-4cde-9447-0d0b6f2c6b01" />

## 🔗 관련 이슈
- closes #643 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Discord 알림이 불필요한 경우 전송되지 않도록 개선했습니다.
  * 이벤트 유형(리뷰 요청 또는 풀 요청)에 따라 알림 대상을 정확하게 결정하도록 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->