### PR TITLE
네트워크 재연결 시 현재 탭 상태에 따라 적절한 데이터 로드 로직 호출

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -484,7 +484,10 @@ class CoursesActivity :
             object : OnReconnectListener {
                 @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
                 override fun onReconnect() {
-                    fetchCourses()
+                    when (viewModel.content.value) {
+                        CoursesContent.EXPLORE -> fetchCourses()
+                        CoursesContent.FAVORITES -> viewModel.fetchFavorites()
+                    }
                 }
             }
 


### PR DESCRIPTION
## 🛠️ 설명
**AS-IS** : 재연결 시, 즐겨찾기 목록이 아닌 코스 탐색 목록이 뜹니다. 또는 즐겨찾기 목록이 없다고 뜹니다.
**TO-BE** : 즐겨찾기 탭에서 재연결 시, 즐겨찾기 목록을 띄웁니다.

## 📸 스크린샷 / 동영상

| AS-IS | TO-BE |
|-------|-------|
| ![Screen_recording_20260210_161344](https://github.com/user-attachments/assets/5c1f9026-c74b-4957-8b01-d4e858031282) | ![Screen_recording_20260210_161222](https://github.com/user-attachments/assets/b07db8d8-e03b-47d8-905b-f73c619485cd) |



## 🔍 리뷰 요청사항

## 🔗 관련 이슈

- closes #692 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **버그 수정**
  * 네트워크 재연결 시 현재 화면에 맞는 콘텐츠를 새로고침합니다. 탐색 목록과 즐겨찾기 목록이 각각 올바르게 업데이트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->