### PR TITLE
대략적인 위치 권한으로 현 위치 조회 시 간헐적으로 NPE가 발생하는 현상 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/LocationProvider.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/LocationProvider.kt
@@ -50,7 +50,16 @@ class LocationProvider(
 
         locationClient
             .getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
-            .addOnSuccessListener { location: Location ->
+            .addOnSuccessListener { location: Location? ->
+                if (location == null) {
+                    val exception = IllegalStateException("위치 정보를 불러오지 못했습니다.")
+                    Logger.log(
+                        Logger.Event.Failure("get_current_location"),
+                        "message" to exception.message.toString(),
+                    )
+                    onFailure(exception)
+                    return@addOnSuccessListener
+                }
                 Logger.log(Logger.Event.Success("get_current_location"))
                 onSuccess(location)
             }.addOnFailureListener { exception: Exception ->


### PR DESCRIPTION
## 🛠️ 설명

대략적인 위치 권한으로 현 위치 조회 시 간헐적으로 `NullPointerException`이 발생해 앱이 종료되는 현상이 수정됩니다.


## 🔗 관련 이슈

- closes #711 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* **버그 수정**
  * 위치 정보 조회 중 예외 상황 발생 시 안정성을 강화했습니다. 앱이 예기치 않은 상황에서도 더욱 견고하고 안정적으로 대응하도록 개선되었습니다. 이로 인해 위치 기반 기능의 신뢰성과 전반적인 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->