### PR TITLE
특정 상황에서 로딩 스피너가 표시되지 않는 현상 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -39,7 +39,7 @@ class CoursesViewModel
         private val _state: MutableLiveData<CoursesUiState> =
             MutableLiveData(
                 CoursesUiState(
-                    originalCourses = emptyList(),
+                    originalCourses = listOf(CourseListItem.Loading),
                     query = "",
                     status = UiStatus.Loading,
                 ),


### PR DESCRIPTION
## 🛠️ 설명

다음 상황에서 로딩 스피너가 표시되지 않는 현상이 수정됩니다.
- 코스 화면에서 즐겨찾기를 불러올 때
- 코스 화면을 최초로 표시한 후와 코스 목록 fetch를 시작하기 전 사이의 시점일 때

## 📸 스크린샷 / 동영상

### As-is
https://github.com/user-attachments/assets/3c8d0680-6dec-4ea7-afb6-2a4cc9e979e3

### To-be
https://github.com/user-attachments/assets/1f565369-e307-4c4a-879f-d4acdb3bbe36

## 🔗 관련 이슈

- closes #697 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 즐겨찾기 불러오기 중 로딩 상태 처리 개선

* **개선사항**
  * 코스 데이터 로딩 시 사용자 인터페이스 상태 관리 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->