### PR TITLE
PR 리마인더 리뷰 작성 시 업데이트 제거 및 시간 변경

### DIFF
--- a/.github/workflows/pr-auto-labeling.yml
+++ b/.github/workflows/pr-auto-labeling.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened]
   schedule:
-    - cron: '0 15 * * *'
+    - cron: '0 1 * * *'
 
 jobs:
   label:

--- a/.github/workflows/pr-auto-labeling.yml
+++ b/.github/workflows/pr-auto-labeling.yml
@@ -5,8 +5,6 @@ on:
     types: [opened]
   schedule:
     - cron: '0 15 * * *'
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   label:
@@ -32,11 +30,3 @@ jobs:
         uses: kkiseug/pr-deadline-labeler@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 리뷰 제출 시 마감일로 라벨 조정
-        if: github.event_name == 'pull_request_review'
-        uses: kkiseug/pr-deadline-labeler@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          base-date: ${{ github.event.review.submitted_at }}
-          pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-auto-labeling.yml
+++ b/.github/workflows/pr-auto-labeling.yml
@@ -25,7 +25,7 @@ jobs:
           base-date: ${{ github.event.pull_request.created_at }}
           pr-number: ${{ github.event.pull_request.number }}
 
-      - name: 매일 자정에 라벨 업데이트
+      - name: 매일 오전 10시 라벨 업데이트
         if: github.event_name == 'schedule'
         uses: kkiseug/pr-deadline-labeler@v1
         with:


### PR DESCRIPTION
## 🛠️ 설명
- 기존에 있던 리뷰 작성 시 라벨 업데이트 항목을 제거했습니다.
- 그리고, 리마인드 알림 시간을 오전 10시로 변경했습니다.

## 🔗 관련 이슈

- closes #812 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 자동 레이블링 워크플로우의 예약 실행 시간이 변경되었습니다.
  * PR 리뷰 제출 시 자동으로 마감일 레이블을 조정하던 트리거가 제거되었습니다.

---

참고: 이 변경은 내부 워크플로우 조정으로, 사용자 경험에 직접적인 영향은 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->