### PR TITLE
Http 요청/응답 로깅 시 응답 바디 메모리 저장 문제 해결

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
-import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 
@@ -19,16 +18,13 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
-        ContentCachingResponseWrapper responseWrapper = new ContentCachingResponseWrapper(response);
 
         long startTime = System.currentTimeMillis();
-        filterChain.doFilter(requestWrapper, responseWrapper);
+        filterChain.doFilter(requestWrapper, response);
         long duration = System.currentTimeMillis() - startTime;
 
         if (!request.getRequestURI().startsWith("/actuator")) {
-            log.info("[HTTP]", LogContent.http(requestWrapper, responseWrapper, duration));
+            log.info("[HTTP]", LogContent.http(requestWrapper, response, duration));
         }
-
-        responseWrapper.copyBodyToResponse();
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
@@ -1,8 +1,8 @@
 package coursepick.coursepick.logging;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.bson.Document;
 import org.springframework.web.util.ContentCachingRequestWrapper;
-import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
@@ -18,7 +18,7 @@ public class LogContent {
             Pattern.compile("^/admin/login$")
     );
 
-    public static Object[] http(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response, long duration) {
+    public static Object[] http(ContentCachingRequestWrapper request, HttpServletResponse response, long duration) {
         String method = request.getMethod();
         String uri = extractUriWithQueryString(request);
         String headers = extractHeaderString(request);
@@ -27,7 +27,6 @@ public class LogContent {
             requestBody = "[this is sensitive data]";
         }
         int status = response.getStatus();
-        String responseBody = new String(response.getContentAsByteArray(), StandardCharsets.UTF_8).strip();
 
         return new Object[]{
                 kv("method", method),
@@ -35,8 +34,7 @@ public class LogContent {
                 kv("status", status),
                 kv("duration_ms", duration),
                 kv("req_headers", headers),
-                kv("req_body", left(requestBody, 100)),
-                kv("res_body", left(responseBody, 100))
+                kv("req_body", left(requestBody, 100))
         };
     }
 


### PR DESCRIPTION
## 🛠️ 설명
- ResponseWrapper 자체가 1차 메모리를 점유하고,
- `new String().strip()`으로 응답 값을 json에 매핑하고 있습니다.
- 이 과정에서 응답 크키가 클 경우 메모리 사용량이 응답의 2~3배 증가할 수 있습니다.

- 힙 덤프 분석 결과 메모리 사용량이 전체 70~80MB가 되는만큼 치명적인 문제라 생각해서 로깅에서 **응답 바디를 제거하고 메타 데이터만 남기도록 수정**했습니다.

## 📸 스크린샷 / 동영상

## 🔍 리뷰 요청사항

## 🔗 관련 이슈
- closes #709 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로깅 시스템 최적화로 응답 본문 캐싱 제거 및 메모리 사용 효율성 개선
  * 요청 로깅은 계속 유지되며 정상 작동

<!-- end of auto-generated comment: release notes by coderabbit.ai -->