### PR TITLE
PR 코드리뷰 마감일 라벨 자동으로 관리하는 스크립트 작성

### DIFF
--- a/.github/workflows/pr-auto-labeling.yml
+++ b/.github/workflows/pr-auto-labeling.yml
@@ -32,7 +32,6 @@ jobs:
         uses: kkiseug/pr-deadline-labeler@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          base-date: ${{ github.event.pull_request.created_at }}
 
       - name: 리뷰 제출 시 마감일로 라벨 조정
         if: github.event_name == 'pull_request_review'


### PR DESCRIPTION
## 🛠️ 설명
- 이제 PR에 코드리뷰 마감일 D-Day 라벨이 자동으로 삽입됩니다.
  - 직접!! 라이브러리를 우리 팀에 맞게 만들어 봤어요. [관련 레포지토리](https://github.com/kkiseug/pr-deadline-labeler)
- 트리거를 보시면 아시겠지만, 작동되는 방식은 3가지 입니다.
  - pr이 생성될 때: 마감일 (2일) 기준으로 라벨을 업데이트 합니다.
  - 매일 자정에: 어제 라벨을 기준으로 -1 하여 라벨을 업데이트 합니다.
  - 리뷰가 달렸을 때: 마감일 (2일) 기준으로 라벨을 업데이트 합니다.

## 🔗 관련 이슈

- closes #739 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **작업 (Chores)**
  * PR 자동 라벨링 워크플로우를 추가했습니다. PR 생성, 정기 스케줄(일간), 검토 제출 시 트리거되어 각 이벤트 시점을 기준으로 자동으로 라벨을 적용합니다. 이로써 PR 관리 시 수동 분류 부담이 줄고 라벨링 일관성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->