### PR TITLE
초기 탐색 시 '이 지역 검색' 버튼 노출 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -612,8 +612,6 @@ class CoursesActivity :
                 viewModel.fetchCourses(mapCoordinate, null, scope)
             },
         )
-
-        binding.mainSearchThisAreaButton.visibility = View.GONE
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
@@ -672,6 +670,9 @@ class CoursesActivity :
         }
 
         viewModel.content.observe(this) { content: CoursesContent ->
+            if (content != CoursesContent.EXPLORE) {
+                binding.mainSearchThisAreaButton.visibility = View.GONE
+            }
             switchContent(content)
         }
     }

--- a/android/app/src/main/res/layout/activity_courses.xml
+++ b/android/app/src/main/res/layout/activity_courses.xml
@@ -95,7 +95,7 @@
                 android:orientation="horizontal"
                 android:padding="10dp"
                 android:translationY="50dp"
-                android:visibility="@{viewModel.content == CoursesContent.EXPLORE ? View.VISIBLE : View.GONE}"
+                android:visibility="gone"
                 app:layout_anchor="@id/mainSearchBar"
                 app:layout_anchorGravity="bottom|center_horizontal"
                 app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
## 🛠️ 설명
- 초기 코스 탐색 시 '이 지역 검색' 버튼의 노출을 명시적으로 Gone 처리했습니다.

## 📸 스크린샷 / 동영상

| AS-IS | TO-BE |
|-------|-------|
| https://github.com/user-attachments/assets/f8315345-fa11-484e-b7ba-d78ccfce57c9  | https://github.com/user-attachments/assets/edf0f2c1-f152-426f-8e7f-8c91736b4860  |

## 🔗 관련 이슈

- closes #717 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 탐색(EXPLORE) 상태가 아닐 때 검색 영역 버튼이 항상 숨겨지도록 일관되게 처리되었습니다.
  * 레이아웃에서 해당 버튼의 동적 표시가 제거되어 기본적으로 보이지 않게 변경되었습니다.
  * 초기 로드 및 지도 상호작용 후의 표시 상태와 일치하도록 버튼 표시 로직이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->