### PR TITLE
안드로이드 CD 수정

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -95,7 +95,7 @@ jobs:
           echo "Selected Update Type: $UPDATE_TYPE -> Priority: $PRIORITY_VALUE"
           PACKAGE_NAME="${{ secrets.ANDROID_PACKAGE_NAME }}"
           AAB_PATH="android/app/build/outputs/bundle/release/app-release.aab"
-          TRACK="qa"
+          TRACK="internal"
 
           # 인증된 액세스 토큰 가져오기 (참조 방식 변경)
           ACCESS_TOKEN="${{ steps.generate_token.outputs.access_token }}"


### PR DESCRIPTION
## 🛠️ 설명
안드로이드 CD가 정상 동작하도록 수정합니다.

[이 문서](https://developers.google.com/android-publisher/tracks#adding_and_modifying_apks)를 보고 내부 테스트는 `track` 값이 `qa`인줄 알았는데, [이전 CD](https://github.com/woowacourse-teams/2025-course-pick/actions/runs/17663035226/workflow)를 보니 `internal`인 것으로 보이네요 🤔


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **내부 개선**
  * Play Store 배포 워크플로우 설정이 업데이트되었습니다.

---

**사용자 영향**: 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->