### PR TITLE
Douglas-Peucker 알고리즘을 통해 코스 좌표 단순화 적용

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.9")
 
+    // Zstandard Compression
+    implementation("com.github.luben:zstd-jni:1.5.7-1")
+
     // JSpecify
     compileOnly("org.jspecify:jspecify:1.0.0")
 

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -61,6 +61,14 @@ public enum ErrorType {
             "쿼리 실행에 제한된 시간을 초과했습니다.",
             QueryTimeoutException::new
     ),
+    COMPRESS_FAIL(
+            "압축에 실패했습니다.",
+            RuntimeException::new
+    ),
+    DECOMPRESS_FAIL(
+            "압축 해제에 실패했습니다.",
+            RuntimeException::new
+    ),
     ;
 
     private final String message;

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -62,11 +62,11 @@ public enum ErrorType {
             QueryTimeoutException::new
     ),
     COMPRESS_FAIL(
-            "압축에 실패했습니다.",
+            "압축에 실패했습니다. 원인=%s",
             RuntimeException::new
     ),
     DECOMPRESS_FAIL(
-            "압축 해제에 실패했습니다.",
+            "압축 해제에 실패했습니다. 원인=%s",
             RuntimeException::new
     ),
     INVALID_COMPRESS_DATA(

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -69,6 +69,10 @@ public enum ErrorType {
             "압축 해제에 실패했습니다.",
             RuntimeException::new
     ),
+    INVALID_COMPRESS_DATA(
+            "압축 및 해제할 데이터가 없습니다.",
+            IllegalArgumentException::new
+    ),
     ;
 
     private final String message;

--- a/backend/src/main/java/coursepick/coursepick/domain/course/CoordinateBuilder.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/CoordinateBuilder.java
@@ -68,6 +68,61 @@ public class CoordinateBuilder {
         return new CoordinateBuilder(smoothCoordinates);
     }
 
+    /**
+     * Douglas-Peucker 알고리즘을 사용하여 경로를 단순화합니다.
+     * <br>
+     * 오차 범위(tolerance) 내에 있는 점들을 제거하여 꼭짓점 수를 줄입니다.
+     */
+    public CoordinateBuilder simplify(Meter tolerance) {
+        if (coordinates.size() <= 2) {
+            return this;
+        }
+
+        boolean[] kept = new boolean[coordinates.size()];
+        kept[0] = true;
+        kept[coordinates.size() - 1] = true;
+
+        simplifyRecursive(0, coordinates.size() - 1, tolerance, kept);
+
+        List<Coordinate> simplified = new ArrayList<>();
+        for (int i = 0; i < coordinates.size(); i++) {
+            if (kept[i]) {
+                simplified.add(coordinates.get(i));
+            }
+        }
+
+        return new CoordinateBuilder(simplified);
+    }
+
+    private void simplifyRecursive(int first, int last, Meter tolerance, boolean[] kept) {
+        if (first + 1 >= last) {
+            return;
+        }
+
+        double maxDistance = -1.0;
+        int maxIndex = -1;
+
+        GeoLine line = GeoLine.between(coordinates.get(first), coordinates.get(last));
+
+        for (int i = first + 1; i < last; i++) {
+            Coordinate target = coordinates.get(i);
+            Coordinate closest = line.closestCoordinateFrom(target);
+            double distance = GeoLine.between(target, closest).length().value();
+
+            if (distance > maxDistance) {
+                maxDistance = distance;
+                maxIndex = i;
+            }
+        }
+
+        if (maxDistance > tolerance.value()) {
+            kept[maxIndex] = true;
+            simplifyRecursive(first, maxIndex, tolerance, kept);
+            simplifyRecursive(maxIndex, last, tolerance, kept);
+        }
+    }
+
+
     public List<Coordinate> build() {
         return Collections.unmodifiableList(coordinates);
     }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -25,8 +25,10 @@ public class Course {
     @Indexed(name = "idx_name", unique = true)
     private CourseName name;
 
-    @GeoSpatialIndexed(name = "idx_geo_coordinates", type = GeoSpatialIndexType.GEO_2DSPHERE)
     private List<Coordinate> coordinates;
+
+    @GeoSpatialIndexed(name = "idx_geo_simplified_coordinates", type = GeoSpatialIndexType.GEO_2DSPHERE)
+    private List<Coordinate> simplifiedCoordinates;
 
     private Meter length;
 
@@ -34,6 +36,7 @@ public class Course {
         this.id = id;
         this.name = new CourseName(name);
         this.coordinates = refineCoordinates(rawCoordinates);
+        this.simplifiedCoordinates = simplifyCoordinates(this.coordinates);
         this.length = calculateLength(coordinates);
     }
 
@@ -41,6 +44,12 @@ public class Course {
         return CoordinateBuilder.fromRawCoordinates(rawCoordinates)
                 .removeSimilar()
                 .smooth()
+                .build();
+    }
+
+    private List<Coordinate> simplifyCoordinates(List<Coordinate> coordinates) {
+        return CoordinateBuilder.fromRawCoordinates(coordinates)
+                .simplify(new Meter(10))
                 .build();
     }
 
@@ -77,6 +86,7 @@ public class Course {
 
     public void changeCoordinates(List<Coordinate> coordinates) {
         this.coordinates = refineCoordinates(coordinates);
+        this.simplifiedCoordinates = simplifyCoordinates(this.coordinates);
         this.length = calculateLength(this.coordinates);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/DataCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/DataCompressor.java
@@ -1,0 +1,8 @@
+package coursepick.coursepick.infrastructure.compressor;
+
+public interface DataCompressor {
+
+    byte[] compress(String content);
+
+    String decompress(byte[] compressed, int originalSize);
+}

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
@@ -1,5 +1,7 @@
 package coursepick.coursepick.infrastructure.compressor;
 
+import coursepick.coursepick.application.exception.ErrorType;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -13,7 +15,7 @@ public class GzipCompressor implements DataCompressor {
 
     public byte[] compress(String content) {
         if (content == null || content.isBlank()) {
-            throw INVALID_COORDINATE_COUNT.create();
+            throw INVALID_COMPRESS_DATA.create();
         }
 
         byte[] input = content.getBytes(StandardCharsets.UTF_8);
@@ -31,7 +33,7 @@ public class GzipCompressor implements DataCompressor {
 
     public String decompress(byte[] bytes, int originalSize) {
         if (bytes == null || bytes.length == 0) {
-            throw INVALID_COORDINATE_COUNT.create();
+            throw INVALID_COMPRESS_DATA.create();
         }
 
         try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(bytes));

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
@@ -1,44 +1,50 @@
 package coursepick.coursepick.infrastructure.compressor;
 
-import coursepick.coursepick.domain.course.Coordinate;
-
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.List;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import org.bson.Document;
+import static coursepick.coursepick.application.exception.ErrorType.*;
 
-public class GzipCompressor {
+public class GzipCompressor implements DataCompressor {
 
-    private Document convertCoordinatesToByteArray(List<Coordinate> coordinates) throws IOException {
-        List<List<Double>> coordinatesData = coordinates.stream()
-                .map(coordinate -> List.of(coordinate.longitude(), coordinate.latitude()))
-                .toList();
+    public byte[] compress(String content) {
+        if (content == null || content.isBlank()) {
+            throw INVALID_COORDINATE_COUNT.create();
+        }
+
+        byte[] input = content.getBytes(StandardCharsets.UTF_8);
 
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
-        gzipOutputStream.write(compress(coordinatesData));
-        gzipOutputStream.flush();
-        gzipOutputStream.close();
+        try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
+            gzipOutputStream.write(input);
+            gzipOutputStream.finish();
+        } catch (IOException e) {
+            throw COMPRESS_FAIL.create(e.getMessage());
+        }
 
-        Document document = new Document();
-        document.put("coordinates", byteArrayOutputStream.toByteArray());
-
-        return document;
+        return byteArrayOutputStream.toByteArray();
     }
 
-    public static byte[] compress(List<List<Double>> data) {
-        int count = data.size();
-        // 헤더(개수 정보 4바이트) + (경도 8바이트 + 위도 8바이트) * 개수
-        ByteBuffer buffer = ByteBuffer.allocate(4 + (count * 2 * 8));
-
-        buffer.putInt(count); // 좌표가 몇 개인지 먼저 기록 (복원용)
-        for (List<Double> coord : data) {
-            buffer.putDouble(coord.get(0)); // Longitude
-            buffer.putDouble(coord.get(1)); // Latitude
+    public String decompress(byte[] bytes, int originalSize) {
+        if (bytes == null || bytes.length == 0) {
+            throw INVALID_COORDINATE_COUNT.create();
         }
-        return buffer.array();
+
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(bytes));
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream(originalSize)) {
+
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gzipInputStream.read(buffer)) > 0) {
+                outputStream.write(buffer, 0, len);
+            }
+            return outputStream.toString(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw DECOMPRESS_FAIL.create(e.getMessage());
+        }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
@@ -1,7 +1,5 @@
 package coursepick.coursepick.infrastructure.compressor;
 
-import coursepick.coursepick.application.exception.ErrorType;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/GzipCompressor.java
@@ -1,0 +1,44 @@
+package coursepick.coursepick.infrastructure.compressor;
+
+import coursepick.coursepick.domain.course.Coordinate;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import org.bson.Document;
+
+public class GzipCompressor {
+
+    private Document convertCoordinatesToByteArray(List<Coordinate> coordinates) throws IOException {
+        List<List<Double>> coordinatesData = coordinates.stream()
+                .map(coordinate -> List.of(coordinate.longitude(), coordinate.latitude()))
+                .toList();
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
+        gzipOutputStream.write(compress(coordinatesData));
+        gzipOutputStream.flush();
+        gzipOutputStream.close();
+
+        Document document = new Document();
+        document.put("coordinates", byteArrayOutputStream.toByteArray());
+
+        return document;
+    }
+
+    public static byte[] compress(List<List<Double>> data) {
+        int count = data.size();
+        // 헤더(개수 정보 4바이트) + (경도 8바이트 + 위도 8바이트) * 개수
+        ByteBuffer buffer = ByteBuffer.allocate(4 + (count * 2 * 8));
+
+        buffer.putInt(count); // 좌표가 몇 개인지 먼저 기록 (복원용)
+        for (List<Double> coord : data) {
+            buffer.putDouble(coord.get(0)); // Longitude
+            buffer.putDouble(coord.get(1)); // Latitude
+        }
+        return buffer.array();
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/ZstdCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/ZstdCompressor.java
@@ -1,5 +1,7 @@
 package coursepick.coursepick.infrastructure.compressor;
 
+import static coursepick.coursepick.application.exception.ErrorType.INVALID_COMPRESS_DATA;
+
 import com.github.luben.zstd.Zstd;
 
 import java.nio.charset.StandardCharsets;
@@ -10,7 +12,7 @@ public class ZstdCompressor implements DataCompressor {
 
     public byte[] compress(String content) {
         if (content == null || content.isBlank()) {
-            return new byte[0];
+            throw INVALID_COMPRESS_DATA.create();
         }
 
         byte[] input = content.getBytes(StandardCharsets.UTF_8);
@@ -19,7 +21,7 @@ public class ZstdCompressor implements DataCompressor {
 
     public String decompress(byte[] compressed, int originalSize) {
         if (compressed == null || compressed.length == 0) {
-            return "";
+            throw INVALID_COMPRESS_DATA.create();
         }
 
         byte[] decompressed = Zstd.decompress(compressed, originalSize);

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/ZstdCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/ZstdCompressor.java
@@ -1,0 +1,28 @@
+package coursepick.coursepick.infrastructure.compressor;
+
+import com.github.luben.zstd.Zstd;
+
+import java.nio.charset.StandardCharsets;
+
+public class ZstdCompressor implements DataCompressor {
+
+    private static final int COMPRESSION_LEVEL = 3;
+
+    public byte[] compress(String content) {
+        if (content == null || content.isBlank()) {
+            return new byte[0];
+        }
+
+        byte[] input = content.getBytes(StandardCharsets.UTF_8);
+        return Zstd.compress(input, COMPRESSION_LEVEL);
+    }
+
+    public String decompress(byte[] compressed, int originalSize) {
+        if (compressed == null || compressed.length == 0) {
+            return "";
+        }
+
+        byte[] decompressed = Zstd.decompress(compressed, originalSize);
+        return new String(decompressed, StandardCharsets.UTF_8);
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/ZstdCompressor.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/compressor/ZstdCompressor.java
@@ -1,10 +1,10 @@
 package coursepick.coursepick.infrastructure.compressor;
 
-import static coursepick.coursepick.application.exception.ErrorType.INVALID_COMPRESS_DATA;
-
 import com.github.luben.zstd.Zstd;
 
 import java.nio.charset.StandardCharsets;
+
+import static coursepick.coursepick.application.exception.ErrorType.INVALID_COMPRESS_DATA;
 
 public class ZstdCompressor implements DataCompressor {
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
@@ -24,6 +24,7 @@ public abstract class CourseConverter {
             }
             document.put("name", source.name().value());
             document.put("coordinates", convertCoordinatesToGeoJson(source.coordinates()));
+            document.put("simplifiedCoordinates", convertCoordinatesToGeoJson(source.simplifiedCoordinates()));
             document.put("length", source.length().value());
             document.put("schemaVersion", 1);
             return document;

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
@@ -8,7 +8,11 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
 public abstract class CourseConverter {
 
@@ -23,7 +27,11 @@ public abstract class CourseConverter {
                 document.put("_id", new ObjectId(source.id()));
             }
             document.put("name", source.name().value());
-            document.put("coordinates", convertCoordinatesToGeoJson(source.coordinates()));
+            try {
+                document.put("coordinates", convertCoordinatesToByteArray(source.coordinates()));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
             document.put("simplifiedCoordinates", convertCoordinatesToGeoJson(source.simplifiedCoordinates()));
             document.put("length", source.length().value());
             document.put("schemaVersion", 1);
@@ -40,6 +48,36 @@ public abstract class CourseConverter {
             document.put("coordinates", coordinatesData);
 
             return document;
+        }
+
+        private Document convertCoordinatesToByteArray(List<Coordinate> coordinates) throws IOException {
+            List<List<Double>> coordinatesData = coordinates.stream()
+                    .map(coordinate -> List.of(coordinate.longitude(), coordinate.latitude()))
+                    .toList();
+
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
+            gzipOutputStream.write(compress(coordinatesData));
+            gzipOutputStream.flush();
+            gzipOutputStream.close();
+
+            Document document = new Document();
+            document.put("coordinates", byteArrayOutputStream.toByteArray());
+
+            return document;
+        }
+
+        public static byte[] compress(List<List<Double>> data) {
+            int count = data.size();
+            // 헤더(개수 정보 4바이트) + (경도 8바이트 + 위도 8바이트) * 개수
+            ByteBuffer buffer = ByteBuffer.allocate(4 + (count * 2 * 8));
+
+            buffer.putInt(count); // 좌표가 몇 개인지 먼저 기록 (복원용)
+            for (List<Double> coord : data) {
+                buffer.putDouble(coord.get(0)); // Longitude
+                buffer.putDouble(coord.get(1)); // Latitude
+            }
+            return buffer.array();
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
@@ -2,82 +2,29 @@ package coursepick.coursepick.infrastructure.mongodb;
 
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
+import coursepick.coursepick.infrastructure.compressor.DataCompressor;
+import coursepick.coursepick.infrastructure.compressor.ZstdCompressor;
 import org.bson.Document;
 import org.bson.types.ObjectId;
+import org.jspecify.annotations.NonNull;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.zip.GZIPOutputStream;
+import java.util.stream.Collectors;
 
 public abstract class CourseConverter {
 
-    private static final CourseReader COURSE_READER = new CourseReader();
+    private static final DataCompressor DATA_COMPRESSOR = new ZstdCompressor();
+    private static final CourseReader COURSE_READER = new CourseReader(DATA_COMPRESSOR);
+    private static final CourseWriter COURSE_WRITER = new CourseWriter(DATA_COMPRESSOR);
 
     @WritingConverter
     public static class Writer implements Converter<Course, Document> {
         @Override
         public Document convert(Course source) {
-            Document document = new Document();
-            if (source.id() != null && !source.id().isBlank()) {
-                document.put("_id", new ObjectId(source.id()));
-            }
-            document.put("name", source.name().value());
-            try {
-                document.put("coordinates", convertCoordinatesToByteArray(source.coordinates()));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            document.put("simplifiedCoordinates", convertCoordinatesToGeoJson(source.simplifiedCoordinates()));
-            document.put("length", source.length().value());
-            document.put("schemaVersion", 1);
-            return document;
-        }
-
-        private Document convertCoordinatesToGeoJson(List<Coordinate> coordinates) {
-            List<List<Double>> coordinatesData = coordinates.stream()
-                    .map(coordinate -> List.of(coordinate.longitude(), coordinate.latitude()))
-                    .toList();
-
-            Document document = new Document();
-            document.put("type", "LineString");
-            document.put("coordinates", coordinatesData);
-
-            return document;
-        }
-
-        private Document convertCoordinatesToByteArray(List<Coordinate> coordinates) throws IOException {
-            List<List<Double>> coordinatesData = coordinates.stream()
-                    .map(coordinate -> List.of(coordinate.longitude(), coordinate.latitude()))
-                    .toList();
-
-            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
-            gzipOutputStream.write(compress(coordinatesData));
-            gzipOutputStream.flush();
-            gzipOutputStream.close();
-
-            Document document = new Document();
-            document.put("coordinates", byteArrayOutputStream.toByteArray());
-
-            return document;
-        }
-
-        public static byte[] compress(List<List<Double>> data) {
-            int count = data.size();
-            // 헤더(개수 정보 4바이트) + (경도 8바이트 + 위도 8바이트) * 개수
-            ByteBuffer buffer = ByteBuffer.allocate(4 + (count * 2 * 8));
-
-            buffer.putInt(count); // 좌표가 몇 개인지 먼저 기록 (복원용)
-            for (List<Double> coord : data) {
-                buffer.putDouble(coord.get(0)); // Longitude
-                buffer.putDouble(coord.get(1)); // Latitude
-            }
-            return buffer.array();
+            return COURSE_WRITER.convert(source);
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -13,20 +13,11 @@ public class CourseReader implements Converter<Document, Course> {
 
     @Override
     public Course convert(Document source) {
-        List<Coordinate> coordinates = parseCoordinates(source.get("coordinates", Document.class));
-        List<Coordinate> simplifiedCoordinates;
-
-        if (source.containsKey("simplifiedCoordinates")) {
-            simplifiedCoordinates = parseCoordinates(source.get("simplifiedCoordinates", Document.class));
-        } else {
-            simplifiedCoordinates = coordinates; // Or use Course.simplifyCoordinates logic
-        }
-
         return new Course(
                 source.getObjectId("_id").toHexString(),
                 new CourseName(source.getString("name")),
-                coordinates,
-                simplifiedCoordinates,
+                parseCoordinates(source.get("coordinates", Document.class)),
+                parseCoordinates(source.get("simplifiedCoordinates", Document.class)),
                 new Meter(source.getDouble("length"))
         );
     }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -4,7 +4,19 @@ import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseName;
 import coursepick.coursepick.domain.course.Meter;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import java.util.ArrayList;
+
+import java.util.zip.GZIPInputStream;
+
 import org.bson.Document;
+import org.bson.types.Binary;
 import org.springframework.core.convert.converter.Converter;
 
 import java.util.List;
@@ -13,13 +25,17 @@ public class CourseReader implements Converter<Document, Course> {
 
     @Override
     public Course convert(Document source) {
-        return new Course(
-                source.getObjectId("_id").toHexString(),
-                new CourseName(source.getString("name")),
-                parseCoordinates(source.get("coordinates", Document.class)),
-                parseCoordinates(source.get("simplifiedCoordinates", Document.class)),
-                new Meter(source.getDouble("length"))
-        );
+        try {
+            return new Course(
+                    source.getObjectId("_id").toHexString(),
+                    new CourseName(source.getString("name")),
+                    parseByteCoordinates(source.get("coordinates", Document.class)),
+                    parseCoordinates(source.get("simplifiedCoordinates", Document.class)),
+                    new Meter(source.getDouble("length"))
+            );
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public List<Coordinate> parseCoordinates(Document source) {
@@ -31,5 +47,42 @@ public class CourseReader implements Converter<Document, Course> {
                         ((Number) coordinateData.get(0)).doubleValue()
                 ))
                 .toList();
+    }
+
+    public List<Coordinate> parseByteCoordinates(Document source) throws IOException {
+        Binary byteCoordinates = (Binary) source.get("coordinates");
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+
+        GZIPInputStream gzipInStream = new GZIPInputStream(
+                new BufferedInputStream(new ByteArrayInputStream(byteCoordinates.getData())));
+
+        int size = 0;
+        byte[] buffer = new byte[1024];
+        while ( (size = gzipInStream.read(buffer)) > 0 ) {
+            outStream.write(buffer, 0, size);
+        }
+        outStream.flush();
+        outStream.close();
+
+
+        List<List<Double>> coordinatesData = decompress(outStream.toByteArray());
+
+        return coordinatesData.stream()
+                .map(coordinateData -> new Coordinate(
+                        coordinateData.get(1),
+                        coordinateData.get(0)
+                ))
+                .toList();
+    }
+
+    public static List<List<Double>> decompress(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        int count = buffer.getInt(); // 첫 4바이트에서 개수 읽기
+
+        List<List<Double>> result = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            result.add(List.of(buffer.getDouble(), buffer.getDouble()));
+        }
+        return result;
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -13,19 +13,32 @@ public class CourseReader implements Converter<Document, Course> {
 
     @Override
     public Course convert(Document source) {
+        List<Coordinate> coordinates = parseCoordinates(source.get("coordinates", Document.class));
+        List<Coordinate> simplifiedCoordinates;
+
+        if (source.containsKey("simplifiedCoordinates")) {
+            simplifiedCoordinates = parseCoordinates(source.get("simplifiedCoordinates", Document.class));
+        } else {
+            simplifiedCoordinates = coordinates; // Or use Course.simplifyCoordinates logic
+        }
+
         return new Course(
                 source.getObjectId("_id").toHexString(),
                 new CourseName(source.getString("name")),
-                parseCoordinates(source.get("coordinates", Document.class)),
+                coordinates,
+                simplifiedCoordinates,
                 new Meter(source.getDouble("length"))
         );
     }
 
     public List<Coordinate> parseCoordinates(Document source) {
-        List<List<Double>> coordinatesData = (List<List<Double>>) source.get("coordinates");
+        List<List<Object>> coordinatesData = (List<List<Object>>) source.get("coordinates");
 
         return coordinatesData.stream()
-                .map(coordinateData -> new Coordinate(coordinateData.get(1), coordinateData.get(0)))
+                .map(coordinateData -> new Coordinate(
+                        ((Number) coordinateData.get(1)).doubleValue(),
+                        ((Number) coordinateData.get(0)).doubleValue()
+                ))
                 .toList();
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -4,41 +4,65 @@ import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseName;
 import coursepick.coursepick.domain.course.Meter;
-
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-
-import java.util.ArrayList;
-
-import java.util.zip.GZIPInputStream;
-
+import coursepick.coursepick.infrastructure.compressor.DataCompressor;
+import lombok.RequiredArgsConstructor;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.springframework.core.convert.converter.Converter;
 
+import java.util.ArrayList;
 import java.util.List;
 
+@RequiredArgsConstructor
 public class CourseReader implements Converter<Document, Course> {
+
+    private final DataCompressor dataCompressor;
 
     @Override
     public Course convert(Document source) {
-        try {
-            return new Course(
-                    source.getObjectId("_id").toHexString(),
-                    new CourseName(source.getString("name")),
-                    parseByteCoordinates(source.get("coordinates", Document.class)),
-                    parseCoordinates(source.get("simplifiedCoordinates", Document.class)),
-                    new Meter(source.getDouble("length"))
-            );
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        List<Coordinate> coordinates = parseCoordinatesFromSource(source);
+        List<Coordinate> simplifiedCoordinates = parseSimplifiedCoordinates(source);
+
+        return new Course(
+                source.getObjectId("_id").toHexString(),
+                new CourseName(source.getString("name")),
+                coordinates,
+                simplifiedCoordinates,
+                new Meter(source.getDouble("length"))
+        );
     }
 
-    public List<Coordinate> parseCoordinates(Document source) {
+    private List<Coordinate> parseCoordinatesFromSource(Document source) {
+        Document rawCoordinates = (Document) source.get("coordinates");
+
+        Binary binary = rawCoordinates.get("zip_coordinates", Binary.class);
+        int originalSize = rawCoordinates.getInteger("zip_size");
+
+        String json = dataCompressor.decompress(binary.getData(), originalSize);
+        return parseCoordinatesFromJson(json);
+    }
+
+    private List<Coordinate> parseCoordinatesFromJson(String json) {
+        // [ [lng, lat], [lng, lat] ] 형태 파싱
+        if (json == null || json.length() < 4) return List.of();
+
+        String content = json.substring(2, json.length() - 2);
+        String[] pairs = content.split("\\],\\[");
+
+        List<Coordinate> result = new ArrayList<>();
+        for (String pair : pairs) {
+            String[] coords = pair.split(",");
+            result.add(new Coordinate(Double.parseDouble(coords[1]), Double.parseDouble(coords[0])));
+        }
+        return result;
+    }
+
+    private List<Coordinate> parseSimplifiedCoordinates(Document source) {
+        Document simplified = (Document) source.get("simplifiedCoordinates");
+        return parseCoordinatesFromGeoJson(simplified);
+    }
+
+    private List<Coordinate> parseCoordinatesFromGeoJson(Document source) {
         List<List<Object>> coordinatesData = (List<List<Object>>) source.get("coordinates");
 
         return coordinatesData.stream()
@@ -47,42 +71,5 @@ public class CourseReader implements Converter<Document, Course> {
                         ((Number) coordinateData.get(0)).doubleValue()
                 ))
                 .toList();
-    }
-
-    public List<Coordinate> parseByteCoordinates(Document source) throws IOException {
-        Binary byteCoordinates = (Binary) source.get("coordinates");
-        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-
-        GZIPInputStream gzipInStream = new GZIPInputStream(
-                new BufferedInputStream(new ByteArrayInputStream(byteCoordinates.getData())));
-
-        int size = 0;
-        byte[] buffer = new byte[1024];
-        while ( (size = gzipInStream.read(buffer)) > 0 ) {
-            outStream.write(buffer, 0, size);
-        }
-        outStream.flush();
-        outStream.close();
-
-
-        List<List<Double>> coordinatesData = decompress(outStream.toByteArray());
-
-        return coordinatesData.stream()
-                .map(coordinateData -> new Coordinate(
-                        coordinateData.get(1),
-                        coordinateData.get(0)
-                ))
-                .toList();
-    }
-
-    public static List<List<Double>> decompress(byte[] bytes) {
-        ByteBuffer buffer = ByteBuffer.wrap(bytes);
-        int count = buffer.getInt(); // 첫 4바이트에서 개수 읽기
-
-        List<List<Double>> result = new ArrayList<>(count);
-        for (int i = 0; i < count; i++) {
-            result.add(List.of(buffer.getDouble(), buffer.getDouble()));
-        }
-        return result;
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
@@ -71,7 +71,7 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
     private static void addPositionAndScopeCriteria(CourseFindCondition condition, Query query) {
         GeoJsonPoint point = new GeoJsonPoint(condition.mapPosition().longitude(), condition.mapPosition().latitude());
 
-        Criteria criteria = Criteria.where("coordinates")
+        Criteria criteria = Criteria.where("simplifiedCoordinates")
                 .nearSphere(point)
                 .maxDistance(condition.scope().value());
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
@@ -1,0 +1,65 @@
+package coursepick.coursepick.infrastructure.mongodb;
+
+import coursepick.coursepick.domain.course.Coordinate;
+import coursepick.coursepick.domain.course.Course;
+
+import coursepick.coursepick.infrastructure.compressor.DataCompressor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.springframework.core.convert.converter.Converter;
+
+@RequiredArgsConstructor
+public class CourseWriter implements Converter<Course, Document> {
+
+    private final DataCompressor dataCompressor;
+
+    @Override
+    public Document convert(Course source) {
+        Document document = new Document();
+        if (source.id() != null && !source.id().isBlank()) {
+            document.put("_id", new ObjectId(source.id()));
+        }
+        document.put("name", source.name().value());
+
+        Document rawCoordinatesDoc = convertCoordinatesToCompressedData(source.coordinates());
+        document.put("coordinates", rawCoordinatesDoc);
+
+        document.put("simplifiedCoordinates", convertCoordinatesToGeoJson(source.simplifiedCoordinates()));
+
+        document.put("length", source.length().value());
+        document.put("schemaVersion", 1);
+        return document;
+    }
+
+    private String convertCoordinatesToJson(List<Coordinate> coordinates) {
+        return coordinates.stream()
+                .map(c -> "[" + c.longitude() + "," + c.latitude() + "]")
+                .collect(Collectors.joining(",", "[", "]"));
+    }
+
+    private Document convertCoordinatesToCompressedData(List<Coordinate> coordinates) {
+        String jsonCoordinates = convertCoordinatesToJson(coordinates);
+
+        Document rawCoordinatesDoc = new Document();
+        rawCoordinatesDoc.put("zip_coordinates", dataCompressor.compress(jsonCoordinates));
+        rawCoordinatesDoc.put("zip_size", jsonCoordinates.getBytes(java.nio.charset.StandardCharsets.UTF_8).length);
+        return rawCoordinatesDoc;
+    }
+
+    private Document convertCoordinatesToGeoJson(List<Coordinate> coordinates) {
+        List<List<Double>> coordinatesData = coordinates.stream()
+                .map(coordinate -> List.of(coordinate.longitude(), coordinate.latitude()))
+                .toList();
+
+        Document document = new Document();
+        document.put("type", "LineString");
+        document.put("coordinates", coordinatesData);
+
+        return document;
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CoordinateBuilderTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CoordinateBuilderTest.java
@@ -1,0 +1,60 @@
+package coursepick.coursepick.domain.course;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoordinateBuilderTest {
+
+    @Test
+    @DisplayName("Douglas-Peucker 알고리즘을 사용하여 경로를 단순화할 수 있다.")
+    void simplifyTest() {
+        // Given: 직선상에 있는 점들과 튀는 점 하나
+        List<Coordinate> coordinates = List.of(
+                new Coordinate(0, 0),
+                new Coordinate(0.00001, 0.00001), // 직선에 가까움
+                new Coordinate(0.00005, 0.00005), // 직선에 가까움
+                new Coordinate(0.0001, 0.0001),   // 직선에 가까움
+                new Coordinate(0.0002, 0.0005),   // 멀리 뜀 (특징점)
+                new Coordinate(0.0003, 0.0003),   // 다시 직선 근처
+                new Coordinate(0.0005, 0.0005)    // 마지막 점
+        );
+
+        CoordinateBuilder builder = CoordinateBuilder.fromRawCoordinates(coordinates);
+
+        // When: 10m 오차로 단순화
+        List<Coordinate> simplified = builder.simplify(new Meter(10)).build();
+
+        // Then: 점의 개수가 줄어들어야 함
+        assertThat(simplified.size()).isLessThan(coordinates.size());
+        assertThat(simplified.getFirst()).isEqualTo(new Coordinate(0, 0));
+        assertThat(simplified.getLast()).isEqualTo(new Coordinate(0.0005, 0.0005));
+    }
+
+    @Test
+    @DisplayName("직선 경로의 경우 첫 점과 끝 점만 남는다.")
+    void simplifyStraightLineTest() {
+        // Given: 완벽한 직선상에 있는 점들
+        List<Coordinate> coordinates = List.of(
+                new Coordinate(37.5, 127.0),
+                new Coordinate(37.51, 127.01),
+                new Coordinate(37.52, 127.02),
+                new Coordinate(37.53, 127.03),
+                new Coordinate(37.54, 127.04),
+                new Coordinate(37.55, 127.05)
+        );
+
+        CoordinateBuilder builder = CoordinateBuilder.fromRawCoordinates(coordinates);
+
+        // When: 아주 작은 오차로 단순화해도 직선이면 점이 많이 제거됨
+        List<Coordinate> simplified = builder.simplify(new Meter(1)).build();
+
+        // Then: 첫 점과 끝 점만 남음
+        assertThat(simplified).hasSize(2);
+        assertThat(simplified.getFirst()).isEqualTo(new Coordinate(37.5, 127.0));
+        assertThat(simplified.getLast()).isEqualTo(new Coordinate(37.55, 127.05));
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CoordinateBuilderTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CoordinateBuilderTest.java
@@ -1,6 +1,5 @@
 package coursepick.coursepick.domain.course;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -10,9 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CoordinateBuilderTest {
 
     @Test
-    @DisplayName("Douglas-Peucker 알고리즘을 사용하여 경로를 단순화할 수 있다.")
-    void simplifyTest() {
-        // Given: 직선상에 있는 점들과 튀는 점 하나
+    void Douglas_Peucker_알고리즘을_사용하여_경로를_단순화한다() {
+        // 직선상에 있는 점들과 튀는 점 하나
         List<Coordinate> coordinates = List.of(
                 new Coordinate(0, 0),
                 new Coordinate(0.00001, 0.00001), // 직선에 가까움
@@ -25,19 +23,17 @@ class CoordinateBuilderTest {
 
         CoordinateBuilder builder = CoordinateBuilder.fromRawCoordinates(coordinates);
 
-        // When: 10m 오차로 단순화
+        // 10m 오차로 단순화
         List<Coordinate> simplified = builder.simplify(new Meter(10)).build();
 
-        // Then: 점의 개수가 줄어들어야 함
+        // 점의 개수가 줄어들어야 함
         assertThat(simplified.size()).isLessThan(coordinates.size());
         assertThat(simplified.getFirst()).isEqualTo(new Coordinate(0, 0));
         assertThat(simplified.getLast()).isEqualTo(new Coordinate(0.0005, 0.0005));
     }
 
     @Test
-    @DisplayName("직선 경로의 경우 첫 점과 끝 점만 남는다.")
-    void simplifyStraightLineTest() {
-        // Given: 완벽한 직선상에 있는 점들
+    void 직선_경로의_경우_첫_점과_끝_점만_남는다() {
         List<Coordinate> coordinates = List.of(
                 new Coordinate(37.5, 127.0),
                 new Coordinate(37.51, 127.01),
@@ -49,10 +45,10 @@ class CoordinateBuilderTest {
 
         CoordinateBuilder builder = CoordinateBuilder.fromRawCoordinates(coordinates);
 
-        // When: 아주 작은 오차로 단순화해도 직선이면 점이 많이 제거됨
+        // 아주 작은 오차로 단순화해도 직선이면 점이 많이 제거됨
         List<Coordinate> simplified = builder.simplify(new Meter(1)).build();
 
-        // Then: 첫 점과 끝 점만 남음
+        // 첫 점과 끝 점만 남음
         assertThat(simplified).hasSize(2);
         assertThat(simplified.getFirst()).isEqualTo(new Coordinate(37.5, 127.0));
         assertThat(simplified.getLast()).isEqualTo(new Coordinate(37.55, 127.05));


### PR DESCRIPTION
## 🛠️ 설명
- 공간 쿼리를 최적화하기 위해 쿼리가 아닌 데이터를 [Douglas-Peucker 알고리즘](https://m.blog.naver.com/dorergiverny/223113215510)을 통해 최적화 합니다.
- 핵심 코드는 아래와 같습니다. 자세한 내용은 주석을 통해 설명해두었습니다.

```java
// 임계치(tolerance)
public CoordinateBuilder simplify(Meter tolerance) {
    if (coordinates.size() <= 2) {
        return this;
    }

    // 살릴 좌표를 결정하는 변수입니다.
    // 살릴 좌표라면 true
    // 버려도 되는 좌표라면 false
    boolean[] kept = new boolean[coordinates.size()];
    kept[0] = true;
    kept[coordinates.size() - 1] = true;

    simplifyRecursive(0, coordinates.size() - 1, tolerance, kept); // 실질적인 Douglas-Peucker 알고리즘 수행 부분

    // 결과를 기준으로 좌표를 단순화 합니다.
    List<Coordinate> simplified = new ArrayList<>();
    for (int i = 0; i < coordinates.size(); i++) {
        if (kept[i]) {
            simplified.add(coordinates.get(i));
        }
    }

    return new CoordinateBuilder(simplified);
}

private void simplifyRecursive(int first, int last, Meter tolerance, boolean[] kept) {
    if (first + 1 >= last) {
        return;
    }

    double maxDistance = -1.0;
    int maxIndex = -1;

    // 시작점과 끝점을 기준으로 직선을 그으며 시작합니다.
    // 블로그 글에서는 가장 먼 두 점을 찾아 시작하지만, 여기서는 시작점과 끝점을 이용했습니다.
    // 이유는 블로그는 닫힌 도형을 기준으로 하지만, 
    // 저희는 러닝 코스 데이터 특성상 시작점과 끝점이 이어지지 않은 경우가 많고, 중요할 수 있기 때문입니다.
    // 그래서 시작점과 끝점을 어느 상황에서도 살리기 위해 결정했습니다.
    GeoLine line = GeoLine.between(coordinates.get(first), coordinates.get(last));

    // 가장 먼 좌표를 찾는 과정입니다.
    // 블로그 설명에 따르면 2번 과정입니다.
    for (int i = first + 1; i < last; i++) {
        Coordinate target = coordinates.get(i);
        Coordinate closest = line.closestCoordinateFrom(target);
        double distance = GeoLine.between(target, closest).length().value();

        if (distance > maxDistance) {
            maxDistance = distance;
            maxIndex = i;
        }
    }

    // 가장 먼 좌표가 임계치를 넘어가는지 확인하고, 넘어가지 않으면 버리고
    // 넘으면 보존합니다.
    if (maxDistance > tolerance.value()) {
        kept[maxIndex] = true;
        // 살릴 좌표를 기준으로 '시작점-살릴 좌표', '살릴 좌표-끝점'을 재귀적으로 처리합니다.
        simplifyRecursive(first, maxIndex, tolerance, kept);
        simplifyRecursive(maxIndex, last, tolerance, kept);
    }
}
```
- 임계치(tolerance)는 **10m를 기준**으로 잡았습니다. 이유는 몇 개의 데이터를 뽑아 실험해보았는데,
<img width="1046" height="695" alt="스크린샷 2026-04-03 02 00 55" src="https://github.com/user-attachments/assets/5a0fc424-7b8c-4f07-90d7-bc9d5c6c1505" />
<img width="749" height="611" alt="스크린샷 2026-04-03 02 01 14" src="https://github.com/user-attachments/assets/393aa8f3-d37a-42bf-a415-173d479d41dd" />
<img width="746" height="615" alt="스크린샷 2026-04-03 02 01 20" src="https://github.com/user-attachments/assets/f22b8e3f-9a39-48fb-b478-c68537f8f565" />
<img width="1506" height="1333" alt="스크린샷 2026-04-02 23 31 57" src="https://github.com/user-attachments/assets/b12ae173-6354-4e78-b8bf-a9a02b9a86f4" />

- 특징점을 최대한 유지하면서 데이터가 많은 경우 90% 이상의 좌표 단순화를 시킬 수 있었기 때문입니다.


## 📸 스크린샷 / 동영상
### 개발서버 (t4g.small) 기준
#### 데이터 간소화 전 (2.8s)
<img width="1301" height="609" alt="스크린샷 2026-04-02 21 54 09" src="https://github.com/user-attachments/assets/8be073ac-261b-4896-aadd-a30b61169ab5" />

#### 데이터 간소화 후 (337ms)
<img width="1314" height="607" alt="알고리즘적용후" src="https://github.com/user-attachments/assets/9b1ef889-91a3-4701-9980-b5347595fb85" />

## 🔍 리뷰 요청사항
- 두 가지가 존재합니다.
1. 돔푸가 말해주신 GeoJson 포맷이 아닌 다른 포맷으로 저장해도 되지 않냐?
  - [2차원 구체 인덱스](https://www.mongodb.com/ko-kr/docs/manual/core/indexes/index-types/geospatial/2dsphere/#std-label-2dsphere-index) 문서에서 공간 인덱스는 GeoJson 형태이거나 레거시 쌍 좌표라고 합니다.
  - 근데, 레거시 쌍 좌표는 유클리드(평면)을 기준으로 해서 원래 의도를 지켜려면 GeoJson 형태로 저장해야 할 것 같습니다.

2. 단순화 된 좌표를 응답으로 주는 것
  - 이건 생각보다 단순화 된 좌표의 정확도가 높아서 생각해보았던 것입니다.
  - 위의 결과 사진을 보시면, 회색 선이 살짝 보이실텐데 그게 사실은 원본 좌표입니다.
  - 2번을 제외하고는 회색이 아예 안보이는 수준이라서 고민해봤습니다.
  - 근데, 저희가 코스 좌표를 일일히 수정해서 길에 맞췄던 것을 생각하면 필요없는 고민일 수도 있겠습니다.

## 🔗 관련 이슈

- closes #797 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 허용오차 기반 경로 단순화 기능 추가 — 코스 좌표 수 자동 축소

* **개선사항**
  * 단순화된 좌표를 별도 필드로 저장해 지리공간 인덱스로 활용(거리 검색에 적용)
  * 좌표 데이터를 압축 저장하고 조회 시 복원하는 흐름 도입 — 저장 효율 및 검색 성능 향상

* **테스트**
  * 단순화 동작을 검증하는 단위 테스트 추가

* **문서/오류**
  * 압축·해제 관련 사용자 친화적 오류 유형 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->