### PR TITLE
chore: 라벨 업데이트 시 디스코드 알림도 전송하도록 변경

### DIFF
--- a/.github/workflows/pr-auto-labeling.yml
+++ b/.github/workflows/pr-auto-labeling.yml
@@ -36,9 +36,10 @@ jobs:
           ASSIGNEES: ${{ join(github.event.pull_request.assignees.*.login, ', ') }}
           REVIEWERS: ${{ join(github.event.pull_request.requested_reviewers.*.login, ', ') }}
         run: |
-          BODY=$(jq -n \
-            --arg desc "#${PR_NUMBER}가 등록되었습니다!\n담당자: ${ASSIGNEES}\n리뷰어: ${REVIEWERS}\n-> [당장 리뷰하러 가기](${PR_URL})" \
-            '{"embeds":[{"description":$desc,"color":5814783}]}')
+          DESC=$(printf "#%s가 등록되었습니다!\n담당자: %s\n리뷰어: %s\n-> [당장 리뷰하러 가기](%s)" \
+              "$PR_NUMBER" "$ASSIGNEE_MENTIONS" "$REVIEWER_MENTIONS" "$PR_URL")
+          
+          BODY=$(jq -n --arg desc "$DESC" '{"embeds":[{"description":$desc,"color":5814783}]}')
           
           curl -s -X POST "$DISCORD_WEBHOOK" \
             -H "Content-Type: application/json" \
@@ -74,9 +75,10 @@ jobs:
           
             DAYS="${LABEL#D-}"
           
-            BODY=$(jq -n \
-              --arg desc "#${PR_NUMBER}가 D-${DAYS}일 남았습니다!\n담당자: ${ASSIGNEES}\n리뷰어: ${REVIEWERS}\n-> [당장 리뷰하러 가기](${PR_URL})" \
-              '{"embeds":[{"description":$desc,"color":15548997}]}')
+            DESC=$(printf "#%s가 D-%s일 남았습니다!\n담당자: %s\n리뷰어: %s\n-> [당장 리뷰하러 가기](%s)" \
+              "$PR_NUMBER" "$DAYS" "$ASSIGNEE_MENTIONS" "$REVIEWER_MENTIONS" "$PR_URL")
+  
+            BODY=$(jq -n --arg desc "$DESC" '{"embeds":[{"description":$desc,"color":15548997}]}')
           
             curl -s -X POST "$DISCORD_WEBHOOK" \
               -H "Content-Type: application/json" \


### PR DESCRIPTION
## 🛠️ 설명

## 📸 스크린샷 / 동영상

| AS-IS | TO-BE |
|-------|-------|
| 전     | 후     |

## 🔍 리뷰 요청사항

## 🔗 관련 이슈

- closes #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * PR 생성 시 관련 정보(번호, 담당자, 검토자, 링크)를 Discord로 자동 알림하도록 추가
  * 자정 스케줄로 열린 PR을 검사해 D-n(마감일) 라벨이 있는 PR의 남은 일수를 계산해 Discord로 일괄 알림하도록 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->