### PR TITLE
코스 추가 화면 진입 시 기존 위치를 표시하도록 변경

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/Logger.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/Logger.kt
@@ -68,16 +68,10 @@ object Logger {
             override val name: String = "${target}_click"
         }
 
-        class MapMoveStart(
+        class MapMove(
             target: String,
         ) : Event() {
-            override val name: String = "${target}_map_move_start"
-        }
-
-        class MapMoveEnd(
-            target: String,
-        ) : Event() {
-            override val name: String = "${target}_map_move_end"
+            override val name: String = "${target}_map_move"
         }
 
         class Search(

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/compat/ParcelableCompat.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/compat/ParcelableCompat.kt
@@ -1,9 +1,9 @@
 package io.coursepick.coursepick.presentation.compat
 
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
-import java.io.Serializable
 
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -13,10 +13,10 @@ inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? 
         getParcelable(key) as? T
     }
 
-inline fun <reified T : Serializable> Bundle.getSerializableCompat(key: String): T? =
+inline fun <reified T : Parcelable> Intent.getParcelableCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getSerializable(key, T::class.java)
+        getParcelableExtra(key, T::class.java)
     } else {
         @Suppress("DEPRECATION")
-        getSerializable(key) as? T
+        getParcelableExtra(key) as? T
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/compat/ParcelableCompat.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/compat/ParcelableCompat.kt
@@ -4,10 +4,12 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.core.content.IntentCompat
+import androidx.core.os.BundleCompat
 
 inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelable(key, T::class.java)
+        BundleCompat.getParcelable(this, key, T::class.java)
     } else {
         @Suppress("DEPRECATION")
         getParcelable(key) as? T
@@ -15,7 +17,7 @@ inline fun <reified T : Parcelable> Bundle.getParcelableCompat(key: String): T? 
 
 inline fun <reified T : Parcelable> Intent.getParcelableCompat(key: String): T? =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        getParcelableExtra(key, T::class.java)
+        IntentCompat.getParcelableExtra(this, key, T::class.java)
     } else {
         @Suppress("DEPRECATION")
         getParcelableExtra(key) as? T

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -199,6 +199,8 @@ class CoursesActivity :
                 viewModel.select(course)
             }
 
+            mapManager.moveTo(coordinate = INITIAL_COORDINATE, animate = false)
+
             fetchInitialCourses()
         }
 
@@ -323,7 +325,7 @@ class CoursesActivity :
 
         mapManager.resetZoom()
         mapManager.drawSearchCoordinate(coordinate)
-        mapManager.moveTo(coordinate)
+        mapManager.moveTo(coordinate = coordinate, animate = true)
         fetchCourses(coordinate)
     }
 
@@ -408,7 +410,7 @@ class CoursesActivity :
                 }
 
                 mapManager.drawUserLocation(location)
-                mapManager.moveTo(location.coordinate)
+                mapManager.moveTo(coordinate = location.coordinate, animate = true)
                 binding.mainCurrentLocationButton.setColorFilter(
                     ContextCompat.getColor(this@CoursesActivity, R.color.gray3),
                 )
@@ -653,7 +655,7 @@ class CoursesActivity :
                     viewModel.currentLocation()?.let { location: Location ->
                         val userCoordinate = location.coordinate
                         mapManager.drawUserLocation(location)
-                        mapManager.moveTo(location.coordinate)
+                        mapManager.moveTo(coordinate = location.coordinate, animate = true)
                         viewModel.fetchCourses(userCoordinate, userCoordinate, scope)
                     } ?: run {
                         mapManager.hideUserLocation()
@@ -880,5 +882,9 @@ class CoursesActivity :
                 }
             }
         }
+    }
+
+    companion object {
+        private val INITIAL_COORDINATE = Coordinate(Latitude(37.5100226), Longitude(127.1026170))
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -59,6 +59,7 @@ import io.coursepick.coursepick.presentation.compat.getParcelableCompat
 import io.coursepick.coursepick.presentation.customcourse.CustomCoursesFragment
 import io.coursepick.coursepick.presentation.favorites.FavoriteCoursesFragment
 import io.coursepick.coursepick.presentation.filter.CourseFilterBottomSheet
+import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import io.coursepick.coursepick.presentation.map.MapManager
 import io.coursepick.coursepick.presentation.map.MapManagerFactory
 import io.coursepick.coursepick.presentation.notice.NoticeDialog
@@ -175,17 +176,29 @@ class CoursesActivity :
             setUpObservers()
             setUpFlowCollector()
             setUpMapPadding()
-            mapManager.setOnCameraMoveListener {
-                if (viewModel.content.value == CoursesContent.EXPLORE) {
-                    binding.mainSearchThisAreaButton.visibility = View.VISIBLE
+
+            mapManager.setOnCameraMoveListener { coordinate: Coordinate?, reason: CameraMoveReason ->
+                coordinate?.let(viewModel::onMapMoved)
+                if (reason == CameraMoveReason.GESTURE) {
+                    if (viewModel.content.value == CoursesContent.EXPLORE) {
+                        binding.mainSearchThisAreaButton.visibility = View.VISIBLE
+                    }
+                    binding.mainCurrentLocationButton.setColorFilter(
+                        ContextCompat.getColor(this, R.color.item_primary),
+                    )
+
+                    Logger.log(
+                        Logger.Event.MapMove("map"),
+                        "latitude" to coordinate.latitude,
+                        "longitude" to coordinate.longitude,
+                    )
                 }
-                binding.mainCurrentLocationButton.setColorFilter(
-                    ContextCompat.getColor(this, R.color.item_primary),
-                )
             }
+
             mapManager.setOnCourseClickListener { course: CourseItem ->
                 viewModel.select(course)
             }
+
             fetchInitialCourses()
         }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -177,8 +177,9 @@ class CoursesActivity :
             setUpFlowCollector()
             setUpMapPadding()
 
-            mapManager.setOnCameraMoveListener { coordinate: Coordinate?, reason: CameraMoveReason ->
-                coordinate?.let(viewModel::onMapMoved)
+            mapManager.setOnCameraMoveListener { coordinate: Coordinate, reason: CameraMoveReason ->
+                viewModel.onMapMoved(coordinate)
+
                 if (reason == CameraMoveReason.GESTURE) {
                     if (viewModel.content.value == CoursesContent.EXPLORE) {
                         binding.mainSearchThisAreaButton.visibility = View.VISIBLE

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -71,6 +71,9 @@ class CoursesViewModel
         private val _event: MutableSingleLiveData<CoursesUiEvent> = MutableSingleLiveData()
         val event: SingleLiveData<CoursesUiEvent> get() = _event
 
+        var mapCoordinate: Coordinate? = null
+            private set
+
         private var writeFavoriteJob: Job? = null
         private val pendingFavoriteWrites: MutableMap<String, Boolean> = mutableMapOf()
 
@@ -96,6 +99,10 @@ class CoursesViewModel
 
         fun switchContent(content: CoursesContent) {
             _content.value = content
+        }
+
+        fun onMapMoved(coordinate: Coordinate) {
+            mapCoordinate = coordinate
         }
 
         fun select(course: CourseItem) {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CoordinateUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CoordinateUiModel.kt
@@ -1,0 +1,10 @@
+package io.coursepick.coursepick.presentation.createcustomcourse
+
+import android.os.Parcelable
+import io.coursepick.coursepick.domain.course.Coordinate
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class CoordinateUiModel(
+    val value: Coordinate,
+) : Parcelable

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CoordinateUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CoordinateUiModel.kt
@@ -6,5 +6,8 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class CoordinateUiModel(
-    val value: Coordinate,
+    val latitude: Double,
+    val longitude: Double,
 ) : Parcelable
+
+fun Coordinate.toUiModel(): CoordinateUiModel = CoordinateUiModel(latitude.value, longitude.value)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseActivity.kt
@@ -19,6 +19,7 @@ import io.coursepick.coursepick.R
 import io.coursepick.coursepick.databinding.ActivityCustomCourseBinding
 import io.coursepick.coursepick.di.KakaoMap
 import io.coursepick.coursepick.presentation.InstallStateObserver
+import io.coursepick.coursepick.presentation.compat.getParcelableCompat
 import io.coursepick.coursepick.presentation.map.MapManager
 import io.coursepick.coursepick.presentation.map.MapManagerFactory
 import io.coursepick.coursepick.presentation.search.ui.theme.CoursePickTheme
@@ -55,6 +56,12 @@ class CreateCustomCourseActivity : AppCompatActivity() {
         mapManager.startMap {
             mapManager.setPadding(bottom = mapBottomPadding)
             setUpCollectors()
+
+            intent
+                .getParcelableCompat<CoordinateUiModel>(KEY_INITIAL_COORDINATE)
+                ?.let { initialCoordinate: CoordinateUiModel ->
+                    mapManager.moveTo(initialCoordinate.value)
+                }
 
             if (savedInstanceState != null) {
                 restoreProgress()
@@ -132,6 +139,15 @@ class CreateCustomCourseActivity : AppCompatActivity() {
     }
 
     companion object {
-        fun intent(context: Context): Intent = Intent(context, CreateCustomCourseActivity::class.java)
+        private const val KEY_INITIAL_COORDINATE = "key_initial_coordinate"
+
+        fun intent(
+            context: Context,
+            initialCoordinate: CoordinateUiModel?,
+        ): Intent =
+            Intent(
+                context,
+                CreateCustomCourseActivity::class.java,
+            ).putExtra(KEY_INITIAL_COORDINATE, initialCoordinate)
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseActivity.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.coursepick.coursepick.R
 import io.coursepick.coursepick.databinding.ActivityCustomCourseBinding
 import io.coursepick.coursepick.di.KakaoMap
+import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.presentation.InstallStateObserver
 import io.coursepick.coursepick.presentation.compat.getParcelableCompat
 import io.coursepick.coursepick.presentation.map.MapManager
@@ -53,15 +54,18 @@ class CreateCustomCourseActivity : AppCompatActivity() {
             insets
         }
 
+        val initialCoordinate: Coordinate? =
+            intent
+                .getParcelableCompat<CoordinateUiModel>(KEY_INITIAL_COORDINATE)
+                ?.let(CoordinateUiModel::value)
+
         mapManager.startMap {
             mapManager.setPadding(bottom = mapBottomPadding)
             setUpCollectors()
 
-            intent
-                .getParcelableCompat<CoordinateUiModel>(KEY_INITIAL_COORDINATE)
-                ?.let { initialCoordinate: CoordinateUiModel ->
-                    mapManager.moveTo(initialCoordinate.value)
-                }
+            if (initialCoordinate != null) {
+                mapManager.moveTo(coordinate = initialCoordinate, animate = false)
+            }
 
             if (savedInstanceState != null) {
                 restoreProgress()

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseActivity.kt
@@ -19,6 +19,8 @@ import io.coursepick.coursepick.R
 import io.coursepick.coursepick.databinding.ActivityCustomCourseBinding
 import io.coursepick.coursepick.di.KakaoMap
 import io.coursepick.coursepick.domain.course.Coordinate
+import io.coursepick.coursepick.domain.course.Latitude
+import io.coursepick.coursepick.domain.course.Longitude
 import io.coursepick.coursepick.presentation.InstallStateObserver
 import io.coursepick.coursepick.presentation.compat.getParcelableCompat
 import io.coursepick.coursepick.presentation.map.MapManager
@@ -57,7 +59,9 @@ class CreateCustomCourseActivity : AppCompatActivity() {
         val initialCoordinate: Coordinate? =
             intent
                 .getParcelableCompat<CoordinateUiModel>(KEY_INITIAL_COORDINATE)
-                ?.let(CoordinateUiModel::value)
+                ?.let { coordinate: CoordinateUiModel ->
+                    Coordinate(Latitude(coordinate.latitude), Longitude(coordinate.longitude))
+                }
 
         mapManager.startMap {
             mapManager.setPadding(bottom = mapBottomPadding)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -7,13 +7,11 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import dagger.hilt.android.AndroidEntryPoint
 import io.coursepick.coursepick.databinding.FragmentCustomCoursesBinding
 import io.coursepick.coursepick.presentation.course.CoursesViewModel
 import io.coursepick.coursepick.presentation.createcustomcourse.CoordinateUiModel
 import io.coursepick.coursepick.presentation.createcustomcourse.CreateCustomCourseActivity
 
-@AndroidEntryPoint
 class CustomCoursesFragment : Fragment() {
     @Suppress("ktlint:standard:backing-property-naming")
     private var _binding: FragmentCustomCoursesBinding? = null

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -8,9 +8,10 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import io.coursepick.coursepick.databinding.FragmentCustomCoursesBinding
+import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.presentation.course.CoursesViewModel
-import io.coursepick.coursepick.presentation.createcustomcourse.CoordinateUiModel
 import io.coursepick.coursepick.presentation.createcustomcourse.CreateCustomCourseActivity
+import io.coursepick.coursepick.presentation.createcustomcourse.toUiModel
 
 class CustomCoursesFragment : Fragment() {
     @Suppress("ktlint:standard:backing-property-naming")
@@ -43,7 +44,7 @@ class CustomCoursesFragment : Fragment() {
         startActivity(
             CreateCustomCourseActivity.intent(
                 requireContext(),
-                viewModel.mapCoordinate?.let(::CoordinateUiModel),
+                viewModel.mapCoordinate?.let(Coordinate::toUiModel),
             ),
         )
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -6,13 +6,20 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import dagger.hilt.android.AndroidEntryPoint
 import io.coursepick.coursepick.databinding.FragmentCustomCoursesBinding
+import io.coursepick.coursepick.presentation.course.CoursesViewModel
+import io.coursepick.coursepick.presentation.createcustomcourse.CoordinateUiModel
 import io.coursepick.coursepick.presentation.createcustomcourse.CreateCustomCourseActivity
 
+@AndroidEntryPoint
 class CustomCoursesFragment : Fragment() {
     @Suppress("ktlint:standard:backing-property-naming")
     private var _binding: FragmentCustomCoursesBinding? = null
     private val binding: FragmentCustomCoursesBinding get() = _binding!!
+
+    private val viewModel: CoursesViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -35,6 +42,11 @@ class CustomCoursesFragment : Fragment() {
     }
 
     private fun navigateCreateCustomCourse() {
-        startActivity(CreateCustomCourseActivity.intent(requireContext()))
+        startActivity(
+            CreateCustomCourseActivity.intent(
+                requireContext(),
+                viewModel.mapCoordinate?.let(::CoordinateUiModel),
+            ),
+        )
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/CameraMoveReason.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/CameraMoveReason.kt
@@ -1,0 +1,6 @@
+package io.coursepick.coursepick.presentation.map
+
+enum class CameraMoveReason {
+    SYSTEM,
+    GESTURE,
+}

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
@@ -46,7 +46,7 @@ interface MapManager {
 
     fun setOnCourseClickListener(onClick: (CourseItem) -> Unit)
 
-    fun setOnCameraMoveListener(onCameraMove: () -> Unit)
+    fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit)
 
     fun moveTo(coordinate: Coordinate)
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
@@ -46,7 +46,7 @@ interface MapManager {
 
     fun setOnCourseClickListener(onClick: (CourseItem) -> Unit)
 
-    fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit)
+    fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate, reason: CameraMoveReason) -> Unit)
 
     fun moveTo(
         coordinate: Coordinate,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
@@ -48,7 +48,10 @@ interface MapManager {
 
     fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit)
 
-    fun moveTo(coordinate: Coordinate)
+    fun moveTo(
+        coordinate: Coordinate,
+        animate: Boolean,
+    )
 
     fun resetZoom()
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
@@ -166,7 +166,7 @@ class GoogleMapManager(
         } ?: run { Timber.w("${GoogleMap::class.simpleName} is null.") }
     }
 
-    override fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit) {
+    override fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate, reason: CameraMoveReason) -> Unit) {
         map?.let { map: GoogleMap ->
             map.setOnCameraMoveStartedListener { reason: Int ->
                 onCameraMove(

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
@@ -16,6 +16,7 @@ import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
 import io.coursepick.coursepick.presentation.Logger
 import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import io.coursepick.coursepick.presentation.map.DistanceCalculator
 import io.coursepick.coursepick.presentation.map.MapManager
 import timber.log.Timber
@@ -174,17 +175,17 @@ class GoogleMapManager(
         } ?: run { Timber.w("${GoogleMap::class.simpleName} is null.") }
     }
 
-    override fun setOnCameraMoveListener(onCameraMove: () -> Unit) {
+    override fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit) {
         map?.let { map: GoogleMap ->
             map.setOnCameraMoveStartedListener { reason: Int ->
-                if (reason == CAMERA_MOVE_REASON_GESTURE) {
-                    Logger.log(
-                        Logger.Event.MapMoveStart("map"),
-                        "latitude" to map.cameraPosition.target.latitude,
-                        "longitude" to map.cameraPosition.target.longitude,
-                    )
-                    onCameraMove()
-                }
+                onCameraMove(
+                    map.cameraPosition.target.toCoordinate(),
+                    if (reason == CAMERA_MOVE_REASON_GESTURE) {
+                        CameraMoveReason.GESTURE
+                    } else {
+                        CameraMoveReason.SYSTEM
+                    },
+                )
             }
         } ?: run { Timber.w("${GoogleMap::class.simpleName} is null.") }
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
@@ -1,9 +1,9 @@
 package io.coursepick.coursepick.presentation.map.google
 
+import com.google.android.gms.maps.CameraUpdate
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.SupportMapFragment
-import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
 import com.google.android.gms.maps.model.MapStyleOptions
@@ -61,15 +61,6 @@ class GoogleMapManager(
                 ),
             )
             map.uiSettings.isCompassEnabled = false
-            map.moveCamera(
-                CameraUpdateFactory.newCameraPosition(
-                    CameraPosition
-                        .builder()
-                        .target(DEFAULT_LATLNG)
-                        .zoom(DEFAULT_ZOOM_LEVEL)
-                        .build(),
-                ),
-            )
             setLogger()
 
             onMapReady()
@@ -190,13 +181,21 @@ class GoogleMapManager(
         } ?: run { Timber.w("${GoogleMap::class.simpleName} is null.") }
     }
 
-    override fun moveTo(coordinate: Coordinate) {
+    override fun moveTo(
+        coordinate: Coordinate,
+        animate: Boolean,
+    ) {
         map?.let { map: GoogleMap ->
-            map.animateCamera(
-                CameraUpdateFactory.newLatLng(coordinate.toLatLng()),
-                MOVE_ANIMATION_DURATION_MS.toInt(),
-                null,
-            )
+            val cameraUpdate: CameraUpdate = CameraUpdateFactory.newLatLng(coordinate.toLatLng())
+            if (animate) {
+                map.animateCamera(
+                    cameraUpdate,
+                    MOVE_ANIMATION_DURATION_MS.toInt(),
+                    null,
+                )
+            } else {
+                map.moveCamera(cameraUpdate)
+            }
         } ?: run { Timber.w("${GoogleMap::class.simpleName} is null.") }
     }
 
@@ -240,9 +239,6 @@ class GoogleMapManager(
 
     companion object {
         private const val MOVE_ANIMATION_DURATION_MS = 750L
-        private const val DEFAULT_LATITUDE = 37.5100226
-        private const val DEFAULT_LONGITUDE = 127.1026170
-        private val DEFAULT_LATLNG = LatLng(DEFAULT_LATITUDE, DEFAULT_LONGITUDE)
         private const val DEFAULT_ZOOM_LEVEL = 15F
         private const val CAMERA_MOVE_REASON_GESTURE = 1
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapCameraController.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapCameraController.kt
@@ -19,11 +19,16 @@ class KakaoMapCameraController(
     fun moveTo(
         map: KakaoMap,
         coordinate: Coordinate,
+        animate: Boolean,
     ) {
         val cameraUpdate: CameraUpdate =
             CameraUpdateFactory.newCenterPosition(coordinate.toLatLng())
-        val cameraAnimation = CameraAnimation.from(MOVE_ANIMATION_DURATION, true, false)
-        map.moveCamera(cameraUpdate, cameraAnimation)
+        if (animate) {
+            val cameraAnimation = CameraAnimation.from(MOVE_ANIMATION_DURATION, true, false)
+            map.moveCamera(cameraUpdate, cameraAnimation)
+        } else {
+            map.moveCamera(cameraUpdate)
+        }
     }
 
     fun fitTo(

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
@@ -51,28 +51,32 @@ class KakaoMapEventHandler {
 
     fun setOnCameraMoveListener(
         map: KakaoMap,
-        onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit,
+        onCameraMove: (coordinate: Coordinate, reason: CameraMoveReason) -> Unit,
     ) {
         map.setOnCameraMoveStartListener { _, gestureType: GestureType ->
-            onCameraMove(
-                map.cameraPosition?.position?.toCoordinate(),
-                if (gestureType == GestureType.Unknown) {
-                    CameraMoveReason.SYSTEM
-                } else {
-                    CameraMoveReason.GESTURE
-                },
-            )
+            map.cameraPosition?.position?.toCoordinate()?.let { coordinate: Coordinate ->
+                onCameraMove(
+                    coordinate,
+                    if (gestureType == GestureType.Unknown) {
+                        CameraMoveReason.SYSTEM
+                    } else {
+                        CameraMoveReason.GESTURE
+                    },
+                )
+            }
         }
 
         map.setOnCameraMoveEndListener { _, cameraPosition: CameraPosition, gestureType: GestureType ->
-            onCameraMove(
-                cameraPosition.position?.toCoordinate(),
-                if (gestureType == GestureType.Unknown) {
-                    CameraMoveReason.SYSTEM
-                } else {
-                    CameraMoveReason.GESTURE
-                },
-            )
+            cameraPosition.position?.toCoordinate()?.let { coordinate: Coordinate ->
+                onCameraMove(
+                    coordinate,
+                    if (gestureType == GestureType.Unknown) {
+                        CameraMoveReason.SYSTEM
+                    } else {
+                        CameraMoveReason.GESTURE
+                    },
+                )
+            }
         }
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
@@ -10,6 +10,7 @@ import com.kakao.vectormap.camera.CameraPosition
 import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.presentation.Logger
 import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import kotlin.math.pow
 import kotlin.math.sqrt
 
@@ -50,35 +51,27 @@ class KakaoMapEventHandler {
 
     fun setOnCameraMoveListener(
         map: KakaoMap,
-        onCameraMove: () -> Unit,
+        onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit,
     ) {
         map.setOnCameraMoveStartListener { _, gestureType: GestureType ->
-            if (gestureType == GestureType.Unknown) return@setOnCameraMoveStartListener
-            val cameraPosition: CameraPosition? = map.cameraPosition
-            Logger.log(
-                Logger.Event.MapMoveStart("map"),
-                "gesture_type" to gestureType.name,
-                "latitude" to cameraPosition?.position?.latitude.toString(),
-                "longitude" to cameraPosition?.position?.longitude.toString(),
-                "height" to cameraPosition?.height.toString(),
-                "tilt_angle" to cameraPosition?.tiltAngle.toString(),
-                "rotation_angle" to cameraPosition?.rotationAngle.toString(),
-                "zoom_level" to cameraPosition?.zoomLevel.toString(),
+            onCameraMove(
+                map.cameraPosition?.position?.toCoordinate(),
+                if (gestureType == GestureType.Unknown) {
+                    CameraMoveReason.SYSTEM
+                } else {
+                    CameraMoveReason.GESTURE
+                },
             )
-            onCameraMove()
         }
 
         map.setOnCameraMoveEndListener { _, cameraPosition: CameraPosition, gestureType: GestureType ->
-            if (gestureType == GestureType.Unknown) return@setOnCameraMoveEndListener
-            Logger.log(
-                Logger.Event.MapMoveEnd("map"),
-                "gesture_type" to gestureType.name,
-                "latitude" to cameraPosition.position.latitude,
-                "longitude" to cameraPosition.position.longitude,
-                "height" to cameraPosition.height,
-                "tilt_angle" to cameraPosition.tiltAngle,
-                "rotation_angle" to cameraPosition.rotationAngle,
-                "zoom_level" to cameraPosition.zoomLevel,
+            onCameraMove(
+                cameraPosition.position?.toCoordinate(),
+                if (gestureType == GestureType.Unknown) {
+                    CameraMoveReason.SYSTEM
+                } else {
+                    CameraMoveReason.GESTURE
+                },
             )
         }
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapLifecycleHandler.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapLifecycleHandler.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.KakaoMapReadyCallback
-import com.kakao.vectormap.LatLng
 import com.kakao.vectormap.MapLifeCycleCallback
 import com.kakao.vectormap.MapView
 
@@ -28,8 +27,6 @@ class KakaoMapLifecycleHandler(
                 override fun onMapReady(map: KakaoMap) {
                     onMapReady(map)
                 }
-
-                override fun getPosition(): LatLng = DEFAULT_LATLNG
             },
         )
     }
@@ -47,11 +44,5 @@ class KakaoMapLifecycleHandler(
     override fun onDestroy(owner: LifecycleOwner) {
         super.onDestroy(owner)
         mapView.finish()
-    }
-
-    companion object {
-        private const val DEFAULT_LATITUDE = 37.5100226
-        private const val DEFAULT_LONGITUDE = 127.1026170
-        private val DEFAULT_LATLNG = LatLng.from(DEFAULT_LATITUDE, DEFAULT_LONGITUDE)
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
@@ -135,9 +135,12 @@ class KakaoMapManager(
         } ?: Timber.w("kakaoMap is null")
     }
 
-    override fun moveTo(coordinate: Coordinate) {
+    override fun moveTo(
+        coordinate: Coordinate,
+        animate: Boolean,
+    ) {
         kakaoMap?.let { kakaoMap: KakaoMap ->
-            cameraController.moveTo(kakaoMap, coordinate)
+            cameraController.moveTo(map = kakaoMap, coordinate = coordinate, animate = animate)
         } ?: Timber.w("kakaoMap is null")
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
@@ -11,6 +11,7 @@ import io.coursepick.coursepick.domain.course.Scope
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
 import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import io.coursepick.coursepick.presentation.map.DistanceCalculator
 import io.coursepick.coursepick.presentation.map.MapManager
 import timber.log.Timber
@@ -128,11 +129,9 @@ class KakaoMapManager(
         } ?: Timber.w("kakaoMap is null")
     }
 
-    override fun setOnCameraMoveListener(onCameraMove: () -> Unit) {
+    override fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit) {
         kakaoMap?.let { kakaoMap: KakaoMap ->
-            eventHandler.setOnCameraMoveListener(kakaoMap) {
-                onCameraMove()
-            }
+            eventHandler.setOnCameraMoveListener(kakaoMap, onCameraMove)
         } ?: Timber.w("kakaoMap is null")
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
@@ -129,7 +129,7 @@ class KakaoMapManager(
         } ?: Timber.w("kakaoMap is null")
     }
 
-    override fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate?, reason: CameraMoveReason) -> Unit) {
+    override fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate, reason: CameraMoveReason) -> Unit) {
         kakaoMap?.let { kakaoMap: KakaoMap ->
             eventHandler.setOnCameraMoveListener(kakaoMap, onCameraMove)
         } ?: Timber.w("kakaoMap is null")


### PR DESCRIPTION
## 🛠️ 설명
코스 추가 화면으로 진입할 때, 사용자가 코스 탐색 화면에서 보고있던 위치를 표시하도록 변경합니다.

## 📸 스크린샷 / 동영상

<table>
  <tr>
    <th>As-is</th>
    <th>To-be</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/68031776-dc33-44f2-9979-5e58c794232d"></td>
    <td><video src="https://github.com/user-attachments/assets/a4968b1d-a1b9-4f08-b84a-34131d734815"></td>
  </tr>
</table>


## 🔗 관련 이슈

- closes #843

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 지도 제스처와 시스템 이벤트를 구분하여 카메라 이동 처리 개선
  * 커스텀 코스 생성 시 현재 지도 위치를 초기 좌표로 자동 설정 가능
  * 지도 이동 시 애니메이션 여부 제어 옵션 추가

* **버그 수정**
  * 지도 UI 업데이트를 사용자 제스처 시에만 적용하도록 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->