### PR TITLE
PR 자동 라벨 부착 후 디스코드 알림 보내기 기능 구현

### DIFF
--- a/.github/workflows/pr-auto-labeling.yml
+++ b/.github/workflows/pr-auto-labeling.yml
@@ -101,7 +101,7 @@ jobs:
             PR_NUMBER=$(echo "$PR" | jq -r '.number')
             PR_URL=$(echo "$PR"    | jq -r '.html_url')
             PR_TITLE=$(echo "$PR"  | jq -r '.title')
-            LABEL=$(echo "$PR"    | jq -r '.labels[].name' | grep -E '^D-[0-9]+$' | head -1)
+            LABEL=$(echo "$PR" | jq -r '.labels[].name' | grep -E '^(D-[0-9]+|D-Day)$' | head -1)
           
             [ -z "$LABEL" ] && continue
           
@@ -115,7 +115,7 @@ jobs:
             [ -z "$ASSIGNEES" ] && ASSIGNEES="없음"
             [ -z "$REVIEWERS" ] && REVIEWERS="없음"
           
-            MSG=$(printf "**#%s PR이 D-%s일 남았습니다!**\n**제목**: %s\n**담당자**: %s\n**리뷰어**: %s\n▶ [당장 리뷰하러 가기](%s) ◀" \
+            MSG=$(printf "**#%s PR이 %s 상태입니다!**\n**제목**: %s\n**담당자**: %s\n**리뷰어**: %s\n▶ [당장 리뷰하러 가기](%s) ◀" \
               "$PR_NUMBER" "$DAYS" "$PR_TITLE" "$ASSIGNEES" "$REVIEWERS" "$PR_URL")
           
             BODY=$(jq -n --arg content "$MSG" '{"content": $content, "flags": 4}')


### PR DESCRIPTION
## 🛠️ 설명
- 라벨을 부착 후 디스코드 알림을 보냅니다.
- 리뷰 등록 시에는 알림을 따로 보내지는 않고, PR 생성/자정 라벨 업데이트 시에만 알림을 보내도록 했습니다.

## 📸 스크린샷 / 동영상
<img width="471" height="153" alt="스크린샷 2026-03-03 13 12 26" src="https://github.com/user-attachments/assets/7ccf4dce-757b-41c7-8413-fe352d28ea75" />

## 🔗 관련 이슈

- closes #748 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* PR 생성 시 Discord 알림 자동 전송 (PR 번호, 제목, 담당자, 검토자 포함)
* 매일 자정 열린 PR 상태 모니터링 및 Discord 알림 전송

<!-- end of auto-generated comment: release notes by coderabbit.ai -->