### PR TITLE
필터링 API 연결

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/data/course/CourseService.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/course/CourseService.kt
@@ -18,6 +18,8 @@ interface CourseService {
         @Query("userLng") userLongitude: Double?,
         @Query("scope") scopeMeter: Int,
         @Query("page") page: Int,
+        @Query("minLength") minLengthMeter: Int? = null,
+        @Query("maxLength") maxLengthMeter: Int? = null,
     ): CoursesPageDto
 
     @GET("courses/{id}/route")

--- a/android/app/src/main/java/io/coursepick/coursepick/data/course/DefaultCourseRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/course/DefaultCourseRepository.kt
@@ -34,7 +34,7 @@ class DefaultCourseRepository
                     scopeMeter = scope.meter.value.toInt(),
                     page = page,
                     minLengthMeter = minLength?.value?.toInt(),
-                    maxLengthMeter = maxLength?.value?.let { ceil(it) }?.toInt(),
+                    maxLengthMeter = maxLength?.value?.let(::ceil)?.toInt(),
                 ).toCoursesPage()
 
         override suspend fun routeToCourse(

--- a/android/app/src/main/java/io/coursepick/coursepick/data/course/DefaultCourseRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/course/DefaultCourseRepository.kt
@@ -7,6 +7,7 @@ import io.coursepick.coursepick.domain.course.CoursesPage
 import io.coursepick.coursepick.domain.course.Meter
 import io.coursepick.coursepick.domain.course.Scope
 import javax.inject.Inject
+import kotlin.math.ceil
 
 class DefaultCourseRepository
     @Inject
@@ -33,7 +34,7 @@ class DefaultCourseRepository
                     scopeMeter = scope.meter.value.toInt(),
                     page = page,
                     minLengthMeter = minLength?.value?.toInt(),
-                    maxLengthMeter = maxLength?.value?.toInt(),
+                    maxLengthMeter = maxLength?.value?.let { ceil(it) }?.toInt(),
                 ).toCoursesPage()
 
         override suspend fun routeToCourse(

--- a/android/app/src/main/java/io/coursepick/coursepick/data/course/DefaultCourseRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/course/DefaultCourseRepository.kt
@@ -4,6 +4,7 @@ import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.course.Course
 import io.coursepick.coursepick.domain.course.CourseRepository
 import io.coursepick.coursepick.domain.course.CoursesPage
+import io.coursepick.coursepick.domain.course.Meter
 import io.coursepick.coursepick.domain.course.Scope
 import javax.inject.Inject
 
@@ -20,6 +21,8 @@ class DefaultCourseRepository
             page: Int,
             mapCoordinate: Coordinate,
             userCoordinate: Coordinate?,
+            minLength: Meter?,
+            maxLength: Meter?,
         ): CoursesPage =
             service
                 .courses(
@@ -29,6 +32,8 @@ class DefaultCourseRepository
                     userLongitude = userCoordinate?.longitude?.value,
                     scopeMeter = scope.meter.value.toInt(),
                     page = page,
+                    minLengthMeter = minLength?.value?.toInt(),
+                    maxLengthMeter = maxLength?.value?.toInt(),
                 ).toCoursesPage()
 
         override suspend fun routeToCourse(

--- a/android/app/src/main/java/io/coursepick/coursepick/domain/course/CourseRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/domain/course/CourseRepository.kt
@@ -8,6 +8,8 @@ interface CourseRepository {
         page: Int,
         mapCoordinate: Coordinate,
         userCoordinate: Coordinate? = null,
+        minLength: Meter? = null,
+        maxLength: Meter? = null,
     ): CoursesPage
 
     suspend fun routeToCourse(

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -211,6 +211,12 @@ class CoursesActivity :
         updateManager.onStop()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+
+        mapManager.finish()
+    }
+
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     override fun searchThisArea() {
         val coordinate = mapCoordinateOrNull() ?: return

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiState.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiState.kt
@@ -14,5 +14,5 @@ data class CoursesUiState(
 ) {
     val isQueryBlank: Boolean = query.isBlank()
     val isFilterDefault: Boolean = courseFilter == CourseFilter.None
-    val courses: List<CourseListItem> = courseFilter.filteredCourses(originalCourses)
+    val courses: List<CourseListItem> = originalCourses
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiState.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiState.kt
@@ -4,7 +4,7 @@ import io.coursepick.coursepick.domain.notice.Notice
 import io.coursepick.coursepick.presentation.filter.CourseFilter
 
 data class CoursesUiState(
-    val originalCourses: List<CourseListItem>,
+    val courses: List<CourseListItem>,
     val query: String = "",
     val status: UiStatus = UiStatus.Loading,
     val courseFilter: CourseFilter = CourseFilter.None,
@@ -14,5 +14,4 @@ data class CoursesUiState(
 ) {
     val isQueryBlank: Boolean = query.isBlank()
     val isFilterDefault: Boolean = courseFilter == CourseFilter.None
-    val courses: List<CourseListItem> = originalCourses
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -71,7 +71,7 @@ class CoursesViewModel
         private fun checkNetwork() {
             if (!networkMonitor.isConnected()) {
                 _state.value =
-                    state.value?.copy(originalCourses = emptyList(), status = UiStatus.NoInternet)
+                    state.value?.copy(courses = emptyList(), status = UiStatus.NoInternet)
             }
         }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -46,8 +46,6 @@ class CoursesViewModel
             )
         val state: LiveData<CoursesUiState> get() = _state
 
-        val a: MutableLiveData<String> = MutableLiveData()
-
         private val _content: MutableLiveData<CoursesContent> = MutableLiveData(CoursesContent.EXPLORE)
         val content: LiveData<CoursesContent> get() = _content
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -454,6 +454,9 @@ class CoursesViewModel
 
                 is CourseFilterAction.Apply -> {
                     _state.value = state.value?.copy(showFilterDialog = false)
+                    val mapCoordinate = lastMapCoordinate ?: return
+                    val scope = lastScope ?: return
+                    fetchCourses(mapCoordinate, lastUserCoordinate, scope)
                 }
 
                 is CourseFilterAction.UpdateLengthRange -> {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -46,6 +46,8 @@ class CoursesViewModel
             )
         val state: LiveData<CoursesUiState> get() = _state
 
+        val a: MutableLiveData<String> = MutableLiveData()
+
         private val _content: MutableLiveData<CoursesContent> = MutableLiveData(CoursesContent.EXPLORE)
         val content: LiveData<CoursesContent> get() = _content
 
@@ -150,6 +152,19 @@ class CoursesViewModel
                     status = UiStatus.Loading,
                 )
 
+            val minLength =
+                state.value
+                    ?.courseFilter
+                    ?.lengthRange
+                    ?.start
+                    ?.toMeter()
+            val maxLength =
+                state.value
+                    ?.courseFilter
+                    ?.lengthRange
+                    ?.endInclusive
+                    ?.toMeter()
+
             viewModelScope.launch {
                 runCatching {
                     courseRepository.courses(
@@ -157,6 +172,8 @@ class CoursesViewModel
                         page = 0,
                         mapCoordinate = mapCoordinate,
                         userCoordinate = userCoordinate,
+                        minLength = minLength,
+                        maxLength = maxLength,
                     )
                 }.onSuccess { coursesPage: CoursesPage ->
                     Logger.log(Logger.Event.Success("fetch_courses_new"))
@@ -222,6 +239,18 @@ class CoursesViewModel
             val mapCoordinate: Coordinate = lastMapCoordinate ?: return
             val userCoordinate: Coordinate? = lastUserCoordinate
             val scope: Scope = lastScope ?: return
+            val minLength =
+                state.value
+                    ?.courseFilter
+                    ?.lengthRange
+                    ?.start
+                    ?.toMeter()
+            val maxLength =
+                state.value
+                    ?.courseFilter
+                    ?.lengthRange
+                    ?.endInclusive
+                    ?.toMeter()
 
             viewModelScope.launch {
                 runCatching {
@@ -231,6 +260,8 @@ class CoursesViewModel
                         page = nextPage,
                         mapCoordinate = mapCoordinate,
                         userCoordinate = userCoordinate,
+                        minLength = minLength,
+                        maxLength = maxLength,
                     )
                 }.onSuccess { coursesPage: CoursesPage ->
                     Logger.log(Logger.Event.Success("fetch_courses_next"))

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -39,7 +39,7 @@ class CoursesViewModel
         private val _state: MutableLiveData<CoursesUiState> =
             MutableLiveData(
                 CoursesUiState(
-                    originalCourses = listOf(CourseListItem.Loading),
+                    courses = listOf(CourseListItem.Loading),
                     query = "",
                     status = UiStatus.Loading,
                 ),
@@ -93,14 +93,14 @@ class CoursesViewModel
             if (selectedIndex == -1) return
 
             val newCourseItems: List<CourseListItem> = newCoursesListItem(oldCourses, course)
-            _state.value = state.value?.copy(originalCourses = newCourseItems)
+            _state.value = state.value?.copy(courses = newCourseItems)
             _event.value = CoursesUiEvent.SelectCourseManually(course)
         }
 
         fun toggleFavorite(toggledCourse: CourseItem) {
             pendingFavoriteWrites[toggledCourse.id] = !toggledCourse.favorite
 
-            state.value?.originalCourses?.let { courses: List<CourseListItem> ->
+            state.value?.courses?.let { courses: List<CourseListItem> ->
                 val newCourses =
                     courses.map { item: CourseListItem ->
                         when (item) {
@@ -117,7 +117,7 @@ class CoursesViewModel
                             }
                         }
                     }
-                _state.value = state.value?.copy(originalCourses = newCourses)
+                _state.value = state.value?.copy(courses = newCourses)
             }
 
             updateFavorites()
@@ -148,7 +148,7 @@ class CoursesViewModel
         ) {
             _state.value =
                 state.value?.copy(
-                    originalCourses = listOf(CourseListItem.Loading),
+                    courses = listOf(CourseListItem.Loading),
                     status = UiStatus.Loading,
                 )
 
@@ -200,7 +200,7 @@ class CoursesViewModel
 
                     _state.value =
                         state.value?.copy(
-                            originalCourses = courseItems.map(CourseListItem::Course),
+                            courses = courseItems.map(CourseListItem::Course),
                             status = UiStatus.Success,
                         )
                 }.onFailure { exception: Throwable ->
@@ -211,14 +211,14 @@ class CoursesViewModel
                     if (exception is NoNetworkException) {
                         _state.value =
                             state.value?.copy(
-                                originalCourses = emptyList(),
+                                courses = emptyList(),
                                 status = UiStatus.NoInternet,
                             )
                         return@onFailure
                     }
                     _state.value =
                         state.value?.copy(
-                            originalCourses = emptyList(),
+                            courses = emptyList(),
                             status = UiStatus.Failure,
                         )
                     _event.value = CoursesUiEvent.FetchCourseFailure
@@ -229,10 +229,10 @@ class CoursesViewModel
         fun fetchNextCourses() {
             if (state.value?.status == UiStatus.Loading || !hasNext) return
 
-            val existingCourses: List<CourseListItem> = state.value?.originalCourses ?: emptyList()
+            val existingCourses: List<CourseListItem> = state.value?.courses ?: emptyList()
             _state.value =
                 state.value?.copy(
-                    originalCourses = existingCourses + CourseListItem.Loading,
+                    courses = existingCourses + CourseListItem.Loading,
                     status = UiStatus.Loading,
                 )
 
@@ -269,7 +269,7 @@ class CoursesViewModel
                     val favoritedCourseIds: Set<String> = favoritesRepository.favoriteCourseIds()
 
                     val existingCoursesWithoutLoading =
-                        (state.value?.originalCourses ?: emptyList())
+                        (state.value?.courses ?: emptyList())
                             .filterNot { courseListItem: CourseListItem -> courseListItem is CourseListItem.Loading }
 
                     val newCourses =
@@ -288,7 +288,7 @@ class CoursesViewModel
 
                     _state.value =
                         state.value?.copy(
-                            originalCourses = existingCoursesWithoutLoading + newCourses,
+                            courses = existingCoursesWithoutLoading + newCourses,
                             status = UiStatus.Success,
                         )
                 }.onFailure { exception: Throwable ->
@@ -298,12 +298,12 @@ class CoursesViewModel
                     )
 
                     val existingCoursesWithoutLoading =
-                        (state.value?.originalCourses ?: emptyList())
+                        (state.value?.courses ?: emptyList())
                             .filterNot { courseListItem: CourseListItem -> courseListItem is CourseListItem.Loading }
 
                     _state.value =
                         state.value?.copy(
-                            originalCourses = existingCoursesWithoutLoading,
+                            courses = existingCoursesWithoutLoading,
                             status = UiStatus.Failure,
                         )
                     _event.value = CoursesUiEvent.FetchNextCoursesFailure
@@ -314,7 +314,7 @@ class CoursesViewModel
         fun fetchFavorites() {
             _state.value =
                 state.value?.copy(
-                    originalCourses = listOf(CourseListItem.Loading),
+                    courses = listOf(CourseListItem.Loading),
                     status = UiStatus.Loading,
                 )
 
@@ -322,7 +322,7 @@ class CoursesViewModel
             if (favoritedCourseIds.isEmpty()) {
                 _state.value =
                     state.value?.copy(
-                        originalCourses = emptyList(),
+                        courses = emptyList(),
                         status = UiStatus.Success,
                     )
                 return
@@ -343,7 +343,7 @@ class CoursesViewModel
                     _state.value =
                         state.value
                             ?.copy(
-                                originalCourses = courseItems.map(CourseListItem::Course),
+                                courses = courseItems.map(CourseListItem::Course),
                                 status = UiStatus.Success,
                             )
                 }.onFailure { exception: Throwable ->
@@ -355,7 +355,7 @@ class CoursesViewModel
                         _state.value =
                             state.value
                                 ?.copy(
-                                    originalCourses = emptyList(),
+                                    courses = emptyList(),
                                     status = UiStatus.NoInternet,
                                 )
                         return@onFailure
@@ -363,7 +363,7 @@ class CoursesViewModel
                     _state.value =
                         state.value
                             ?.copy(
-                                originalCourses = emptyList(),
+                                courses = emptyList(),
                                 status = UiStatus.Failure,
                             )
                     _event.value = CoursesUiEvent.FetchCourseFailure
@@ -379,7 +379,7 @@ class CoursesViewModel
             val newCourseItems: List<CourseListItem> = newCoursesListItem(oldCourses, course)
             _state.value =
                 state.value?.copy(
-                    originalCourses = newCourseItems,
+                    courses = newCourseItems,
                     status = UiStatus.Loading,
                 )
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilter.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilter.kt
@@ -1,36 +1,12 @@
 package io.coursepick.coursepick.presentation.filter
 
 import io.coursepick.coursepick.domain.course.Kilometer
-import io.coursepick.coursepick.domain.course.Meter
-import io.coursepick.coursepick.presentation.course.CourseItem
-import io.coursepick.coursepick.presentation.course.CourseListItem
 
 data class CourseFilter(
     val lengthRange: ClosedRange<Kilometer>,
 ) {
     val lengthRangeAsFloat: ClosedFloatingPointRange<Float> =
         lengthRange.start.value.toFloat()..lengthRange.endInclusive.value.toFloat()
-
-    private val minimumLength: Meter = lengthRange.start.toMeter()
-    private val maximumLength: Meter =
-        if (lengthRange.endInclusive == MAXIMUM_LENGTH_RANGE) {
-            Meter.MAX_VALUE
-        } else {
-            lengthRange.endInclusive.toMeter()
-        }
-
-    fun filteredCourses(courses: List<CourseListItem>): List<CourseListItem> =
-        courses.filter { courseListItem: CourseListItem ->
-            courseListItem is CourseListItem.Loading ||
-                (
-                    courseListItem is CourseListItem.Course &&
-                        this.matches(
-                            courseListItem.item,
-                        )
-                )
-        }
-
-    fun matches(courseItem: CourseItem): Boolean = Meter(courseItem.length) in minimumLength..maximumLength
 
     companion object {
         val MINIMUM_LENGTH_RANGE = Kilometer(0.0)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilterBottomSheet.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilterBottomSheet.kt
@@ -189,7 +189,7 @@ private fun CourseFilterBottomSheetPreview() {
 
         if (showSheet) {
             CourseFilterBottomSheet(
-                coursesUiState = CoursesUiState(originalCourses = listOf()),
+                coursesUiState = CoursesUiState(courses = listOf()),
                 onDismissRequest = { showSheet = false },
                 onFilterAction = {},
             )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilterBottomSheet.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilterBottomSheet.kt
@@ -137,7 +137,6 @@ fun CourseFilterBottomSheet(
 
                 FilterResultButton(
                     text = stringResource(R.string.filter_result_button),
-                    enabled = true,
                     onClick = { onFilterAction(CourseFilterAction.Apply) },
                     modifier = Modifier.weight(1f),
                 )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilterBottomSheet.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/CourseFilterBottomSheet.kt
@@ -136,12 +136,8 @@ fun CourseFilterBottomSheet(
                 }
 
                 FilterResultButton(
-                    text =
-                        stringResource(
-                            R.string.filter_result_with_count_button,
-                            coursesUiState.courses.size,
-                        ),
-                    enabled = coursesUiState.courses.isNotEmpty(),
+                    text = stringResource(R.string.filter_result_button),
+                    enabled = true,
                     onClick = { onFilterAction(CourseFilterAction.Apply) },
                     modifier = Modifier.weight(1f),
                 )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/FilterResultButton.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/FilterResultButton.kt
@@ -55,7 +55,7 @@ private fun FilterResultButtonPreview() {
     CoursePickTheme {
         var enabled by remember { mutableStateOf(true) }
         FilterResultButton(
-            text = stringResource(R.string.filter_result_with_count_button, 10),
+            text = stringResource(R.string.filter_result_button),
             enabled = enabled,
             onClick = { enabled != enabled },
         )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/FilterResultButton.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/filter/FilterResultButton.kt
@@ -23,13 +23,11 @@ import io.coursepick.coursepick.presentation.search.ui.theme.CoursePickTheme
 @Composable
 fun FilterResultButton(
     text: String,
-    enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TextButton(
         onClick = onClick,
-        enabled = enabled,
         shape = RoundedCornerShape(8.dp),
         modifier = modifier,
         colors =
@@ -56,7 +54,6 @@ private fun FilterResultButtonPreview() {
         var enabled by remember { mutableStateOf(true) }
         FilterResultButton(
             text = stringResource(R.string.filter_result_button),
-            enabled = enabled,
             onClick = { enabled != enabled },
         )
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -23,7 +23,6 @@
     <string name="filter_dialog_length_label">길이</string>
     <string name="filter_dialog_cancel_button">취소</string>
     <string name="filter_result_button">검색 결과</string>
-    <string name="filter_result_with_count_button">검색 결과(%1$d개)</string>
     <string name="filter_length_range_total_label">전체</string>
     <string name="filter_length_range_label">%1$d km ~ %2$d km</string>
     <string name="filter_length_range_open_start_label">~ %1$d km</string>

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/course/CoursesViewModelTest.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/course/CoursesViewModelTest.kt
@@ -47,7 +47,7 @@ class CoursesViewModelTest {
         // given
         val expected =
             CoursesUiState(
-                originalCourses =
+                courses =
                     FAKE_COURSES.mapIndexed { index: Int, course: Course ->
                         CourseListItem.Course(
                             CourseItem(course, selected = index == 0, favorite = false),
@@ -129,7 +129,7 @@ class CoursesViewModelTest {
         // then
         val state: CoursesUiState = viewModel.state.getOrAwaitValue()
         Assertions.assertThat(state.status).isEqualTo(UiStatus.Failure)
-        Assertions.assertThat(state.originalCourses).isEmpty()
+        Assertions.assertThat(state.courses).isEmpty()
     }
 
     @Test
@@ -145,9 +145,9 @@ class CoursesViewModelTest {
         // then
         val state: CoursesUiState = mainViewModel.state.getOrAwaitValue()
         Assertions.assertThat(state.status).isEqualTo(UiStatus.Success)
-        Assertions.assertThat(state.originalCourses.size).isEqualTo(FAKE_COURSES.size + 1)
+        Assertions.assertThat(state.courses.size).isEqualTo(FAKE_COURSES.size + 1)
 
-        val lastCourseListItem = state.originalCourses.last()
+        val lastCourseListItem = state.courses.last()
         val lastCourse = (lastCourseListItem as CourseListItem.Course).item
         Assertions.assertThat(lastCourse.course).isEqualTo(COURSE_FIXTURE_20)
         Assertions.assertThat(lastCourse.selected).isFalse()
@@ -169,7 +169,7 @@ class CoursesViewModelTest {
         viewModel.fetchCourses(COORDINATE_FIXTURE, null, Scope.default())
 
         val initialState: CoursesUiState = viewModel.state.getOrAwaitValue()
-        val initialCourseCount = initialState.originalCourses.size
+        val initialCourseCount = initialState.courses.size
 
         // when - fetchNextCourses를 두 번 연속 호출
         fakeCourseRepository.customCoursesPage =
@@ -180,7 +180,7 @@ class CoursesViewModelTest {
 
         // then - 한 번만 추가되었는지 확인
         val state: CoursesUiState = viewModel.state.getOrAwaitValue()
-        Assertions.assertThat(state.originalCourses.size).isEqualTo(initialCourseCount + 1)
+        Assertions.assertThat(state.courses.size).isEqualTo(initialCourseCount + 1)
     }
 
     @Test
@@ -199,7 +199,7 @@ class CoursesViewModelTest {
         viewModel.fetchCourses(COORDINATE_FIXTURE, null, Scope.default())
 
         val initialState: CoursesUiState = viewModel.state.getOrAwaitValue()
-        val initialCourseCount = initialState.originalCourses.size
+        val initialCourseCount = initialState.courses.size
 
         fakeCourseRepository.customCoursesPage =
             CoursesPage(courses = listOf(COURSE_FIXTURE_20), hasNext = false)
@@ -209,14 +209,14 @@ class CoursesViewModelTest {
 
         // then
         val state: CoursesUiState = viewModel.state.getOrAwaitValue()
-        Assertions.assertThat(state.originalCourses.size).isEqualTo(initialCourseCount)
+        Assertions.assertThat(state.courses.size).isEqualTo(initialCourseCount)
     }
 
     @Test
     fun `다음 페이지 로드 실패 시 기존 코스 목록은 유지된다`() {
         // given
         val initialState: CoursesUiState = mainViewModel.state.getOrAwaitValue()
-        val initialCourses = initialState.originalCourses
+        val initialCourses = initialState.courses
 
         fakeCourseRepository.shouldThrowError = true
 
@@ -226,6 +226,6 @@ class CoursesViewModelTest {
         // then
         val state: CoursesUiState = mainViewModel.state.getOrAwaitValue()
         Assertions.assertThat(state.status).isEqualTo(UiStatus.Failure)
-        Assertions.assertThat(state.originalCourses).isEqualTo(initialCourses)
+        Assertions.assertThat(state.courses).isEqualTo(initialCourses)
     }
 }

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeCourseRepository.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeCourseRepository.kt
@@ -4,6 +4,7 @@ import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.course.Course
 import io.coursepick.coursepick.domain.course.CourseRepository
 import io.coursepick.coursepick.domain.course.CoursesPage
+import io.coursepick.coursepick.domain.course.Meter
 import io.coursepick.coursepick.domain.course.Scope
 import io.coursepick.coursepick.domain.fixture.COORDINATE_FIXTURE
 import io.coursepick.coursepick.domain.fixture.COURSE_FIXTURE_1
@@ -20,6 +21,8 @@ class FakeCourseRepository : CourseRepository {
         page: Int,
         mapCoordinate: Coordinate,
         userCoordinate: Coordinate?,
+        minLength: Meter?,
+        maxLength: Meter?,
     ): CoursesPage {
         if (shouldThrowError) {
             throw RuntimeException("Fetch courses failed")


### PR DESCRIPTION
## 🛠️ 설명
코스 탐색 API에 필터링 관련 쿼리가 추가되어 이를 반영하고,
클라이언트 사이드의 필터링 기능을 제거했습니다.

## 📸 스크린샷 / 동영상
## 📌 변경 전 / 변경 후

| AS-IS | TO-BE |
|-------|-------|
| <video src="https://github.com/user-attachments/assets/8de520b3-a313-46dc-b45f-aceeb8267f7f" controls width="100%"></video> | <video src="https://github.com/user-attachments/assets/226aeb98-5a6c-4110-9f38-fa9d247c5881" controls width="100%"></video> |








## 🔍 리뷰 요청사항

## 🔗 관련 이슈

- closes #729 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 코스 검색에 최소/최대 길이 필터 추가

* **버그 수정**
  * 활동 종료 시 지도 리소스 정리로 안정성 향상

* **리팩터**
  * UI 상태 필드명 originalCourses → courses로 변경, 필터 책임 축소(필터 로직 이동)

* **테스트**
  * 단위 테스트 및 테스트용 리포지토리 업데이트

* **기타(잡일)**
  * 카운트 기반 필터 버튼 문자열 리소스 및 사용처 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->