### PR TITLE
코스 추가 시 CourseCreateWebRequest 리팩토링

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseCreateWebRequest.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseCreateWebRequest.java
@@ -2,6 +2,7 @@ package coursepick.coursepick.presentation.dto;
 
 import coursepick.coursepick.domain.course.Coordinate;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -15,16 +16,12 @@ public record CourseCreateWebRequest(
         @Schema(description = "코스를 구성하는 좌표 목록 (최소 2개 이상)", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull
         @Size(min = 2, message = "코스는 출발지와 도착지 등 최소 2개 이상의 좌표가 필요합니다.")
-        List<
-            @NotNull(message = "개별 좌표 값은 비어있을 수 없습니다.") 
-            @Size(min = 2, max = 2, message = "각 좌표는 반드시 [위도, 경도] 2개의 값을 가져야 합니다.")
-            List<Double>
-        > coordinates
+        List<@NotNull(message = "개별 좌표 값은 비어있을 수 없습니다.") @Valid CoordinateWebRequest> coordinates
 ) {
 
     public List<Coordinate> toCoordinates() {
         return coordinates.stream()
-                .map(raw -> new Coordinate(raw.getFirst(), raw.get(1)))
+                .map(CoordinateWebRequest::toCoordinate)
                 .toList();
     }
 }


### PR DESCRIPTION
## 🛠️ 설명
코스 생성 API의 좌표 입력(dto)이 List<List<Double>> -> List<CoordinateWebRequest>로 형식을 통일했습니다.

변경 전
```json
"coordinates": [[37.5, 127.1], [37.6, 127.2]]

```
변경 후
```json
"coordinates": [
  {"latitude": 37.5, "longitude": 127.1},
  {"latitude": 37.6, "longitude": 127.2}
]

```


## 🔗 관련 이슈

- closes #847


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 코스 생성 시 좌표 검증이 강화되어 더욱 정확한 데이터 처리를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->