### PR TITLE
v1 대응하는 경로 화이트 리스트 등록

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/security/PathAllowlistFilter.java
@@ -31,7 +31,13 @@ public class PathAllowlistFilter extends OncePerRequestFilter {
                 Pattern.compile("^/images/verified_location.png$"),
                 Pattern.compile("^/actuator.*$"),
                 Pattern.compile("^/api-docs.html$"),
-                Pattern.compile("^/v3/api-docs.*$")
+                Pattern.compile("^/v3/api-docs.*$"),
+                Pattern.compile("^/v1/login/kakao$"),
+                Pattern.compile("^/v1/courses$"),
+                Pattern.compile("^/v1/courses/[^/]+/route$"),
+                Pattern.compile("^/v1/courses/[^/]+/closest-coordinate$"),
+                Pattern.compile("^/v1/courses/favorites$"),
+                Pattern.compile("^/v1/notices/verified_location$")
         ));
     }
 


### PR DESCRIPTION
## 🛠️ 설명
- /v1/ 경로로 접근하는 경로들을 화이트 리스트에 추가합니다.

## 🔗 관련 이슈
- closes #684 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **보안 개선**
  * 로그인, 강의 조회, 강의 경로 정보, 가까운 위치 조회, 찜하기, 검증된 위치 공지 등 추가 API 엔드포인트에 대한 접근 권한을 활성화했습니다.
  * API 문서 엔드포인트 접근을 추가로 허용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->