### PR TITLE
안드로이드 내부 테스트용 CD 파이프라인 추가

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -1,4 +1,4 @@
-name: Android CD (Deploy to PlayStore directly)
+name: Android CD (Deploy to PlayStore as Internal Testing)
 
 on:
   # Github Action 탭에서 수동으로 실행
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
 
   deploy:
-    name: 플레이스토어 배포
+    name: 플레이스토어 내부 테스트 배포
     needs: ci
     runs-on: ubuntu-latest
     # Job에 권한을 부여하여 Google Cloud 인증 토큰을 발급받을 수 있도록 합니다.


### PR DESCRIPTION
## 🛠️ 설명

플레이 스토어 배포를 테스트할 수 있도록 내부 테스트용 CD 파이프라인이 추가됩니다. 플레이 스토어 인앱 업데이트 기능을 테스트하기 위해 사용될 예정입니다. [관련 이슈](https://github.com/woowacourse-teams/2025-course-pick/issues/772)

배포용 CD와 동일하지만, `TRACK` 값에 `production` 대신 `qa`를 사용해서 배포가 아닌 내부 테스트로 등록되도록 합니다. [관련 문서](https://developers.google.com/android-publisher/tracks#adding_and_modifying_apks)


## 🔗 관련 이슈

- closes #773


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Android 배포 대상이 프로덕션에서 QA(내부 테스트)로 변경되었습니다.
  * 배포 워크플로우 및 작업명이 내부 테스트/QA를 반영하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->