### PR TITLE
예외 메시지 처리 

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -3,6 +3,7 @@ package coursepick.coursepick.application;
 import coursepick.coursepick.application.dto.CourseDetailResponse;
 import coursepick.coursepick.application.dto.CourseResponse;
 import coursepick.coursepick.application.dto.CoursesResponse;
+import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.course.*;
 import coursepick.coursepick.domain.user.User;
 import coursepick.coursepick.domain.user.UserRepository;
@@ -27,11 +28,21 @@ public class CourseApplicationService {
     private final RouteFinder routeFinder;
     private final UserApplicationService userApplicationService;
 
+
     @Transactional
     public void addCustomCourse(String name, List<Coordinate> coordinates, String userId) {
+        CourseName courseName = new CourseName(name);
+        validateDuplicatedCourseName(courseName.value());
         User user = userApplicationService.findUser(userId);
-        Course newCourse = new Course(null, name, coordinates, user);
+
+        Course newCourse = new Course(null, courseName, coordinates, user);
         courseRepository.save(newCourse);
+    }
+
+    private void validateDuplicatedCourseName(String parsedCourseName) {
+        if (courseRepository.existsByName(parsedCourseName)) {
+            throw ErrorType.DUPLICATED_COURSE_NAME.create(parsedCourseName);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -32,16 +32,16 @@ public class CourseApplicationService {
     @Transactional
     public void addCustomCourse(String name, List<Coordinate> coordinates, String userId) {
         CourseName courseName = new CourseName(name);
-        validateDuplicatedCourseName(courseName.value());
+        validateDuplicatedCourseName(courseName);
         User user = userApplicationService.findUser(userId);
 
         Course newCourse = new Course(null, courseName, coordinates, user);
         courseRepository.save(newCourse);
     }
 
-    private void validateDuplicatedCourseName(String parsedCourseName) {
-        if (courseRepository.existsByName(parsedCourseName)) {
-            throw ErrorType.DUPLICATED_COURSE_NAME.create(parsedCourseName);
+    private void validateDuplicatedCourseName(CourseName courseName) {
+        if (courseRepository.existByCourseName(courseName)) {
+            throw ErrorType.DUPLICATED_COURSE_NAME.create(courseName.value());
         }
     }
 

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -81,7 +81,10 @@ public enum ErrorType {
             "유저가 존재하지 않습니다. 유저id=%s",
             NoSuchElementException::new
     ),
-    ;
+    DUPLICATED_COURSE_NAME(
+            "'%s'은(는) 이미 존재하는 코스 이름입니다.",
+            IllegalStateException::new
+    );
 
     private final String message;
     private final Function<String, ? extends RuntimeException> exceptionConstructor;

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -38,9 +38,9 @@ public class Course {
 
     private String creatorId;
 
-    public Course(String id, String name, List<Coordinate> rawCoordinates, User user) {
+    public Course(String id, CourseName courseName, List<Coordinate> rawCoordinates, User user) {
         this.id = id;
-        this.name = new CourseName(name);
+        this.name = courseName;
         this.coordinates = refineCoordinates(rawCoordinates);
         this.simplifiedCoordinates = simplifyCoordinates(this.coordinates);
         this.length = calculateLength(coordinates);

--- a/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
@@ -20,4 +20,6 @@ public interface CourseRepository {
     Optional<Course> findByName(CourseName courseName);
 
     void delete(Course course);
+
+    boolean existsByName(String name);
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
@@ -21,5 +21,5 @@ public interface CourseRepository {
 
     void delete(Course course);
 
-    boolean existsByName(String name);
+    boolean existByCourseName(CourseName courseName);
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Gpx.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Gpx.java
@@ -128,6 +128,6 @@ public class Gpx {
     }
 
     public List<Course> toCourses(User user) {
-        return List.of(new Course(id, name, coordinates, user));
+        return List.of(new Course(id, new CourseName(name), coordinates, user));
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
@@ -119,4 +119,9 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
     public void delete(Course course) {
         mongoTemplate.remove(course);
     }
+
+    @Override
+    public boolean existsByName(String name) {
+        return mongoTemplate.exists(Query.query(Criteria.where("name").is(name)), Course.class);
+    }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
@@ -121,7 +121,7 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
     }
 
     @Override
-    public boolean existsByName(String name) {
-        return mongoTemplate.exists(Query.query(Criteria.where("name").is(name)), Course.class);
+    public boolean existByCourseName(CourseName courseName) {
+        return mongoTemplate.exists(Query.query(Criteria.where("name").is(courseName.value())), Course.class);
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/parser/KmlCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/parser/KmlCourseParser.java
@@ -5,6 +5,7 @@ import coursepick.coursepick.application.dto.CourseFileExtension;
 import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
+import coursepick.coursepick.domain.course.CourseName;
 import coursepick.coursepick.domain.course.CourseParser;
 import coursepick.coursepick.domain.user.User;
 import lombok.extern.slf4j.Slf4j;
@@ -59,15 +60,15 @@ public class KmlCourseParser implements CourseParser {
     }
 
     private Course parseCourse(Element placemark, User user) {
-        String courseName = parseCourseName(placemark);
+        String parsedName = parseCourseName(placemark);
         List<Coordinate> coordinates = parseCoordinates(placemark);
 
-        if (courseName == null || courseName.isBlank())
+        if (parsedName == null || parsedName.isBlank())
             return null;
         if (coordinates.isEmpty())
             return null;
 
-        return new Course(null, courseName, coordinates, user);
+        return new Course(null, new CourseName(parsedName), coordinates, user);
     }
 
     private String parseCourseName(Element placemark) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/WebExceptionHandler.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/WebExceptionHandler.java
@@ -7,11 +7,16 @@ import coursepick.coursepick.presentation.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+import com.mongodb.DuplicateKeyException;
 
 @RestControllerAdvice
 @Slf4j
@@ -34,6 +39,24 @@ public class WebExceptionHandler {
         log.warn("[EXCEPTION] MissingServletRequestParameterException 예외 응답 반환", LogContent.exception(e));
         return ResponseEntity.badRequest().body(ErrorResponse.from(e));
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.warn("[EXCEPTION] MethodArgumentNotValidException 예외 응답 반환", LogContent.exception(e));
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(errorMessage, LocalDateTime.now().toString()));
+    }
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateKeyException(DuplicateKeyException e) {
+        log.warn("[EXCEPTION] DuplicateKeyException 예외 응답 반환", LogContent.exception(e));
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("이미 존재하는 데이터입니다.", LocalDateTime.now().toString()));
+    }
+
 
     @ExceptionHandler(QueryTimeoutException.class)
     public ResponseEntity<ErrorResponse> handleQueryTimeoutException(QueryTimeoutException e) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/WebExceptionHandler.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/WebExceptionHandler.java
@@ -5,6 +5,7 @@ import coursepick.coursepick.application.exception.UnauthorizedException;
 import coursepick.coursepick.logging.LogContent;
 import coursepick.coursepick.presentation.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -12,11 +13,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
-
-import com.mongodb.DuplicateKeyException;
 
 @RestControllerAdvice
 @Slf4j
@@ -43,20 +40,17 @@ public class WebExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.warn("[EXCEPTION] MethodArgumentNotValidException 예외 응답 반환", LogContent.exception(e));
-        String errorMessage = e.getBindingResult().getFieldErrors().stream()
-                .map(error -> error.getField() + ": " + error.getDefaultMessage())
-                .collect(Collectors.joining(", "));
         return ResponseEntity.badRequest()
-                .body(new ErrorResponse(errorMessage, LocalDateTime.now().toString()));
+                .body(ErrorResponse.from(e.getBindingResult()));
     }
 
     @ExceptionHandler(DuplicateKeyException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateKeyException(DuplicateKeyException e) {
         log.warn("[EXCEPTION] DuplicateKeyException 예외 응답 반환", LogContent.exception(e));
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(new ErrorResponse("이미 존재하는 데이터입니다.", LocalDateTime.now().toString()));
-    }
 
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ErrorResponse.fromDuplicatedKey(e.getMessage()));
+    }
 
     @ExceptionHandler(QueryTimeoutException.class)
     public ResponseEntity<ErrorResponse> handleQueryTimeoutException(QueryTimeoutException e) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/WebExceptionHandler.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/WebExceptionHandler.java
@@ -5,7 +5,6 @@ import coursepick.coursepick.application.exception.UnauthorizedException;
 import coursepick.coursepick.logging.LogContent;
 import coursepick.coursepick.presentation.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -31,6 +30,12 @@ public class WebExceptionHandler {
         return ResponseEntity.badRequest().body(ErrorResponse.from(e));
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
+        log.warn("[EXCEPTION] IllegalStateException() 예외 응답 반환", LogContent.exception(e));
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.from(e));
+    }
+
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
         log.warn("[EXCEPTION] MissingServletRequestParameterException 예외 응답 반환", LogContent.exception(e));
@@ -42,14 +47,6 @@ public class WebExceptionHandler {
         log.warn("[EXCEPTION] MethodArgumentNotValidException 예외 응답 반환", LogContent.exception(e));
         return ResponseEntity.badRequest()
                 .body(ErrorResponse.from(e.getBindingResult()));
-    }
-
-    @ExceptionHandler(DuplicateKeyException.class)
-    public ResponseEntity<ErrorResponse> handleDuplicateKeyException(DuplicateKeyException e) {
-        log.warn("[EXCEPTION] DuplicateKeyException 예외 응답 반환", LogContent.exception(e));
-
-        return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(ErrorResponse.fromDuplicatedKey(e.getMessage()));
     }
 
     @ExceptionHandler(QueryTimeoutException.class)

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseCreateWebRequest.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseCreateWebRequest.java
@@ -14,7 +14,7 @@ public record CourseCreateWebRequest(
         String name,
 
         @Schema(description = "코스를 구성하는 좌표 목록 (최소 2개 이상)", requiredMode = Schema.RequiredMode.REQUIRED)
-        @NotNull
+        @NotNull(message = "좌표는 비어있을 수 없습니다.")
         @Size(min = 2, message = "코스는 출발지와 도착지 등 최소 2개 이상의 좌표가 필요합니다.")
         List<@NotNull(message = "개별 좌표 값은 비어있을 수 없습니다.") @Valid CoordinateWebRequest> coordinates
 ) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
@@ -9,17 +9,14 @@ import java.util.stream.Collectors;
 
 public record ErrorResponse(
         String message,
-        String timestamp
-) {
+        String timestamp) {
 
     private static final Pattern DUP_KEY_PATTERN = Pattern.compile("dup key: \\{\\s*(.*?)\\s*}");
 
-    public static ErrorResponse
-    from(Exception exception) {
+    public static ErrorResponse from(Exception exception) {
         return new ErrorResponse(
                 exception.getMessage(),
-                LocalDateTime.now().toString()
-        );
+                LocalDateTime.now().toString());
     }
 
     public static ErrorResponse from(BindingResult bindingResult) {
@@ -27,26 +24,5 @@ public record ErrorResponse(
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
         return new ErrorResponse(errorMessage, LocalDateTime.now().toString());
-    }
-
-    public static ErrorResponse fromDuplicatedKey(String errorDescription) {
-        String responseMessage = "이미 존재하는 데이터입니다.";
-        if (errorDescription != null) {
-            Matcher matcher = DUP_KEY_PATTERN.matcher(errorDescription);
-            if (matcher.find()) {
-                // "" 제거
-                String cause = matcher.group(1).replace("\"", "").trim();
-
-                //중복 값 추출
-                String[] parts = cause.split(":", 2);
-                if (parts.length == 2) {
-                    String duplicateValue = parts[1].trim();
-                    responseMessage = "'%s'은(는) 이미 존재하는 데이터입니다.".formatted(duplicateValue);
-                } else {
-                    responseMessage += " " + cause;
-                }
-            }
-        }
-        return new ErrorResponse(responseMessage, LocalDateTime.now().toString());
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
@@ -1,16 +1,52 @@
 package coursepick.coursepick.presentation.dto;
 
+import org.springframework.validation.BindingResult;
+
 import java.time.LocalDateTime;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public record ErrorResponse(
         String message,
         String timestamp
 ) {
+
+    private static final Pattern DUP_KEY_PATTERN = Pattern.compile("dup key: \\{\\s*(.*?)\\s*}");
+
     public static ErrorResponse
     from(Exception exception) {
         return new ErrorResponse(
                 exception.getMessage(),
                 LocalDateTime.now().toString()
         );
+    }
+
+    public static ErrorResponse from(BindingResult bindingResult) {
+        String errorMessage = bindingResult.getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return new ErrorResponse(errorMessage, LocalDateTime.now().toString());
+    }
+
+    public static ErrorResponse fromDuplicatedKey(String errorDescription) {
+        String responseMessage = "이미 존재하는 데이터입니다.";
+        if (errorDescription != null) {
+            Matcher matcher = DUP_KEY_PATTERN.matcher(errorDescription);
+            if (matcher.find()) {
+                // "" 제거
+                String cause = matcher.group(1).replace("\"", "").trim();
+
+                //중복 값 추출
+                String[] parts = cause.split(":", 2);
+                if (parts.length == 2) {
+                    String duplicateValue = parts[1].trim();
+                    responseMessage = "'%s'은(는) 이미 존재하는 데이터입니다.".formatted(duplicateValue);
+                } else {
+                    responseMessage += " " + cause;
+                }
+            }
+        }
+        return new ErrorResponse(responseMessage, LocalDateTime.now().toString());
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
@@ -3,7 +3,6 @@ package coursepick.coursepick.presentation.dto;
 import org.springframework.validation.BindingResult;
 
 import java.time.LocalDateTime;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -21,7 +20,7 @@ public record ErrorResponse(
 
     public static ErrorResponse from(BindingResult bindingResult) {
         String errorMessage = bindingResult.getFieldErrors().stream()
-                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .map(error -> error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
         return new ErrorResponse(errorMessage, LocalDateTime.now().toString());
     }

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -6,6 +6,7 @@ import coursepick.coursepick.application.dto.ReviewResponse;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseFindCondition;
+import coursepick.coursepick.domain.course.CourseName;
 import coursepick.coursepick.domain.user.User;
 import coursepick.coursepick.domain.user.UserProvider;
 import coursepick.coursepick.test_util.AbstractIntegrationTest;
@@ -14,6 +15,8 @@ import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
@@ -22,6 +25,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static coursepick.coursepick.test_util.UserFixture.ADMIN_USER;
+import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -32,19 +36,19 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 코스는_최소_1KM부터_탐색할_수_있다() {
-        var course1 = new Course(null, "한강 러닝 코스", List.of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, "양재천 산책길", List.of(
+        var course2 = new Course(null, new CourseName("양재천 산책길"), of(
                 new Coordinate(37.5165, 127.0285),
                 new Coordinate(37.5160, 127.0278),
                 new Coordinate(37.5155, 127.0265),
                 new Coordinate(37.5165, 127.0285)
         ), ADMIN_USER);
-        var course3 = new Course(null, "북악산 둘레길", List.of(
+        var course3 = new Course(null, new CourseName("북악산 둘레길"), of(
                 new Coordinate(37.602500, 126.967000),
                 new Coordinate(37.603000, 126.968000),
                 new Coordinate(37.603500, 126.969000),
@@ -70,13 +74,13 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 코스는_최대_3KM까지_탐색할_수_있다() {
-        var course1 = new Course(null, "한강 러닝 코스", List.of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, "북악산 둘레길", List.of(
+        var course2 = new Course(null, new CourseName("북악산 둘레길"), of(
                 new Coordinate(38.602500, 126.967000),
                 new Coordinate(38.603000, 126.968000),
                 new Coordinate(38.603500, 126.969000),
@@ -100,19 +104,19 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 가까운_코스들을_조회한다() {
-        var course1 = new Course(null, "한강 러닝 코스", List.of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, "양재천 산책길", List.of(
+        var course2 = new Course(null, new CourseName("양재천 산책길"), of(
                 new Coordinate(37.5165, 127.0285),
                 new Coordinate(37.5160, 127.0278),
                 new Coordinate(37.5155, 127.0265),
                 new Coordinate(37.5165, 127.0285)
         ), ADMIN_USER);
-        var course3 = new Course(null, "북악산 둘레길", List.of(
+        var course3 = new Course(null, new CourseName("북악산 둘레길"), of(
                 new Coordinate(37.602500, 126.967000),
                 new Coordinate(37.603000, 126.968000),
                 new Coordinate(37.603500, 126.969000),
@@ -138,19 +142,19 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 가까운_코스들을_조회하고_현위치에서_거리를_계산한다() {
-        var course1 = new Course(null, "한강 러닝 코스", List.of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, "양재천 산책길", List.of(
+        var course2 = new Course(null, new CourseName("양재천 산책길"), of(
                 new Coordinate(37.5165, 127.0285),
                 new Coordinate(37.5160, 127.0278),
                 new Coordinate(37.5155, 127.0265),
                 new Coordinate(37.5165, 127.0285)
         ), ADMIN_USER);
-        var course3 = new Course(null, "북악산 둘레길", List.of(
+        var course3 = new Course(null, new CourseName("북악산 둘레길"), of(
                 new Coordinate(37.602500, 126.967000),
                 new Coordinate(37.603000, 126.968000),
                 new Coordinate(37.603500, 126.969000),
@@ -184,7 +188,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
     void 더_보여줄_코스가_없다() {
         List<Coordinate> coordinates = CoordinateTestUtil.square(new Coordinate(37.5180, 127.0280), new Coordinate(37.5175, 127.0270));
         List<Course> courses = new ArrayList<>();
-        for (int i = 0; i < 5; i++) courses.add(new Course(null, "코스" + i, coordinates, ADMIN_USER));
+        for (int i = 0; i < 5; i++) courses.add(new Course(null, new CourseName("코스" + i), coordinates, ADMIN_USER));
         dbUtil.saveAllCourses(courses);
         var condition = new CourseFindCondition(37.5175, 127.0270, 3000, null, null, 0);
 
@@ -197,7 +201,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
     void 더_보여줄_코스가_있다() {
         List<Coordinate> coordinates = CoordinateTestUtil.square(new Coordinate(37.5180, 127.0280), new Coordinate(37.5175, 127.0270));
         List<Course> courses = new ArrayList<>();
-        for (int i = 0; i < 15; i++) courses.add(new Course(null, "코스" + i, coordinates, ADMIN_USER));
+        for (int i = 0; i < 15; i++) courses.add(new Course(null, new CourseName("코스" + i), coordinates, ADMIN_USER));
         dbUtil.saveAllCourses(courses);
         var condition = new CourseFindCondition(37.5175, 127.0270, 3000, null, null, 0);
 
@@ -210,7 +214,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
     void 다음_페이지의_코스를_찾는다() {
         List<Coordinate> coordinates = CoordinateTestUtil.square(new Coordinate(37.5180, 127.0280), new Coordinate(37.5175, 127.0270));
         List<Course> courses = new ArrayList<>();
-        for (int i = 0; i < 15; i++) courses.add(new Course(null, "코스" + i, coordinates, ADMIN_USER));
+        for (int i = 0; i < 15; i++) courses.add(new Course(null, new CourseName("코스" + i), coordinates, ADMIN_USER));
         dbUtil.saveAllCourses(courses);
         var condition = new CourseFindCondition(37.5175, 127.0270, 3000, null, null, 1);
 
@@ -222,7 +226,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 코스의_좌표_중에서_가장_가까운_좌표를_계산한다() {
-        var course = new Course(null, "한강 러닝 코스", List.of(
+        var course = new Course(null, new CourseName("한강 러닝 코스"), of(
                 new Coordinate(0, 0),
                 new Coordinate(0, 0.0001),
                 new Coordinate(0.0001, 0.0001),
@@ -254,6 +258,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
         @Test
         void 유저가_생성한_코스를_저장한다() {
+
             String name = "나만의 코스1";
             List<Coordinate> coordinates = List.of(
                     new Coordinate(37.602500, 126.967000),
@@ -283,57 +288,97 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
                     .isInstanceOf(NoSuchElementException.class);
 
         }
-    }
 
-    @Test
-    void 코스_상세를_조회하면_리뷰_목록이_함께_반환된다() {
-        var course = new Course(null, "리뷰 테스트 코스", List.of(
-                new Coordinate(0, 0),
-                new Coordinate(0, 0.0001),
-                new Coordinate(0.0001, 0.0001),
-                new Coordinate(0.0001, 0),
-                new Coordinate(0, 0)
-        ), ADMIN_USER);
-        var savedCourse = dbUtil.saveCourse(course);
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-1"));
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "나만의 코스",
+                " 나만의 코스   "
+        })
+        void 앞_뒤_공백을_제거하여_코스를_생성한다(String name) {
+            String expectedName = "나만의 코스";
+            List<Coordinate> coordinates = List.of(
+                    new Coordinate(37.602500, 126.967000),
+                    new Coordinate(37.603000, 126.968000),
+                    new Coordinate(37.603500, 126.969000),
+                    new Coordinate(37.602500, 126.967000)
+            );
 
-        sut.addReview(savedCourse.id(), user.id(), "아주 좋은 코스입니다");
+            sut.addCustomCourse(name, coordinates, user.id());
 
-        CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
+            Course result = dbUtil.findCourseByName(expectedName);
+            assertThat(result.name().value()).isEqualTo(expectedName);
+        }
 
-        assertThat(detail.id()).isEqualTo(savedCourse.id());
-        assertThat(detail.name()).isEqualTo("리뷰 테스트 코스");
-        assertThat(detail.reviews())
-                .hasSize(1)
-                .extracting(ReviewResponse::authorNickname, ReviewResponse::content)
-                .containsExactly(org.assertj.core.groups.Tuple.tuple(user.nickname().value(), "아주 좋은 코스입니다"));
-    }
+        @Test
+        void 코스_상세를_조회하면_리뷰_목록이_함께_반환된다() {
+            var course = new Course(null, "리뷰 테스트 코스", List.of(
+                    new Coordinate(0, 0),
+                    new Coordinate(0, 0.0001),
+                    new Coordinate(0.0001, 0.0001),
+                    new Coordinate(0.0001, 0),
+                    new Coordinate(0, 0)
+            ), ADMIN_USER);
+            var savedCourse = dbUtil.saveCourse(course);
+            var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-1"));
 
-    @Test
-    void 동일_사용자가_여러_리뷰를_작성하면_모두_같은_닉네임으로_저장된다() {
-        var course = new Course(null, "동일 사용자 리뷰 코스", List.of(
-                new Coordinate(0, 0),
-                new Coordinate(0, 0.0001),
-                new Coordinate(0.0001, 0.0001),
-                new Coordinate(0, 0)
-        ), ADMIN_USER);
-        var savedCourse = dbUtil.saveCourse(course);
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-2"));
+            sut.addReview(savedCourse.id(), user.id(), "아주 좋은 코스입니다");
 
-        sut.addReview(savedCourse.id(), user.id(), "첫 번째 리뷰");
-        sut.addReview(savedCourse.id(), user.id(), "두 번째 리뷰");
+            CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
 
-        CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
+            assertThat(detail.id()).isEqualTo(savedCourse.id());
+            assertThat(detail.name()).isEqualTo("리뷰 테스트 코스");
+            assertThat(detail.reviews())
+                    .hasSize(1)
+                    .extracting(ReviewResponse::authorNickname, ReviewResponse::content)
+                    .containsExactly(org.assertj.core.groups.Tuple.tuple(user.nickname().value(), "아주 좋은 코스입니다"));
+        }
 
-        assertThat(detail.reviews()).hasSize(2)
-                .allMatch(r -> r.authorNickname().equals(user.nickname().value()));
-    }
+        @Test
+        void 동일_사용자가_여러_리뷰를_작성하면_모두_같은_닉네임으로_저장된다() {
+            var course = new Course(null, "동일 사용자 리뷰 코스", List.of(
+                    new Coordinate(0, 0),
+                    new Coordinate(0, 0.0001),
+                    new Coordinate(0.0001, 0.0001),
+                    new Coordinate(0, 0)
+            ), ADMIN_USER);
+            var savedCourse = dbUtil.saveCourse(course);
+            var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-2"));
 
-    @Test
-    void 존재하지_않는_코스에_리뷰를_작성하면_예외가_발생한다() {
-        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-3"));
+            sut.addReview(savedCourse.id(), user.id(), "첫 번째 리뷰");
+            sut.addReview(savedCourse.id(), user.id(), "두 번째 리뷰");
 
-        assertThatThrownBy(() -> sut.addReview("689c3143182cecc6353cca7b", user.id(), "내용"))
-                .isInstanceOf(NoSuchElementException.class);
+            CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
+
+            assertThat(detail.reviews()).hasSize(2)
+                    .allMatch(r -> r.authorNickname().equals(user.nickname().value()));
+        }
+
+        @Test
+        void 존재하지_않는_코스에_리뷰를_작성하면_예외가_발생한다() {
+            var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-3"));
+
+            assertThatThrownBy(() -> sut.addReview("689c3143182cecc6353cca7b", user.id(), "내용"))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "나만의 코스",
+                "나만의   코스",
+        })
+        void 이름의_연속공백을_한_칸으로_변환하여_코스를_생성한다(String name) {
+            String expectedName = "나만의 코스";
+            List<Coordinate> coordinates = List.of(
+                    new Coordinate(37.602500, 126.967000),
+                    new Coordinate(37.603000, 126.968000),
+                    new Coordinate(37.603500, 126.969000),
+                    new Coordinate(37.602500, 126.967000)
+            );
+
+            sut.addCustomCourse(name, coordinates, user.id());
+
+            Course result = dbUtil.findCourseByName(expectedName);
+            assertThat(result.name().value()).isEqualTo(expectedName);
+        }
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -25,7 +25,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static coursepick.coursepick.test_util.UserFixture.ADMIN_USER;
-import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -36,19 +35,19 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 코스는_최소_1KM부터_탐색할_수_있다() {
-        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), List.of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, new CourseName("양재천 산책길"), of(
+        var course2 = new Course(null, new CourseName("양재천 산책길"), List.of(
                 new Coordinate(37.5165, 127.0285),
                 new Coordinate(37.5160, 127.0278),
                 new Coordinate(37.5155, 127.0265),
                 new Coordinate(37.5165, 127.0285)
         ), ADMIN_USER);
-        var course3 = new Course(null, new CourseName("북악산 둘레길"), of(
+        var course3 = new Course(null, new CourseName("북악산 둘레길"), List.of(
                 new Coordinate(37.602500, 126.967000),
                 new Coordinate(37.603000, 126.968000),
                 new Coordinate(37.603500, 126.969000),
@@ -74,13 +73,13 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 코스는_최대_3KM까지_탐색할_수_있다() {
-        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), List.of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, new CourseName("북악산 둘레길"), of(
+        var course2 = new Course(null, new CourseName("북악산 둘레길"), List.of(
                 new Coordinate(38.602500, 126.967000),
                 new Coordinate(38.603000, 126.968000),
                 new Coordinate(38.603500, 126.969000),
@@ -104,19 +103,19 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 가까운_코스들을_조회한다() {
-        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), List.of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, new CourseName("양재천 산책길"), of(
+        var course2 = new Course(null, new CourseName("양재천 산책길"), List.of(
                 new Coordinate(37.5165, 127.0285),
                 new Coordinate(37.5160, 127.0278),
                 new Coordinate(37.5155, 127.0265),
                 new Coordinate(37.5165, 127.0285)
         ), ADMIN_USER);
-        var course3 = new Course(null, new CourseName("북악산 둘레길"), of(
+        var course3 = new Course(null, new CourseName("북악산 둘레길"), List.of(
                 new Coordinate(37.602500, 126.967000),
                 new Coordinate(37.603000, 126.968000),
                 new Coordinate(37.603500, 126.969000),
@@ -142,19 +141,19 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 가까운_코스들을_조회하고_현위치에서_거리를_계산한다() {
-        var course1 = new Course(null, new CourseName("한강 러닝 코스"), of(
+        var course1 = new Course(null, new CourseName("한강 러닝 코스"), List.of(
                 new Coordinate(37.5180, 127.0280),
                 new Coordinate(37.5175, 127.0270),
                 new Coordinate(37.5170, 127.0265),
                 new Coordinate(37.5180, 127.0280)
         ), ADMIN_USER);
-        var course2 = new Course(null, new CourseName("양재천 산책길"), of(
+        var course2 = new Course(null, new CourseName("양재천 산책길"), List.of(
                 new Coordinate(37.5165, 127.0285),
                 new Coordinate(37.5160, 127.0278),
                 new Coordinate(37.5155, 127.0265),
                 new Coordinate(37.5165, 127.0285)
         ), ADMIN_USER);
-        var course3 = new Course(null, new CourseName("북악산 둘레길"), of(
+        var course3 = new Course(null, new CourseName("북악산 둘레길"), List.of(
                 new Coordinate(37.602500, 126.967000),
                 new Coordinate(37.603000, 126.968000),
                 new Coordinate(37.603500, 126.969000),
@@ -226,7 +225,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
     @Test
     void 코스의_좌표_중에서_가장_가까운_좌표를_계산한다() {
-        var course = new Course(null, new CourseName("한강 러닝 코스"), of(
+        var course = new Course(null, new CourseName("한강 러닝 코스"), List.of(
                 new Coordinate(0, 0),
                 new Coordinate(0, 0.0001),
                 new Coordinate(0.0001, 0.0001),
@@ -311,7 +310,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
         @Test
         void 코스_상세를_조회하면_리뷰_목록이_함께_반환된다() {
-            var course = new Course(null, "리뷰 테스트 코스", List.of(
+            var course = new Course(null, new CourseName("리뷰 테스트 코스"), List.of(
                     new Coordinate(0, 0),
                     new Coordinate(0, 0.0001),
                     new Coordinate(0.0001, 0.0001),
@@ -335,7 +334,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
         @Test
         void 동일_사용자가_여러_리뷰를_작성하면_모두_같은_닉네임으로_저장된다() {
-            var course = new Course(null, "동일 사용자 리뷰 코스", List.of(
+            var course = new Course(null, new CourseName("동일 사용자 리뷰 코스"), List.of(
                     new Coordinate(0, 0),
                     new Coordinate(0, 0.0001),
                     new Coordinate(0.0001, 0.0001),
@@ -380,5 +379,57 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
             Course result = dbUtil.findCourseByName(expectedName);
             assertThat(result.name().value()).isEqualTo(expectedName);
         }
+    }
+
+    @Test
+    void 코스_상세를_조회하면_리뷰_목록이_함께_반환된다() {
+        var course = new Course(null, new CourseName("리뷰 테스트 코스"), List.of(
+                new Coordinate(0, 0),
+                new Coordinate(0, 0.0001),
+                new Coordinate(0.0001, 0.0001),
+                new Coordinate(0.0001, 0),
+                new Coordinate(0, 0)
+        ), ADMIN_USER);
+        var savedCourse = dbUtil.saveCourse(course);
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-1"));
+
+        sut.addReview(savedCourse.id(), user.id(), "아주 좋은 코스입니다");
+
+        CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
+
+        assertThat(detail.id()).isEqualTo(savedCourse.id());
+        assertThat(detail.name()).isEqualTo("리뷰 테스트 코스");
+        assertThat(detail.reviews())
+                .hasSize(1)
+                .extracting(ReviewResponse::authorNickname, ReviewResponse::content)
+                .containsExactly(org.assertj.core.groups.Tuple.tuple(user.nickname().value(), "아주 좋은 코스입니다"));
+    }
+
+    @Test
+    void 동일_사용자가_여러_리뷰를_작성하면_모두_같은_닉네임으로_저장된다() {
+        var course = new Course(null, new CourseName("동일 사용자 리뷰 코스"), List.of(
+                new Coordinate(0, 0),
+                new Coordinate(0, 0.0001),
+                new Coordinate(0.0001, 0.0001),
+                new Coordinate(0, 0)
+        ), ADMIN_USER);
+        var savedCourse = dbUtil.saveCourse(course);
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-2"));
+
+        sut.addReview(savedCourse.id(), user.id(), "첫 번째 리뷰");
+        sut.addReview(savedCourse.id(), user.id(), "두 번째 리뷰");
+
+        CourseDetailResponse detail = sut.findCourseDetail(savedCourse.id());
+
+        assertThat(detail.reviews()).hasSize(2)
+                .allMatch(r -> r.authorNickname().equals(user.nickname().value()));
+    }
+
+    @Test
+    void 존재하지_않는_코스에_리뷰를_작성하면_예외가_발생한다() {
+        var user = dbUtil.saveUser(new User(UserProvider.KAKAO, "kakao-3"));
+
+        assertThatThrownBy(() -> sut.addReview("689c3143182cecc6353cca7b", user.id(), "내용"))
+                .isInstanceOf(NoSuchElementException.class);
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CourseRepositoryTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CourseRepositoryTest.java
@@ -23,10 +23,10 @@ class CourseRepositoryTest extends AbstractIntegrationTest {
     @BeforeEach
     void setUp() {
         var target = new Coordinate(mapLatitude, mapLongitude);
-        var course1 = new Course(null, "코스1", square(upright(target, 1200), 10, 10), ADMIN_USER);
-        var course2 = new Course(null, "코스2", square(upright(target, 1500), 10, 10), ADMIN_USER);
-        var course3 = new Course(null, "코스3", square(upright(target, 1700), 10, 10), ADMIN_USER);
-        var course4 = new Course(null, "코스4", square(upright(target, 2000), 10, 10), ADMIN_USER);
+        var course1 = new Course(null, new CourseName("코스1"), square(upright(target, 1200), 10, 10), ADMIN_USER);
+        var course2 = new Course(null, new CourseName("코스2"), square(upright(target, 1500), 10, 10), ADMIN_USER);
+        var course3 = new Course(null, new CourseName("코스3"), square(upright(target, 1700), 10, 10), ADMIN_USER);
+        var course4 = new Course(null, new CourseName("코스4"), square(upright(target, 2000), 10, 10), ADMIN_USER);
         dbUtil.saveCourse(course1);
         dbUtil.saveCourse(course2);
         dbUtil.saveCourse(course3);
@@ -68,13 +68,13 @@ class CourseRepositoryTest extends AbstractIntegrationTest {
         @BeforeEach
         void setUp() {
             var target = new Coordinate(mapLatitude, mapLongitude);
-            var shortCourse = new Course(null, "짧은코스", square(target, 50, 50), ADMIN_USER);      // 약 200m
-            var mediumCourse = new Course(null, "중간코스", square(target, 500, 500), ADMIN_USER);    // 약 2000m
-            var longCourse = new Course(null, "긴코스", square(target, 2500, 2500), ADMIN_USER);      // 약 10000m
-            var veryLongCourse = new Course(null, "매우긴코스", square(target, 7500, 7500), ADMIN_USER); // 약 30000m
-            var easyCourse = new Course(null, "쉬운코스", square(target, 100, 100), ADMIN_USER);       // 약 400m, 쉬움
-            var normalCourse = new Course(null, "보통코스", square(target, 2000, 2000), ADMIN_USER); // 약 8000m, 보통
-            var hardCourse = new Course(null, "어려운코스", square(target, 4000, 4000), ADMIN_USER);  // 약 16000m, 어려움
+            var shortCourse = new Course(null, new CourseName("짧은코스"), square(target, 50, 50), ADMIN_USER);      // 약 200m
+            var mediumCourse = new Course(null, new CourseName("중간코스"), square(target, 500, 500), ADMIN_USER);    // 약 2000m
+            var longCourse = new Course(null, new CourseName("긴코스"), square(target, 2500, 2500), ADMIN_USER);      // 약 10000m
+            var veryLongCourse = new Course(null, new CourseName("매우긴코스"), square(target, 7500, 7500), ADMIN_USER); // 약 30000m
+            var easyCourse = new Course(null, new CourseName("쉬운코스"), square(target, 100, 100), ADMIN_USER);       // 약 400m, 쉬움
+            var normalCourse = new Course(null, new CourseName("보통코스"), square(target, 2000, 2000), ADMIN_USER); // 약 8000m, 보통
+            var hardCourse = new Course(null, new CourseName("어려운코스"), square(target, 4000, 4000), ADMIN_USER);  // 약 16000m, 어려움
 
             dbUtil.saveCourse(shortCourse);
             dbUtil.saveCourse(mediumCourse);

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Stream;
 
 import static coursepick.coursepick.test_util.CoordinateTestUtil.*;
 import static coursepick.coursepick.test_util.UserFixture.ADMIN_USER;
+import static java.util.List.of;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.data.Percentage.withPercentage;
 
@@ -45,7 +46,7 @@ class CourseTest {
 
     @Test
     void 코스의_총_길이를_계산할_수_있다() {
-        var course = new Course(null, "코스", square(new Coordinate(0, 0), 10000, 10000), ADMIN_USER);
+        var course = new Course(null, new CourseName("코스"), square(new Coordinate(0, 0), 10000, 10000), ADMIN_USER);
 
         var distance = course.length();
 
@@ -56,7 +57,7 @@ class CourseTest {
     @MethodSource("targetAndDistance")
     void 특정_좌표에서_코스까지_가장_가까운_거리를_계산할_수_있다(Coordinate target, double expectedDistance) {
         var base = new Coordinate(0, 0);
-        var course = new Course(null, "코스", square(base, 10000, 10000), ADMIN_USER);
+        var course = new Course(null, new CourseName("코스"), square(base, 10000, 10000), ADMIN_USER);
 
         var distance = course.distanceFrom(target);
 
@@ -67,7 +68,7 @@ class CourseTest {
     @MethodSource("targetCoordinateAndExpectedCoordinate")
     void 코스에서_가장_가까운_좌표를_계산한다(Coordinate target, Coordinate expected) {
         var base = new Coordinate(0, 0);
-        var course = new Course(null, "코스", square(base, 10000, 10000), ADMIN_USER);
+        var course = new Course(null, new CourseName("코스"), square(base, 10000, 10000), ADMIN_USER);
 
         var minDistanceCoordinate = course.closestCoordinateFrom(target);
 
@@ -79,20 +80,14 @@ class CourseTest {
 
         @Test
         void 코스를_생성한다() {
-            assertThatCode(() -> new Course(null, "코스", List.of(new Coordinate(0, 0), new Coordinate(2, 2)), ADMIN_USER))
+            assertThatCode(() -> new Course(null, new CourseName("코스"), of(new Coordinate(0, 0), new Coordinate(2, 2)), ADMIN_USER))
                     .doesNotThrowAnyException();
         }
 
         @Test
         void 유저가_만든_코스를_생성한다() {
-            assertThatCode(() -> new Course(null, "코스", List.of(new Coordinate(0, 0), new Coordinate(2, 2)), TEST_USER))
+            assertThatCode(() -> new Course(null, new CourseName("코스"), of(new Coordinate(0, 0), new Coordinate(2, 2)), TEST_USER))
                     .doesNotThrowAnyException();
-        }
-
-        @Test
-        void 앞_뒤_공백을_제거하여_생성한다() {
-            var course = new Course(null, " 코스   ", List.of(new Coordinate(0, 0), new Coordinate(2, 2)), TEST_USER);
-            assertThat(course.name().value()).isEqualTo("코스");
         }
 
         @ParameterizedTest
@@ -101,29 +96,21 @@ class CourseTest {
                 "짧"
         })
         void 잘못된_길이의_이름으로_코스를_생성하면_예외가_발생한다(String name) {
-            assertThatThrownBy(() -> new Course(null, name, List.of(new Coordinate(0, 0), new Coordinate(2, 2)), ADMIN_USER))
+            assertThatThrownBy(() -> new Course(null, new CourseName(name), of(new Coordinate(0, 0), new Coordinate(2, 2)), ADMIN_USER))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
-        @ParameterizedTest
-        @ValueSource(strings = {
-                "코스 이름",
-                "코스  이름",
-        })
-        void 이름의_연속공백을_한_칸으로_변환하여_코스를_생성한다(String name) {
-            var course = new Course(null, name, List.of(new Coordinate(0, 0), new Coordinate(2, 2)), ADMIN_USER);
-            assertThat(course.name().value()).isEqualTo("코스 이름");
-        }
+
 
         @Test
         void 코스의_좌표의_개수가_2보다_적으면_예외가_발생한다() {
-            assertThatThrownBy(() -> new Course(null, "코스", List.of(new Coordinate(0, 0)), ADMIN_USER))
+            assertThatThrownBy(() -> new Course(null, new CourseName("코스"), of(new Coordinate(0, 0)), ADMIN_USER))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         void 코스_생성시_첫_좌표_끝_좌표만_존재할때_둘은_중복될_수_없다() {
-            assertThatThrownBy(() -> new Course(null, "코스", List.of(new Coordinate(0, 0), new Coordinate(0, 0)), ADMIN_USER))
+            assertThatThrownBy(() -> new Course(null, new CourseName("코스"), of(new Coordinate(0, 0), new Coordinate(0, 0)), ADMIN_USER))
                     .isInstanceOf(IllegalArgumentException.class);
         }
     }

--- a/backend/src/test/java/coursepick/coursepick/domain/course/GpxTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/GpxTest.java
@@ -40,7 +40,7 @@ class GpxTest {
                 new Coordinate(0.00001, 0.00001),
                 new Coordinate(0, 0)
         );
-        var course = new Course(null, "테스트코스", coordinates, ADMIN_USER);
+		var course = new Course(null, new CourseName("테스트코스"), coordinates, ADMIN_USER);
 
         var sut = Gpx.from(course);
 
@@ -61,7 +61,7 @@ class GpxTest {
                 new Coordinate(0.00001, 0.00001),
                 new Coordinate(0, 0)
         );
-        var course = new Course(null, "테스트코스", coordinates, ADMIN_USER);
+		var course = new Course(null, new CourseName("테스트코스"), coordinates, ADMIN_USER);
         var sut = Gpx.from(course);
 
         var xml = sut.toXmlContent();
@@ -83,7 +83,7 @@ class GpxTest {
                 new Coordinate(0.00001, 0.00001),
                 new Coordinate(0, 0)
         );
-        var course = new Course(null, "테스트코스", coordinates, ADMIN_USER);
+		var course = new Course(null, new CourseName("테스트코스"), coordinates, ADMIN_USER);
         var sut = Gpx.from(course);
 
         var courses = sut.toCourses(ADMIN_USER);


### PR DESCRIPTION
## 🛠️ 설명
- #810 pr 코드에 기반합니다.
- 코스 네임 중복 예외 메시지 처리와 그 외 예외 메시지 처리 로직을 추가했습니다.
- 응답에 관해 안드로이드와 소통 완료됐습니다.
## 📸 스크린샷 / 동영상
<img width="1414" height="568" alt="image" src="https://github.com/user-attachments/assets/264a3944-1376-4ffb-abed-844cb941198d" />
<img width="1336" height="1284" alt="image" src="https://github.com/user-attachments/assets/9931e8e8-10c4-4e7f-b32a-0cb8218c66a4" />


## 🔍 리뷰 요청사항

## 🔗 관련 이슈

- closes #827 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 입력 데이터 유효성 검사 실패 시 필드별 오류 메시지와 함께 400 Bad Request 반환
  * 중복 코스명 입력 시 명시된 한국어 오류 메시지와 함께 409 Conflict 반환
  * 좌표 필드가 비어있을 경우 명확한 한국어 검증 메시지("좌표는 비어있을 수 없습니다.") 반환
  * 오류 응답에 필드별 메시지 집약 및 타임스탬프 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->