### PR TITLE
json 파싱 및 변환을 objectMapper로 수행하도록 변경

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/domain/course/Coordinate.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Coordinate.java
@@ -1,7 +1,6 @@
 package coursepick.coursepick.domain.course;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.math.BigDecimal;

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Coordinate.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Coordinate.java
@@ -1,11 +1,17 @@
 package coursepick.coursepick.domain.course;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
 import static coursepick.coursepick.application.exception.ErrorType.INVALID_LATITUDE_RANGE;
 import static coursepick.coursepick.application.exception.ErrorType.INVALID_LONGITUDE_RANGE;
 
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder({ "longitude", "latitude" })
 public record Coordinate(
         double latitude,
         double longitude

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseConverter.java
@@ -1,38 +1,45 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
-import coursepick.coursepick.domain.course.Coordinate;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.infrastructure.compressor.DataCompressor;
 import coursepick.coursepick.infrastructure.compressor.ZstdCompressor;
 import org.bson.Document;
-import org.bson.types.ObjectId;
-import org.jspecify.annotations.NonNull;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 public abstract class CourseConverter {
 
     private static final DataCompressor DATA_COMPRESSOR = new ZstdCompressor();
-    private static final CourseReader COURSE_READER = new CourseReader(DATA_COMPRESSOR);
-    private static final CourseWriter COURSE_WRITER = new CourseWriter(DATA_COMPRESSOR);
 
     @WritingConverter
     public static class Writer implements Converter<Course, Document> {
+
+        private final CourseWriter courseWriter;
+
+        public Writer(ObjectMapper objectMapper) {
+            this.courseWriter = new CourseWriter(DATA_COMPRESSOR, objectMapper);
+        }
+
         @Override
         public Document convert(Course source) {
-            return COURSE_WRITER.convert(source);
+            return courseWriter.convert(source);
         }
     }
 
     @ReadingConverter
     public static class Reader implements Converter<Document, Course> {
+
+        private final CourseReader courseReader;
+
+        public Reader(ObjectMapper objectMapper) {
+            this.courseReader = new CourseReader(DATA_COMPRESSOR, objectMapper);
+        }
+
         @Override
         public Course convert(Document source) {
-            return COURSE_READER.convert(source);
+            return courseReader.convert(source);
         }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -1,5 +1,7 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseName;
@@ -10,13 +12,13 @@ import org.bson.Document;
 import org.bson.types.Binary;
 import org.springframework.core.convert.converter.Converter;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
 public class CourseReader implements Converter<Document, Course> {
 
     private final DataCompressor dataCompressor;
+    private final ObjectMapper objectMapper;
 
     @Override
     public Course convert(Document source) {
@@ -43,18 +45,17 @@ public class CourseReader implements Converter<Document, Course> {
     }
 
     private List<Coordinate> parseCoordinatesFromJson(String json) {
-        // [ [lng, lat], [lng, lat] ] 형태 파싱
         if (json == null || json.length() < 4) return List.of();
 
-        String content = json.substring(2, json.length() - 2);
-        String[] pairs = content.split("\\],\\[");
+        try {
+            List<Double[]> rawList = objectMapper.readValue(json, new TypeReference<List<Double[]>>() {});
 
-        List<Coordinate> result = new ArrayList<>();
-        for (String pair : pairs) {
-            String[] coords = pair.split(",");
-            result.add(new Coordinate(Double.parseDouble(coords[1]), Double.parseDouble(coords[0])));
+            return rawList.stream()
+                    .map(point -> new Coordinate(point[1], point[0])) // [1]이 lat, [0]이 lng
+                    .toList();
+        } catch (Exception e) {
+            throw new RuntimeException("JSON을 좌표 데이터로 변환하는 중 오류 발생", e);
         }
-        return result;
     }
 
     private List<Coordinate> parseSimplifiedCoordinates(Document source) {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -45,7 +45,7 @@ public class CourseReader implements Converter<Document, Course> {
     }
 
     private List<Coordinate> parseCoordinatesFromJson(String json) {
-        if (json == null || json.length() < 4) return List.of();
+        if (json == null || json.isBlank()) return List.of();
 
         try {
             return objectMapper.readValue(json, new TypeReference<List<Coordinate>>() {});

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -1,5 +1,6 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import coursepick.coursepick.domain.course.Coordinate;
@@ -49,8 +50,8 @@ public class CourseReader implements Converter<Document, Course> {
 
         try {
             return objectMapper.readValue(json, new TypeReference<List<Coordinate>>() {});
-        } catch (Exception e) {
-            throw new RuntimeException("JSON을 좌표 데이터로 변환하는 중 오류 발생", e);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("JSON을 좌표 데이터로 변환하는 중 오류 발생", e);
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -48,11 +48,7 @@ public class CourseReader implements Converter<Document, Course> {
         if (json == null || json.length() < 4) return List.of();
 
         try {
-            List<Double[]> rawList = objectMapper.readValue(json, new TypeReference<List<Double[]>>() {});
-
-            return rawList.stream()
-                    .map(point -> new Coordinate(point[1], point[0])) // [1]이 lat, [0]이 lng
-                    .toList();
+            return objectMapper.readValue(json, new TypeReference<List<Coordinate>>() {});
         } catch (Exception e) {
             throw new RuntimeException("JSON을 좌표 데이터로 변환하는 중 오류 발생", e);
         }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
@@ -37,11 +37,7 @@ public class CourseWriter implements Converter<Course, Document> {
 
     private String convertCoordinatesToJson(List<Coordinate> coordinates) {
         try {
-            List<Double[]> rawData = coordinates.stream()
-                    .map(c -> new Double[]{c.longitude(), c.latitude()})
-                    .toList();
-
-            return objectMapper.writeValueAsString(rawData);
+            return objectMapper.writeValueAsString(coordinates);
         } catch (Exception e) {
             throw new RuntimeException("좌표 데이터를 JSON으로 변환하는 중 오류 발생", e);
         }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
@@ -1,22 +1,21 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
-
 import coursepick.coursepick.infrastructure.compressor.DataCompressor;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.springframework.core.convert.converter.Converter;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 public class CourseWriter implements Converter<Course, Document> {
 
     private final DataCompressor dataCompressor;
+    private final ObjectMapper objectMapper;
 
     @Override
     public Document convert(Course source) {
@@ -37,9 +36,15 @@ public class CourseWriter implements Converter<Course, Document> {
     }
 
     private String convertCoordinatesToJson(List<Coordinate> coordinates) {
-        return coordinates.stream()
-                .map(c -> "[" + c.longitude() + "," + c.latitude() + "]")
-                .collect(Collectors.joining(",", "[", "]"));
+        try {
+            List<Double[]> rawData = coordinates.stream()
+                    .map(c -> new Double[]{c.longitude(), c.latitude()})
+                    .toList();
+
+            return objectMapper.writeValueAsString(rawData);
+        } catch (Exception e) {
+            throw new RuntimeException("좌표 데이터를 JSON으로 변환하는 중 오류 발생", e);
+        }
     }
 
     private Document convertCoordinatesToCompressedData(List<Coordinate> coordinates) {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
@@ -1,5 +1,6 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
@@ -38,8 +39,8 @@ public class CourseWriter implements Converter<Course, Document> {
     private String convertCoordinatesToJson(List<Coordinate> coordinates) {
         try {
             return objectMapper.writeValueAsString(coordinates);
-        } catch (Exception e) {
-            throw new RuntimeException("좌표 데이터를 JSON으로 변환하는 중 오류 발생", e);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("좌표 데이터를 JSON으로 변환하는 중 오류 발생", e);
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/MongoConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/MongoConfig.java
@@ -21,7 +21,7 @@ public class MongoConfig {
     }
 
     @Bean
-    public MongoCustomConversions mongoCustomConversions(ObjectMapper objectMapper) {
+    public MongoCustomConversions mongoCustomConversions() {
         return new MongoCustomConversions(List.of(
                 new CourseConverter.Reader(objectMapper),
                 new CourseConverter.Writer(objectMapper)

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/MongoConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/MongoConfig.java
@@ -1,5 +1,7 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
@@ -12,11 +14,17 @@ import java.util.List;
 @Configuration
 public class MongoConfig {
 
+    private final ObjectMapper objectMapper;
+
+    public MongoConfig(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
     @Bean
-    public MongoCustomConversions mongoCustomConversions() {
+    public MongoCustomConversions mongoCustomConversions(ObjectMapper objectMapper) {
         return new MongoCustomConversions(List.of(
-                new CourseConverter.Reader(),
-                new CourseConverter.Writer()
+                new CourseConverter.Reader(objectMapper),
+                new CourseConverter.Writer(objectMapper)
         ));
     }
 


### PR DESCRIPTION
## 🛠️ 설명
- 기존에 코스를 삽입하거나 조회할 때, String을 이용해서 json 포맷으로 변환하다보니 쓸모없는 메모리 사용량이 높은 문제가 있었습니다.
- 그래서 ObjectMapper를 활용하여 String없이 `Json -> List<Coordinate>`, `List<Coordinate> -> Json` 과정으로 바로 가능하도록 했습니다.

<img width="793" height="532" alt="스크린샷 2026-04-10 16 18 34" src="https://github.com/user-attachments/assets/26bd607d-056a-4f2a-a835-81a4cce611c2" />

- 사진 보시면, `List<Coordinate>`보다 String 객체의 메모리 차지 비율이 2배나 커서 없애야만 했습니다.

## 🔍 리뷰 요청사항
```java
import com.fasterxml.jackson.annotation.JsonFormat;
import com.fasterxml.jackson.annotation.JsonPropertyOrder;

@JsonFormat(shape = JsonFormat.Shape.ARRAY)
@JsonPropertyOrder({ "longitude", "latitude" })
public record Coordinate(
        double latitude,
        double longitude
) { }
```
도메인 객체인 Coordinate에 Jackson 외부 라이브러리가 붙게 되었는데요. 저는 어노테이션이 주석이라서 이정도 의존성은 허용 가능한 수준이라고 보는데요. 다른 팀원은 어떻게 생각하는지 궁금합니다.
해당 방법을 적용하지 않으면 `Json -> List<Double[]> -> List<Coordinate>`, `List<Coordinate> -> List<Double[]> -> Json`로 중간 과정이 생기긴 합니다. 그만큼 수 많은 좌표 데이터가 메모리를 차지하기도 해요!

## 🔗 관련 이슈

- closes #815 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 변경 사항

* **Refactor**
  * 좌표의 JSON 표현을 배열 형태(경도, 위도 순)로 변경했습니다.
  * 직렬화/역직렬화 로직을 Jackson 기반으로 개선해 안정성과 오류 처리를 향상시켰습니다.
  * 데이터 변환 파이프라인을 재구성해 변환 처리의 일관성과 유지보수성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->