### PR TITLE
코스 리뷰 작성 및 조회 API 추가

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -1,9 +1,11 @@
 package coursepick.coursepick.application;
 
+import coursepick.coursepick.application.dto.CourseDetailResponse;
 import coursepick.coursepick.application.dto.CourseResponse;
 import coursepick.coursepick.application.dto.CoursesResponse;
 import coursepick.coursepick.domain.course.*;
 import coursepick.coursepick.domain.user.User;
+import coursepick.coursepick.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
@@ -13,8 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static coursepick.coursepick.application.exception.ErrorType.INVALID_COORDINATE_COUNT;
-import static coursepick.coursepick.application.exception.ErrorType.NOT_EXIST_COURSE;
+import static coursepick.coursepick.application.exception.ErrorType.*;
 
 @Slf4j
 @Service
@@ -22,6 +23,7 @@ import static coursepick.coursepick.application.exception.ErrorType.NOT_EXIST_CO
 public class CourseApplicationService {
 
     private final CourseRepository courseRepository;
+    private final UserRepository userRepository;
     private final RouteFinder routeFinder;
     private final UserApplicationService userApplicationService;
 
@@ -81,6 +83,23 @@ public class CourseApplicationService {
         return courses.stream()
                 .map(CourseResponse::from)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public CourseDetailResponse findCourseDetail(String id) {
+        Course course = courseRepository.findById(id)
+                .orElseThrow(() -> NOT_EXIST_COURSE.create(id));
+        return CourseDetailResponse.from(course);
+    }
+
+    @Transactional
+    public void addReview(String courseId, String userId, String content) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(AUTHENTICATION_FAIL::create);
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> NOT_EXIST_COURSE.create(courseId));
+        course.addReview(user, content);
+        courseRepository.save(course);
     }
 
     private void loggingForNotExistsCourse(List<String> ids, List<Course> courses) {

--- a/backend/src/main/java/coursepick/coursepick/application/dto/CourseDetailResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/CourseDetailResponse.java
@@ -1,0 +1,25 @@
+package coursepick.coursepick.application.dto;
+
+import coursepick.coursepick.domain.course.Coordinate;
+import coursepick.coursepick.domain.course.Course;
+import coursepick.coursepick.domain.course.Meter;
+
+import java.util.List;
+
+public record CourseDetailResponse(
+        String id,
+        String name,
+        Meter length,
+        List<Coordinate> coordinates,
+        List<ReviewResponse> reviews
+) {
+    public static CourseDetailResponse from(Course course) {
+        return new CourseDetailResponse(
+                course.id(),
+                course.name().value(),
+                course.length(),
+                course.coordinates(),
+                ReviewResponse.from(course.reviews())
+        );
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/application/dto/ReviewResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/ReviewResponse.java
@@ -1,0 +1,20 @@
+package coursepick.coursepick.application.dto;
+
+import coursepick.coursepick.domain.course.Review;
+
+import java.util.List;
+
+public record ReviewResponse(
+        String authorNickname,
+        String content
+) {
+    public static ReviewResponse from(Review review) {
+        return new ReviewResponse(review.authorNickname(), review.content());
+    }
+
+    public static List<ReviewResponse> from(List<Review> reviews) {
+        return reviews.stream()
+                .map(ReviewResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -73,6 +73,10 @@ public enum ErrorType {
             "압축 및 해제할 데이터가 없습니다.",
             IllegalArgumentException::new
     ),
+    INVALID_REVIEW_CONTENT_LENGTH(
+            "리뷰 내용은 1자 이상 500자 이하여야 합니다. 입력 길이=%s",
+            IllegalArgumentException::new
+    ),
     NOT_EXIST_USER(
             "유저가 존재하지 않습니다. 유저id=%s",
             NoSuchElementException::new

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -12,6 +12,7 @@ import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Document
@@ -33,6 +34,8 @@ public class Course {
 
     private Meter length;
 
+    private List<Review> reviews;
+
     private String creatorId;
 
     public Course(String id, String name, List<Coordinate> rawCoordinates, User user) {
@@ -41,6 +44,7 @@ public class Course {
         this.coordinates = refineCoordinates(rawCoordinates);
         this.simplifiedCoordinates = simplifyCoordinates(this.coordinates);
         this.length = calculateLength(coordinates);
+        this.reviews = new ArrayList<>();
         this.creatorId = user.id();
     }
 
@@ -96,5 +100,9 @@ public class Course {
 
     public void changeName(String courseName) {
         this.name = new CourseName(courseName);
+    }
+
+    public void addReview(User author, String content) {
+        reviews.add(new Review(author, content));
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
@@ -1,0 +1,40 @@
+package coursepick.coursepick.domain.course;
+
+import coursepick.coursepick.domain.user.User;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.springframework.data.annotation.PersistenceCreator;
+
+import java.time.Instant;
+
+import static coursepick.coursepick.application.exception.ErrorType.INVALID_REVIEW_CONTENT_LENGTH;
+
+@Getter
+@Accessors(fluent = true)
+public class Review {
+
+    public static final int MAX_CONTENT_LENGTH = 500;
+
+    private final String authorNickname;
+    private final String content;
+    private final Instant createdAt;
+
+    @PersistenceCreator
+    public Review(String authorNickname, String content, Instant createdAt) {
+        validateContent(content);
+        this.authorNickname = authorNickname;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public Review(User author, String content) {
+        this(author.nickname(), content, Instant.now());
+    }
+
+    private static void validateContent(String content) {
+        if (content == null || content.isEmpty() || content.length() > MAX_CONTENT_LENGTH) {
+            int length = content == null ? 0 : content.length();
+            throw INVALID_REVIEW_CONTENT_LENGTH.create(length);
+        }
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
@@ -28,7 +28,7 @@ public class Review {
     }
 
     public Review(User author, String content) {
-        this(author.nickname(), content, Instant.now());
+        this(author.nickname().value(), content, Instant.now());
     }
 
     private static void validateContent(String content) {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -1,19 +1,19 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import coursepick.coursepick.domain.course.*;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import coursepick.coursepick.domain.course.Coordinate;
-import coursepick.coursepick.domain.course.Course;
-import coursepick.coursepick.domain.course.CourseName;
-import coursepick.coursepick.domain.course.Meter;
+import coursepick.coursepick.domain.course.*;
 import coursepick.coursepick.infrastructure.compressor.DataCompressor;
 import lombok.RequiredArgsConstructor;
-import coursepick.coursepick.domain.course.*;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.springframework.core.convert.converter.Converter;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -26,6 +26,7 @@ public class CourseReader implements Converter<Document, Course> {
     public Course convert(Document source) {
         List<Coordinate> coordinates = parseCoordinatesFromSource(source);
         List<Coordinate> simplifiedCoordinates = parseSimplifiedCoordinates(source);
+        List<Review> reviews = parseReviews(source);
 
         return new Course(
                 source.getObjectId("_id").toHexString(),
@@ -33,6 +34,7 @@ public class CourseReader implements Converter<Document, Course> {
                 coordinates,
                 simplifiedCoordinates,
                 new Meter(source.getDouble("length")),
+                reviews,
                 source.getString("creatorId")
         );
     }
@@ -51,7 +53,8 @@ public class CourseReader implements Converter<Document, Course> {
         if (json == null || json.isBlank()) return List.of();
 
         try {
-            return objectMapper.readValue(json, new TypeReference<List<Coordinate>>() {});
+            return objectMapper.readValue(json, new TypeReference<>() {
+            });
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("JSON을 좌표 데이터로 변환하는 중 오류 발생", e);
         }
@@ -71,5 +74,31 @@ public class CourseReader implements Converter<Document, Course> {
                         ((Number) coordinateData.get(0)).doubleValue()
                 ))
                 .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Review> parseReviews(Document source) {
+        List<Document> reviewDocs = (List<Document>) source.get("reviews");
+        if (reviewDocs == null || reviewDocs.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<Review> reviews = new ArrayList<>();
+        for (Document reviewDoc : reviewDocs) {
+            String authorNickname = reviewDoc.getString("authorNickname");
+            String content = reviewDoc.getString("content");
+            Instant createdAt = toInstant(reviewDoc.get("createdAt"));
+            reviews.add(new Review(authorNickname, content, createdAt));
+        }
+        return reviews;
+    }
+
+    private Instant toInstant(Object value) {
+        if (value instanceof Date date) {
+            return date.toInstant();
+        }
+        if (value instanceof Instant instant) {
+            return instant;
+        }
+        return Instant.now();
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
+import coursepick.coursepick.domain.course.Review;
 import coursepick.coursepick.infrastructure.compressor.DataCompressor;
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
@@ -32,9 +33,22 @@ public class CourseWriter implements Converter<Course, Document> {
         document.put("simplifiedCoordinates", convertCoordinatesToGeoJson(source.simplifiedCoordinates()));
 
         document.put("length", source.length().value());
+        document.put("reviews", convertReviewsToDocuments(source.reviews()));
         document.put("creatorId", source.creatorId());
         document.put("schemaVersion", 1);
         return document;
+    }
+
+    private List<Document> convertReviewsToDocuments(List<Review> reviews) {
+        return reviews.stream()
+                .map(review -> {
+                    Document reviewDoc = new Document();
+                    reviewDoc.put("authorNickname", review.authorNickname());
+                    reviewDoc.put("content", review.content());
+                    reviewDoc.put("createdAt", review.createdAt());
+                    return reviewDoc;
+                })
+                .toList();
     }
 
     private String convertCoordinatesToJson(List<Coordinate> coordinates) {

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/UserConverter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/UserConverter.java
@@ -4,6 +4,7 @@ import coursepick.coursepick.domain.user.Nickname;
 import coursepick.coursepick.domain.user.User;
 import coursepick.coursepick.domain.user.UserProvider;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
@@ -17,7 +18,7 @@ public abstract class UserConverter {
         public Document convert(User source) {
             Document document = new Document();
             if (source.id() != null && !source.id().isBlank()) {
-                document.put("_id", source.id());
+                document.put("_id", new ObjectId(source.id()));
             }
             document.put("provider", source.provider().name());
             document.put("providerId", source.providerId());

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
@@ -1,6 +1,7 @@
 package coursepick.coursepick.presentation;
 
 import coursepick.coursepick.application.CourseApplicationService;
+import coursepick.coursepick.application.dto.CourseDetailResponse;
 import coursepick.coursepick.application.dto.CoursesResponse;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.CourseFindCondition;
@@ -11,6 +12,7 @@ import coursepick.coursepick.security.Login;
 import coursepick.coursepick.security.UserId;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -67,6 +69,25 @@ public class CourseV1WebController implements CourseWebApi {
         return courseApplicationService.findFavoriteCourses(ids).stream()
                 .map(CourseWebResponse::from)
                 .toList();
+    }
+
+    @Override
+    @GetMapping("/courses/{id}")
+    public CourseDetailWebResponse findCourseDetail(@PathVariable("id") String id) {
+        CourseDetailResponse response = courseApplicationService.findCourseDetail(id);
+        return CourseDetailWebResponse.from(response);
+    }
+
+    @Override
+    @Login
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/courses/{id}/reviews")
+    public void addReview(
+            @PathVariable("id") String id,
+            @UserId String userId,
+            @RequestBody CreateReviewWebRequest request
+    ) {
+        courseApplicationService.addReview(id, userId, request.content());
     }
 
     @Override

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
@@ -80,7 +80,6 @@ public class CourseV1WebController implements CourseWebApi {
 
     @Override
     @Login
-    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/courses/{id}/reviews")
     public void addReview(
             @PathVariable("id") String id,

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -94,6 +94,48 @@ public interface CourseWebApi {
             @Parameter(description = "사용자 경도(-180 ~ 180)", example = "127.1040109", required = true) double longitude
     );
 
+    @Operation(summary = "코스 상세 조회 (리뷰 포함)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "코스가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                    )
+            })),
+    })
+    CourseDetailWebResponse findCourseDetail(
+            @Parameter(description = "코스 ID", example = "689c3143182cecc6353cca7b", required = true) String id
+    );
+
+    @Operation(summary = "코스 리뷰 작성")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201"),
+            @ApiResponse(responseCode = "400", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "리뷰 내용 길이가 범위 외인 경우",
+                            ref = "#/components/examples/INVALID_REVIEW_CONTENT_LENGTH"
+                    )
+            })),
+            @ApiResponse(responseCode = "401", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "인증에 실패한 경우",
+                            ref = "#/components/examples/AUTHENTICATION_FAIL"
+                    )
+            })),
+            @ApiResponse(responseCode = "404", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "코스가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                    )
+            })),
+    })
+    void addReview(
+            @Parameter(description = "코스 ID", example = "689c3143182cecc6353cca7b", required = true) String id,
+            String userId,
+            CreateReviewWebRequest request
+    );
+
     @Operation(summary = "즐겨찾기 코스 조회")
     @ApiResponse(responseCode = "200")
     List<CourseWebResponse> findFavoriteCourses(

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -132,7 +132,7 @@ public interface CourseWebApi {
     })
     void addReview(
             @Parameter(description = "코스 ID", example = "689c3143182cecc6353cca7b", required = true) String id,
-            String userId,
+            @Parameter(hidden = true) String userId,
             CreateReviewWebRequest request
     );
 

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseDetailWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseDetailWebResponse.java
@@ -1,0 +1,29 @@
+package coursepick.coursepick.presentation.dto;
+
+import coursepick.coursepick.application.dto.CourseDetailResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record CourseDetailWebResponse(
+        @Schema(description = "코스 ID", example = "689c3143182cecc6353cca7b")
+        String id,
+        @Schema(description = "코스 이름", example = "석촌호수")
+        String name,
+        @Schema(description = "코스 전체 길이 (미터)", example = "2146.123")
+        double length,
+        @Schema(description = "코스를 구성하는 좌표 목록")
+        List<CoordinateWebResponse> coordinates,
+        @Schema(description = "코스 리뷰 목록")
+        List<ReviewWebResponse> reviews
+) {
+    public static CourseDetailWebResponse from(CourseDetailResponse response) {
+        return new CourseDetailWebResponse(
+                response.id(),
+                response.name(),
+                response.length().value(),
+                CoordinateWebResponse.from(response.coordinates()),
+                ReviewWebResponse.from(response.reviews())
+        );
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CreateReviewWebRequest.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CreateReviewWebRequest.java
@@ -1,0 +1,9 @@
+package coursepick.coursepick.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CreateReviewWebRequest(
+        @Schema(description = "리뷰 내용 (1~500자)", example = "노을이 예쁜 코스입니다")
+        String content
+) {
+}

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/ReviewWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/ReviewWebResponse.java
@@ -1,0 +1,23 @@
+package coursepick.coursepick.presentation.dto;
+
+import coursepick.coursepick.application.dto.ReviewResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record ReviewWebResponse(
+        @Schema(description = "리뷰 작성자 닉네임", example = "피곤한 하마")
+        String authorNickname,
+        @Schema(description = "리뷰 내용", example = "노을이 예쁜 코스입니다")
+        String content
+) {
+    public static ReviewWebResponse from(ReviewResponse reviewResponse) {
+        return new ReviewWebResponse(reviewResponse.authorNickname(), reviewResponse.content());
+    }
+
+    public static List<ReviewWebResponse> from(List<ReviewResponse> reviewResponses) {
+        return reviewResponses.stream()
+                .map(ReviewWebResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -336,22 +336,4 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
         assertThatThrownBy(() -> sut.addReview("689c3143182cecc6353cca7b", user.id(), "내용"))
                 .isInstanceOf(NoSuchElementException.class);
     }
-
-    @Test
-    void 리뷰_내용이_길이_제한을_위반하면_예외가_발생한다() {
-        var course = new Course(null, "제한 코스", List.of(
-                new Coordinate(0, 0),
-                new Coordinate(0, 0.0001),
-                new Coordinate(0.0001, 0.0001),
-                new Coordinate(0, 0)
-        ), ADMIN_USER);
-        var savedCourse = dbUtil.saveCourse(course);
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-4"));
-
-        assertThatThrownBy(() -> sut.addReview(savedCourse.id(), user.id(), ""))
-                .isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> sut.addReview(savedCourse.id(), user.id(), "가".repeat(501)))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
 }

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -1,6 +1,8 @@
 package coursepick.coursepick.application;
 
+import coursepick.coursepick.application.dto.CourseDetailResponse;
 import coursepick.coursepick.application.dto.CourseResponse;
+import coursepick.coursepick.application.dto.ReviewResponse;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseFindCondition;
@@ -283,4 +285,73 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
         }
     }
 
+    @Test
+    void 코스_상세를_조회하면_리뷰_목록이_함께_반환된다() {
+        var course = new Course(null, "리뷰 테스트 코스", List.of(
+                new Coordinate(0, 0),
+                new Coordinate(0, 0.0001),
+                new Coordinate(0.0001, 0.0001),
+                new Coordinate(0.0001, 0),
+                new Coordinate(0, 0)
+        ), ADMIN_USER);
+        var savedCourse = dbUtil.saveCourse(course);
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-1", "피곤한 하마"));
+
+        sut.addReview(savedCourse.id(), user.id(), "아주 좋은 코스입니다");
+
+        CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
+
+        assertThat(detail.id()).isEqualTo(savedCourse.id());
+        assertThat(detail.name()).isEqualTo("리뷰 테스트 코스");
+        assertThat(detail.reviews())
+                .hasSize(1)
+                .extracting(ReviewResponse::authorNickname, ReviewResponse::content)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple("피곤한 하마", "아주 좋은 코스입니다"));
+    }
+
+    @Test
+    void 동일_사용자가_여러_리뷰를_작성하면_모두_같은_닉네임으로_저장된다() {
+        var course = new Course(null, "동일 사용자 리뷰 코스", List.of(
+                new Coordinate(0, 0),
+                new Coordinate(0, 0.0001),
+                new Coordinate(0.0001, 0.0001),
+                new Coordinate(0, 0)
+        ), ADMIN_USER);
+        var savedCourse = dbUtil.saveCourse(course);
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-2", "행복한 기린"));
+
+        sut.addReview(savedCourse.id(), user.id(), "첫 번째 리뷰");
+        sut.addReview(savedCourse.id(), user.id(), "두 번째 리뷰");
+
+        CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
+
+        assertThat(detail.reviews()).hasSize(2)
+                .allMatch(r -> r.authorNickname().equals("행복한 기린"));
+    }
+
+    @Test
+    void 존재하지_않는_코스에_리뷰를_작성하면_예외가_발생한다() {
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-3", "용감한 펭귄"));
+
+        assertThatThrownBy(() -> sut.addReview("689c3143182cecc6353cca7b", user.id(), "내용"))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void 리뷰_내용이_길이_제한을_위반하면_예외가_발생한다() {
+        var course = new Course(null, "제한 코스", List.of(
+                new Coordinate(0, 0),
+                new Coordinate(0, 0.0001),
+                new Coordinate(0.0001, 0.0001),
+                new Coordinate(0, 0)
+        ), ADMIN_USER);
+        var savedCourse = dbUtil.saveCourse(course);
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-4", "졸린 다람쥐"));
+
+        assertThatThrownBy(() -> sut.addReview(savedCourse.id(), user.id(), ""))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> sut.addReview(savedCourse.id(), user.id(), "가".repeat(501)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -295,7 +295,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
                 new Coordinate(0, 0)
         ), ADMIN_USER);
         var savedCourse = dbUtil.saveCourse(course);
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-1", "피곤한 하마"));
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-1"));
 
         sut.addReview(savedCourse.id(), user.id(), "아주 좋은 코스입니다");
 
@@ -306,7 +306,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
         assertThat(detail.reviews())
                 .hasSize(1)
                 .extracting(ReviewResponse::authorNickname, ReviewResponse::content)
-                .containsExactly(org.assertj.core.groups.Tuple.tuple("피곤한 하마", "아주 좋은 코스입니다"));
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(user.nickname().value(), "아주 좋은 코스입니다"));
     }
 
     @Test
@@ -318,7 +318,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
                 new Coordinate(0, 0)
         ), ADMIN_USER);
         var savedCourse = dbUtil.saveCourse(course);
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-2", "행복한 기린"));
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-2"));
 
         sut.addReview(savedCourse.id(), user.id(), "첫 번째 리뷰");
         sut.addReview(savedCourse.id(), user.id(), "두 번째 리뷰");
@@ -326,12 +326,12 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
         CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
 
         assertThat(detail.reviews()).hasSize(2)
-                .allMatch(r -> r.authorNickname().equals("행복한 기린"));
+                .allMatch(r -> r.authorNickname().equals(user.nickname().value()));
     }
 
     @Test
     void 존재하지_않는_코스에_리뷰를_작성하면_예외가_발생한다() {
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-3", "용감한 펭귄"));
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-3"));
 
         assertThatThrownBy(() -> sut.addReview("689c3143182cecc6353cca7b", user.id(), "내용"))
                 .isInstanceOf(NoSuchElementException.class);
@@ -346,7 +346,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
                 new Coordinate(0, 0)
         ), ADMIN_USER);
         var savedCourse = dbUtil.saveCourse(course);
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-4", "졸린 다람쥐"));
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-4"));
 
         assertThatThrownBy(() -> sut.addReview(savedCourse.id(), user.id(), ""))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/backend/src/test/java/coursepick/coursepick/application/FindDraftRouteTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/FindDraftRouteTest.java
@@ -4,6 +4,7 @@ import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.CourseRepository;
 import coursepick.coursepick.domain.course.DraftSegment;
 import coursepick.coursepick.domain.course.RouteFinder;
+import coursepick.coursepick.domain.user.UserRepository;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -18,8 +19,9 @@ import static org.mockito.Mockito.when;
 class FindDraftRouteTest {
 
     CourseRepository courseRepository = mock(CourseRepository.class);
+    UserRepository userRepository = mock(UserRepository.class);
     RouteFinder routeFinder = mock(RouteFinder.class);
-    CourseApplicationService courseService = new CourseApplicationService(courseRepository, routeFinder, null);
+    CourseApplicationService courseService = new CourseApplicationService(courseRepository, userRepository, routeFinder, null);
 
     @Test
     void 경로_좌표가_1개이면_예외가_발생한다() {

--- a/backend/src/test/java/coursepick/coursepick/domain/course/ReviewTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/ReviewTest.java
@@ -10,17 +10,16 @@ class ReviewTest {
 
     @Test
     void 리뷰_내용이_1자면_생성된다() {
-        User author = new User(null, "providerId", "피곤한 하마");
+        User author = new User(null, "providerId");
         Review review = new Review(author, "좋");
 
         assertThat(review.content()).isEqualTo("좋");
-        assertThat(review.authorNickname()).isEqualTo("피곤한 하마");
         assertThat(review.createdAt()).isNotNull();
     }
 
     @Test
     void 리뷰_내용이_500자면_생성된다() {
-        User author = new User(null, "providerId", "피곤한 하마");
+        User author = new User(null, "providerId");
         String content = "가".repeat(500);
 
         Review review = new Review(author, content);
@@ -30,21 +29,21 @@ class ReviewTest {
 
     @Test
     void 리뷰_내용이_비어있으면_예외가_발생한다() {
-        User author = new User(null, "providerId", "피곤한 하마");
+        User author = new User(null, "providerId");
         assertThatThrownBy(() -> new Review(author, ""))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void 리뷰_내용이_null이면_예외가_발생한다() {
-        User author = new User(null, "providerId", "피곤한 하마");
+        User author = new User(null, "providerId");
         assertThatThrownBy(() -> new Review(author, null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void 리뷰_내용이_501자이면_예외가_발생한다() {
-        User author = new User(null, "providerId", "피곤한 하마");
+        User author = new User(null, "providerId");
         String content = "가".repeat(501);
 
         assertThatThrownBy(() -> new Review(author, content))

--- a/backend/src/test/java/coursepick/coursepick/domain/course/ReviewTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/ReviewTest.java
@@ -1,0 +1,53 @@
+package coursepick.coursepick.domain.course;
+
+import coursepick.coursepick.domain.user.User;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReviewTest {
+
+    @Test
+    void 리뷰_내용이_1자면_생성된다() {
+        User author = new User(null, "providerId", "피곤한 하마");
+        Review review = new Review(author, "좋");
+
+        assertThat(review.content()).isEqualTo("좋");
+        assertThat(review.authorNickname()).isEqualTo("피곤한 하마");
+        assertThat(review.createdAt()).isNotNull();
+    }
+
+    @Test
+    void 리뷰_내용이_500자면_생성된다() {
+        User author = new User(null, "providerId", "피곤한 하마");
+        String content = "가".repeat(500);
+
+        Review review = new Review(author, content);
+
+        assertThat(review.content()).hasSize(500);
+    }
+
+    @Test
+    void 리뷰_내용이_비어있으면_예외가_발생한다() {
+        User author = new User(null, "providerId", "피곤한 하마");
+        assertThatThrownBy(() -> new Review(author, ""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 리뷰_내용이_null이면_예외가_발생한다() {
+        User author = new User(null, "providerId", "피곤한 하마");
+        assertThatThrownBy(() -> new Review(author, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 리뷰_내용이_501자이면_예외가_발생한다() {
+        User author = new User(null, "providerId", "피곤한 하마");
+        String content = "가".repeat(501);
+
+        assertThatThrownBy(() -> new Review(author, content))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/mongodb/CourseConverterTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/mongodb/CourseConverterTest.java
@@ -1,10 +1,8 @@
 package coursepick.coursepick.infrastructure.mongodb;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import coursepick.coursepick.domain.course.Coordinate;
-import coursepick.coursepick.domain.course.Course;
-import coursepick.coursepick.domain.course.CourseName;
-import coursepick.coursepick.domain.course.Meter;
+import coursepick.coursepick.domain.course.*;
+import coursepick.coursepick.domain.user.User;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.bson.types.ObjectId;
@@ -33,6 +31,7 @@ class CourseConverterTest {
                 List.of(new Coordinate(37.5, 127.0), new Coordinate(37.51, 127.01), new Coordinate(37.52, 127.02)),
                 List.of(new Coordinate(37.5, 127.0), new Coordinate(37.52, 127.02)),
                 new Meter(1500.0),
+                List.of(new Review(new User(null, "providerId", "reviewer"), "hi")),
                 "creatorId123"
         );
 
@@ -41,7 +40,6 @@ class CourseConverterTest {
 
     @Test
     void Course를_Document로_변환한다() {
-
         Document document = writer.convert(course);
 
         assertThat(document.get("_id")).isEqualTo(new ObjectId(course.id()));
@@ -49,6 +47,7 @@ class CourseConverterTest {
         assertThat(document.getDouble("length")).isEqualTo(course.length().value());
         assertThat(document.get("coordinates")).isInstanceOf(Document.class);
         assertThat(document.get("simplifiedCoordinates")).isInstanceOf(Document.class);
+        assertThat(document.get("reviews")).isInstanceOf(List.class);
         assertThat(document.getString("creatorId")).isEqualTo(course.creatorId());
     }
 
@@ -66,6 +65,7 @@ class CourseConverterTest {
         assertThat(result.coordinates()).isEqualTo(course.coordinates());
         assertThat(result.simplifiedCoordinates()).isEqualTo(course.simplifiedCoordinates());
         assertThat(result.length()).isEqualTo(course.length());
+        assertThat(result.reviews()).hasSameSizeAs(course.reviews());
         assertThat(result.creatorId()).isEqualTo(course.creatorId());
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/test_util/DatabaseTestUtil.java
+++ b/backend/src/test/java/coursepick/coursepick/test_util/DatabaseTestUtil.java
@@ -9,7 +9,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.Collection;
-import java.util.Optional;
 
 @TestComponent
 public class DatabaseTestUtil {


### PR DESCRIPTION
## 🛠️ 설명

- 리뷰 추가, 코스 상세 조회 API를 추가했습니다.
- 리뷰 추가 API
  - 코스 ID와 코멘트 내용을 통해 리뷰를 작성합니다.
- 코스 상세 조회 API
  - 기존 코스 API 응답에 더해, 리뷰에 대한 내용이 추가됩니다.
  - 리뷰 작성자 닉네임과 리뷰 코멘트가 배열로 같이 넘어옵니다.

## 🔗 관련 이슈

- closes #817 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 코스 상세 조회 추가 (좌표·거리·리뷰 포함, GET /courses/{id})
  * 코스에 리뷰 작성 가능 추가 (POST /courses/{id}/reviews, 인증 필요)
  * API 응답/요청 페이로드에 리뷰 필드 추가 (작성자 닉네임·내용·작성시각 등)

* **검증**
  * 리뷰 내용 길이 검증 적용 (1~500자, 위반 시 400)

* **테스트**
  * 코스 상세 조회 및 리뷰 작성 관련 단위·통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->