### PR TITLE
README 멤버 아이디 및 포매팅 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@
 
 |<img src="https://avatars.githubusercontent.com/u/161921046?v=4" width="125" />|<img src="https://avatars.githubusercontent.com/u/192606356?v=4" width="125" />|<img src="https://avatars.githubusercontent.com/u/108331578?v=4" width="125" />|<img src="https://avatars.githubusercontent.com/u/176254419?v=4" width="125" />|<img src="https://avatars.githubusercontent.com/u/46932235?v=4" width="125" />|<img src="https://avatars.githubusercontent.com/u/104622150?v=4" width="125" />|<img src="https://avatars.githubusercontent.com/u/111430281?v=4" width="125" />|
 |:---------:|:---------:|:---------:|:----------:|:---------:|:---------:|:---------:|
-|[디랙<br>(허찬)](https://github.com/doabletuple)|[모찌<br>(황채원)](https://github.com/wondroid-world)|[지오<br>(김준서)](https://github.com/giovannijunseokim)|[토바에<br>(박지원)](https://github.com/tobae-time)|[돔푸<br>(이창근)](https://github.com/Dompoo)|[율무<br>(강기석)](https://github.com/kkiseug)|[짱구<br>(박준혁)](https://github.com/jhpark1227)|
+|[디랙<br>(허찬)](https://github.com/doabletuple)|[모찌<br>(황채원)](https://github.com/wondroid-world)|[지오<br>(김준서)](https://github.com/giovannijunseokim)|[토바에<br>(박지원)](https://github.com/tobae-time)|[돔푸<br>(이창근)](https://github.com/dompoo)|[율무<br>(강기석)](https://github.com/kkiseug)|[짱구<br>(박준혁)](https://github.com/jhpark1227)|
 |Android|Android|Android|Android|Backend|Backend|Backend|


### PR DESCRIPTION
## 🛠️ 설명
- 깃허브 아이디를 변경에 따라 수정했습니다.
- 화면 비율에 따라 불규칙하게 보이던 이름 부분을 `<br/>` 태그를 통해 닉네임과 본명에서 줄바꿈 하도록 변경했습니다.
- 디스코드 아이디 <-> 깃허브 아이디 매핑 Secret을 수정하여 디스코드 알림 테스트 겸사겸사...

## 📸 스크린샷 / 동영상

| AS-IS | TO-BE |
|-------|-------|
| <img width="657" height="260" alt="스크린샷 2026-02-18 오후 4 24 38" src="https://github.com/user-attachments/assets/74fb2c76-023f-4b51-b6bb-b759c2eae0e2" />  | <img width="735" height="271" alt="스크린샷 2026-02-18 오후 4 25 39" src="https://github.com/user-attachments/assets/69b62db4-3ca1-40db-b76c-f27e9c807a8a" />  |

- closes # 이슈 안 만들어서 0번 차지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * README의 팀 멤버 표 표시가 개선되었습니다. 멤버 이름 레이블에 줄바꿈을 적용해 각 항목이 두 줄로 표시되어 가독성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->