### PR TITLE
초기 코스 탐색 시 현 위치 미반영 현상

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -470,16 +470,8 @@ class CoursesActivity :
                 @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
                 override fun onReconnect() {
                     when (viewModel.content.value) {
-                        CoursesContent.EXPLORE -> {
-                            val mapCoordinate: Coordinate? = mapCoordinateOrNull()
-                            if (mapCoordinate != null) {
-                                fetchCourses(mapCoordinate)
-                            }
-                        }
-
-                        CoursesContent.FAVORITES -> {
-                            viewModel.fetchFavorites()
-                        }
+                        CoursesContent.EXPLORE -> mapCoordinateOrNull()?.let(::fetchCourses)
+                        CoursesContent.FAVORITES -> viewModel.fetchFavorites()
                     }
                 }
             }
@@ -578,8 +570,7 @@ class CoursesActivity :
         mapManager.fetchCurrentLocation(
             onSuccess = { userLatitude: Latitude, userLongitude: Longitude ->
                 val userCoordinate = Coordinate(userLatitude, userLongitude)
-                val mapCoordinate: Coordinate = userCoordinate
-                viewModel.fetchCourses(mapCoordinate, userCoordinate, scope)
+                viewModel.fetchCourses(userCoordinate, userCoordinate, scope)
             },
             onFailure = {
                 val mapCoordinate: Coordinate = mapCoordinateOrNull() ?: return@fetchCurrentLocation


### PR DESCRIPTION
## 🛠️ 설명
- 앱 초기 진입 시 사용자가 위치 권한을 허용했을 때, 사용자의 위치가 아닌 런세권 기본 위치 (루터 회관)으로 보여지는 현상을 수정하였습니다.


## 🔍 리뷰 요청사항
기존의 `이 지역 검색` 버튼 관련은 해당 PR에서 제외했습니다.
카카오맵의 카메라 리스너를 통해 함께 수정 가능하다고 생각했는데, 제대로 수정하려면 새로운 PR에서 하는 게 좋을 것 같아서 수정했던 코드는 제거했습니다.

## 📸 스크린샷 / 동영상

| AS-IS | TO-BE |
|-------|-------|
| [Screen_recording_20260210_210757.webm](https://github.com/user-attachments/assets/dcdf1266-f0f6-4786-a768-ddf26e94a2cb) |  [Screen_recording_20260212_044245.webm](https://github.com/user-attachments/assets/656e9494-bec6-4e5f-bb6e-7cb72187e612) |


## 🔗 관련 이슈

- closes #689 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 지도 상의 좌표를 명시적으로 사용해 강좌 검색 수행, 위치 기반 검색 정확도·일관성 향상
  * 위치 기반 조회 실패 시 제공된 지도 좌표로 재시도해 검색 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->