### PR TITLE
즐겨찾기 메뉴에서 configuration change 발생 시 잘못된 목록이 보이는 현상 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -600,18 +600,27 @@ class CoursesActivity :
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     private fun fetchInitialCourses() {
-        val scope: Scope = Scope.default()
+        when (viewModel.content.value) {
+            CoursesContent.EXPLORE -> {
+                val scope: Scope = Scope.default()
 
-        mapManager.fetchCurrentLocation(
-            onSuccess = { userLatitude: Latitude, userLongitude: Longitude ->
-                val userCoordinate = Coordinate(userLatitude, userLongitude)
-                viewModel.fetchCourses(userCoordinate, userCoordinate, scope)
-            },
-            onFailure = {
-                val mapCoordinate: Coordinate = mapCoordinateOrNull() ?: return@fetchCurrentLocation
-                viewModel.fetchCourses(mapCoordinate, null, scope)
-            },
-        )
+                mapManager.fetchCurrentLocation(
+                    onSuccess = { userLatitude: Latitude, userLongitude: Longitude ->
+                        val userCoordinate = Coordinate(userLatitude, userLongitude)
+                        viewModel.fetchCourses(userCoordinate, userCoordinate, scope)
+                    },
+                    onFailure = {
+                        val mapCoordinate: Coordinate =
+                            mapCoordinateOrNull() ?: return@fetchCurrentLocation
+                        viewModel.fetchCourses(mapCoordinate, null, scope)
+                    },
+                )
+            }
+
+            CoursesContent.FAVORITES -> {
+                viewModel.fetchFavorites()
+            }
+        }
     }
 
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])


### PR DESCRIPTION
## 🛠️ 설명

즐겨찾기 메뉴가 선택된 상태에서 configuration change 발생 시, `ViewModel` 및 `BottomNavigationView`는 즐겨찾기 상태를 유지 하지만 `onCreate()`에서 `fetchInitialCourses()`가 다시 호출되면서 목록에는 코스 탐색 항목이 표시되는 현상이 있습니다.

`fetchInitialCourses()`에서 `CoursesContent`의 값에 따라 `코스 탐색` 또는 `즐겨찾기`를 불러오도록 변경해 configuration change가 발생해도 올바른 목록이 표시되도록 수정됩니다.


## 📸 스크린샷 / 동영상

### As-is
https://github.com/user-attachments/assets/4dd1c8d9-eef1-4e53-a5b8-209a349f130d

### To-be
https://github.com/user-attachments/assets/b4f7881b-58ad-408c-99a6-e016ee11ff88


## 🔗 관련 이슈

- closes #724 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 앱이 재시작될 때 발생하던 불필요한 데이터 재로드를 최적화하여 앱의 성능과 응답성을 개선했습니다.
  * 즐겨찾기 화면에서 위치 기반 데이터를 불필요하게 가져오던 문제를 수정하여 즐겨찾기 목록이 정확하고 빠르게 표시되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->