### PR TITLE
네트워크 연결이 없을 시 네트워크 없음 안내가 다른 UI와 겹쳐서 표시되는 현상 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -704,6 +704,12 @@ class CoursesActivity :
                         .show()
                 }
 
+                is CoursesUiEvent.FetchRouteToCourseNoNetwork -> {
+                    Toast
+                        .makeText(this, "네트워크에 연결되지 않아 길찾기에 실패했습니다.", Toast.LENGTH_SHORT)
+                        .show()
+                }
+
                 is CoursesUiEvent.FetchNearestCoordinateSuccess -> {
                     event.routeFinder.launch(
                         this@CoursesActivity,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiEvent.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiEvent.kt
@@ -17,6 +17,8 @@ sealed interface CoursesUiEvent {
 
     object FetchRouteToCourseFailure : CoursesUiEvent
 
+    object FetchRouteToCourseNoNetwork : CoursesUiEvent
+
     class FetchNearestCoordinateSuccess(
         val origin: Coordinate,
         val destination: Coordinate,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -358,33 +358,20 @@ class CoursesViewModel
                     courseRepository.routeToCourse(selectedCourse.course, origin)
                 }.onSuccess { route: List<Coordinate> ->
                     Logger.log(Logger.Event.Success("fetch_route_to_course"))
-                    _state.value =
-                        state.value?.copy(
-                            status = UiStatus.Success,
-                        )
+                    _state.value = state.value?.copy(status = UiStatus.Success)
                     _event.value = CoursesUiEvent.FetchRouteToCourseSuccess(route, selectedCourse)
                 }.onFailure { error: Throwable ->
-                    when (error) {
-                        is NoNetworkException -> {
-                            _state.value =
-                                state.value?.copy(
-                                    originalCourses = emptyList(),
-                                    status = UiStatus.NoInternet,
-                                )
-                        }
-
-                        else -> {
-                            _state.value =
-                                state.value?.copy(
-                                    status = UiStatus.Failure,
-                                )
-                        }
-                    }
                     Logger.log(
                         Logger.Event.Failure("fetch_route_to_course"),
                         "message" to error.message.toString(),
                     )
-                    _event.value = CoursesUiEvent.FetchRouteToCourseFailure
+                    _state.value = state.value?.copy(status = UiStatus.Failure)
+                    _event.value =
+                        if (error is NoNetworkException) {
+                            CoursesUiEvent.FetchRouteToCourseNoNetwork
+                        } else {
+                            CoursesUiEvent.FetchRouteToCourseFailure
+                        }
                 }
             }
         }


### PR DESCRIPTION
## 🛠️ 설명

다음 오류가 수정됩니다.
- 앱 실행 시 네트워크 연결이 없으면 `네트워크 없음` 안내가 로딩 스피너와 겹쳐서 표시되는 현상
- 길찾기 시 네트워크 연결이 없으면 `네트워크 없음` 안내가 코스 목록과 겹쳐서 표시되는 현상


## 📸 스크린샷 / 동영상

### 앱 실행 시 As-is
https://github.com/user-attachments/assets/9aa33bee-e865-427e-af85-ca5c7aee979c

### 앱 실행 시 To-be
https://github.com/user-attachments/assets/6e66cd4a-99ac-4231-b39f-7741e6dbdebf


### 길찾기 시
|As-is|To-be|
|-|-|
|<img width="1408" height="2974" alt="image" src="https://github.com/user-attachments/assets/b970ef22-d549-4007-b665-c9a6f1cf49ff" />|<img width="1408" height="2974" alt="image" src="https://github.com/user-attachments/assets/a87a7aff-2340-4933-a8e4-c76ce352959b" />|


## 🔗 관련 이슈

- closes #722 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 네트워크 없음 상태에서 이전 강좌 데이터를 명시적으로 초기화하여 오프라인 시 빈 목록으로 처리합니다.

* **신규 기능**
  * 경로 조회 실패 중 네트워크 전용 실패를 별도 이벤트로 추가하고, 해당 경우 사용자에게 토스트로 알립니다.

* **UI 개선**
  * 실패/빈 상태를 반영하는 가시성 제어 로직을 추가하고 헤더 및 빈 상태의 여백을 패딩 기반으로 조정해 레이아웃을 안정화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->