### PR TITLE
토스트 메시지를 문자열을 리소스로 분리

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -138,7 +138,7 @@ class CoursesActivity :
                         Toast
                             .makeText(
                                 this@CoursesActivity,
-                                getString(R.string.toast_failed_to_get_current_location),
+                                getString(R.string.courses_failed_to_get_current_location_message),
                                 Toast.LENGTH_SHORT,
                             ).show()
                     },
@@ -235,7 +235,7 @@ class CoursesActivity :
         searchLauncher?.launch(intent) ?: Toast
             .makeText(
                 this,
-                getString(R.string.toast_search_unavailable),
+                getString(R.string.courses_search_unavailable_message),
                 Toast.LENGTH_SHORT,
             ).show()
     }
@@ -244,7 +244,7 @@ class CoursesActivity :
         val clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
         val clip: ClipData = ClipData.newPlainText(null, coursePickApplication.installationId.value)
         clipboard.setPrimaryClip(clip)
-        Toast.makeText(this, getString(R.string.toast_client_id_copied), Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, getString(R.string.courses_client_id_copied_message), Toast.LENGTH_SHORT).show()
     }
 
     override fun clearQuery() {
@@ -258,7 +258,7 @@ class CoursesActivity :
                 Toast
                     .makeText(
                         this,
-                        getString(R.string.toast_failed_to_calculate_length_range),
+                        getString(R.string.courses_failed_to_calculate_length_range_message),
                         Toast.LENGTH_SHORT,
                     ).show()
                 return null
@@ -271,7 +271,7 @@ class CoursesActivity :
             Toast
                 .makeText(
                     this,
-                    getString(R.string.toast_failed_to_get_map_location),
+                    getString(R.string.courses_failed_to_get_map_location_message),
                     Toast.LENGTH_SHORT,
                 ).show()
             return null
@@ -292,7 +292,7 @@ class CoursesActivity :
             Toast
                 .makeText(
                     this@CoursesActivity,
-                    getString(R.string.toast_search_information_not_provided),
+                    getString(R.string.courses_search_information_not_provided_message),
                     Toast.LENGTH_SHORT,
                 ).show()
             return
@@ -307,7 +307,7 @@ class CoursesActivity :
             Toast
                 .makeText(
                     this,
-                    getString(R.string.toast_location_not_provided),
+                    getString(R.string.courses_location_not_provided_message),
                     Toast.LENGTH_SHORT,
                 ).show()
             return
@@ -408,7 +408,7 @@ class CoursesActivity :
                 Toast
                     .makeText(
                         this,
-                        getString(R.string.toast_failed_to_get_current_location),
+                        getString(R.string.courses_failed_to_get_current_location_message),
                         Toast.LENGTH_SHORT,
                     ).show()
             },
@@ -724,7 +724,7 @@ class CoursesActivity :
                     Toast
                         .makeText(
                             this,
-                            getString(R.string.toast_failed_to_load_course),
+                            getString(R.string.courses_failed_to_load_course_message),
                             Toast.LENGTH_SHORT,
                         ).show()
                 }
@@ -749,7 +749,7 @@ class CoursesActivity :
                     Toast
                         .makeText(
                             this,
-                            getString(R.string.toast_failed_to_find_route_to_course),
+                            getString(R.string.courses_failed_to_find_route_to_course_message),
                             Toast.LENGTH_SHORT,
                         ).show()
                 }
@@ -758,7 +758,7 @@ class CoursesActivity :
                     Toast
                         .makeText(
                             this,
-                            getString(R.string.toast_no_network_connection_for_route),
+                            getString(R.string.courses_no_network_connection_for_route_message),
                             Toast.LENGTH_SHORT,
                         ).show()
                 }
@@ -776,7 +776,7 @@ class CoursesActivity :
                     Toast
                         .makeText(
                             this,
-                            getString(R.string.toast_failed_to_find_route_to_course),
+                            getString(R.string.courses_failed_to_find_route_to_course_message),
                             Toast.LENGTH_SHORT,
                         ).show()
                 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/routefinder/RouteFinderApplication.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/routefinder/RouteFinderApplication.kt
@@ -92,7 +92,7 @@ sealed interface RouteFinderApplication : Parcelable {
                 Toast
                     .makeText(
                         context,
-                        context.getString(R.string.toast_failed_to_launch_route_finder_app),
+                        context.getString(R.string.selected_route_finder_application_failed_to_launch_route_finder_app_message),
                         Toast.LENGTH_SHORT,
                     ).show()
             }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,6 +3,16 @@
 
     <!--  코스 화면  -->
     <string name="courses_press_back_to_exit_message">버튼을 한 번 더 누르면 종료됩니다.</string>
+    <string name="courses_client_id_copied_message">사용자 ID가 복사됐습니다.</string>
+    <string name="courses_failed_to_calculate_length_range_message">탐색 범위를 계산하지 못했습니다.</string>
+    <string name="courses_failed_to_get_map_location_message">지도 위치를 가져올 수 없습니다.</string>
+    <string name="courses_search_information_not_provided_message">검색 정보가 전달되지 않았습니다.</string>
+    <string name="courses_location_not_provided_message">위치 정보가 전달되지 않았습니다.</string>
+    <string name="courses_failed_to_get_current_location_message">현재 위치를 불러오지 못했습니다.</string>
+    <string name="courses_failed_to_load_course_message">코스 정보를 불러오지 못했습니다.</string>
+    <string name="courses_failed_to_find_route_to_course_message">코스까지 가는 길을 찾지 못했습니다.</string>
+    <string name="courses_no_network_connection_for_route_message">네트워크에 연결되지 않아 길찾기에 실패했습니다.</string>
+    <string name="courses_search_unavailable_message">현재 검색 기능을 사용할 수 없습니다.</string>
 
     <!--  코스 화면 - 코스 목록 아이템  -->
     <string name="course_item_unit_meter">%dm</string>
@@ -70,6 +80,7 @@
     <string name="selected_route_finder_application_entry_kakao_map">카카오맵에서 보기</string>
     <string name="selected_route_finder_application_entry_naver_map">네이버 지도에서 보기</string>
     <string name="selected_route_finder_application_entry_none_map">선택 안 함</string>
+    <string name="selected_route_finder_application_failed_to_launch_route_finder_app_message">길찾기 앱을 실행할 수 없습니다.</string>
 
     <!--  공지 다이얼로그  -->
     <string name="notice_dialog_do_not_show_again_button">다시 보지 않음</string>
@@ -86,16 +97,4 @@
     <string name="selected_route_finder_application_value_naver">naver map</string>
     <string name="selected_route_finder_application_value_none">none</string>
 
-    <!--  토스트 메시지 문자열  -->
-    <string name="toast_client_id_copied">사용자 ID가 복사됐습니다.</string>
-    <string name="toast_failed_to_launch_route_finder_app">길찾기 앱을 실행할 수 없습니다.</string>
-    <string name="toast_failed_to_calculate_length_range">탐색 범위를 계산하지 못했습니다.</string>
-    <string name="toast_failed_to_get_map_location">지도 위치를 가져올 수 없습니다.</string>
-    <string name="toast_search_information_not_provided">검색 정보가 전달되지 않았습니다.</string>
-    <string name="toast_location_not_provided">위치 정보가 전달되지 않았습니다.</string>
-    <string name="toast_failed_to_get_current_location">현재 위치를 불러오지 못했습니다.</string>
-    <string name="toast_failed_to_load_course">코스 정보를 불러오지 못했습니다.</string>
-    <string name="toast_failed_to_find_route_to_course">코스까지 가는 길을 찾지 못했습니다.</string>
-    <string name="toast_no_network_connection_for_route">네트워크에 연결되지 않아 길찾기에 실패했습니다.</string>
-    <string name="toast_search_unavailable">현재 검색 기능을 사용할 수 없습니다.</string>
 </resources>


### PR DESCRIPTION
## 🛠️ 설명
- 하드코딩된 `Toast` 메시지를 `string resource`로 분리

## 🔍 리뷰 요청사항
- `string name`에 대해서 의견이 있으시면, 코멘트 부탁드립니다!

## 🔗 관련 이슈
- closes #737 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **지역화**
  * 여러 화면의 하드코딩 알림 메시지를 문자열 리소스로 전환하여 한국어 지원을 개선했습니다.
  * 위치 조회, 검색 불가, 클립보드 복사, 지도/경로 오류 등 사용자 안내 메시지 11개를 추가 및 적용했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->