### PR TITLE
fix: 즐겨찾기 코스 선택 시 새 코스가 불러와지는 현상 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -250,7 +250,12 @@ class CoursesActivity :
         val clipboard = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
         val clip: ClipData = ClipData.newPlainText(null, coursePickApplication.installationId.value)
         clipboard.setPrimaryClip(clip)
-        Toast.makeText(this, getString(R.string.courses_client_id_copied_message), Toast.LENGTH_SHORT).show()
+        Toast
+            .makeText(
+                this,
+                getString(R.string.courses_client_id_copied_message),
+                Toast.LENGTH_SHORT,
+            ).show()
     }
 
     override fun clearQuery() {
@@ -741,7 +746,10 @@ class CoursesActivity :
                         supportFragmentManager.findFragmentByTag(
                             ExploreCoursesFragment::class.java.name,
                         ) as? ExploreCoursesFragment
-                    fragment?.scrollTo(event.course)
+
+                    if (viewModel.content.value == CoursesContent.EXPLORE) {
+                        fragment?.scrollTo(event.course)
+                    }
                 }
 
                 is CoursesUiEvent.FetchRouteToCourseSuccess -> {


### PR DESCRIPTION
## 🛠️ 설명

- 즐겨찾기된 코스를 선택할 시 코스 페이지가 추가로 로드되는 현상이 수정됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 수동 과정 선택 시 불필요한 스크롤 동작이 발생하는 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->