### PR TITLE
코스 직접 생성의 경로 탐색 API 응답에서 보정되지 않은 첫/마지막 좌표 제외

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -69,7 +69,8 @@ public class CourseApplicationService {
             List<Coordinate> path = routeFinder.find(routePoints.get(i), routePoints.get(i + 1));
             draftRoute = draftRoute.merge(DraftSegment.of(path));
         }
-        return draftRoute;
+        List<Coordinate> coordinates = draftRoute.coordinates();
+        return DraftSegment.of(coordinates.subList(1, coordinates.size() - 1));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/coursepick/coursepick/application/FindDraftRouteTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/FindDraftRouteTest.java
@@ -32,39 +32,49 @@ class FindDraftRouteTest {
     }
 
     @Test
-    void 경로_좌표_두_개로_경로를_조회할_때_반환된_경로에_중간_좌표까지_모두_포함된다() {
-        // 사용자가 입력하는 좌표: start -> end (2개)
-        var start = new Coordinate(0, 0);
-        var end = right(start, 1000);
+    void 경로_좌표_두_개로_경로를_조회할_때_원본_첫_끝_좌표는_제외되고_보정된_경로가_반환된다() {
+        // 사용자가 도로 밖을 탭한 원본 좌표
+        var rawStart = new Coordinate(0, 0);
+        var rawEnd = right(rawStart, 1000);
 
-        // routeFinder가 실제 도로 경로를 탐색하면 중간 좌표도 함께 반환된다.
-        var midPoint1 = right(start, 300);
-        var midPoint2 = right(start, 700);
-        when(routeFinder.find(start, end)).thenReturn(List.of(start, midPoint1, midPoint2, end));
+        // OsrmRouteFinder: OSRM 보정 경로 앞뒤에 원본(raw) 좌표를 붙여서 반환한다
+        var snappedStart = right(rawStart, 50);  // OSRM이 도로에 보정한 시작 좌표
+        var midPoint = right(rawStart, 500);
+        var snappedEnd = right(rawStart, 950);   // OSRM이 도로에 보정한 끝 좌표
+        when(routeFinder.find(rawStart, rawEnd))
+                .thenReturn(List.of(rawStart, snappedStart, midPoint, snappedEnd, rawEnd));
 
-        DraftSegment result = courseService.findDraftRoute(List.of(start, end));
+        DraftSegment result = courseService.findDraftRoute(List.of(rawStart, rawEnd));
 
-        assertThat(result.coordinates()).containsExactly(start, midPoint1, midPoint2, end);
-        assertThat(result.length().value()).isCloseTo(1000, withPercentage(1));
+        // 원본(raw) 첫/마지막 좌표는 제외되고, 보정된 좌표로 시작/끝난다
+        assertThat(result.coordinates()).containsExactly(snappedStart, midPoint, snappedEnd);
+
+        //snappedStart부터 midPoint까지(450m), midPoint부터 snappedEnd까지(450m) = 900m
+        assertThat(result.length().value()).isCloseTo(900, withPercentage(1));
     }
 
     @Test
     void 경로_좌표_세_개로_경로를_조회할_때_두_구간이_중복_없이_병합된다() {
-        // 사용자가 입력하는 좌표: start -> mid -> end (3개, 구간 2개)
-        var start = new Coordinate(0, 0);
-        var mid = right(start, 1000);
-        var end = right(mid, 1000);
+        // 사용자가 입력하는 좌표: rawStart -> rawMid -> rawEnd (3개, 구간 2개)
+        var rawStart = new Coordinate(0, 0);
+        var rawMid = right(rawStart, 1000);
+        var rawEnd = right(rawMid, 1000);
 
-        // 각 구간별로 routeFinder가 중간 좌표를 포함한 경로를 반환
-        var midPoint1 = right(start, 300);  // start -> mid 구간의 중간 좌표
-        var midPoint2 = right(mid, 300);    // mid -> end 구간의 중간 좌표
-        when(routeFinder.find(start, mid)).thenReturn(List.of(start, midPoint1, mid));
-        when(routeFinder.find(mid, end)).thenReturn(List.of(mid, midPoint2, end));
+        // 각 구간은 OsrmRouteFinder처럼 원본 좌표를 앞뒤에 붙여서 반환
+        var snappedStart = right(rawStart, 50); // 보정된 시작 좌표
+        var midPoint1 = right(rawStart, 300);
+        var midPoint2 = right(rawMid, 300);
+        var snappedEnd = right(rawMid, 950); // 보정된 끝 좌표
+        when(routeFinder.find(rawStart, rawMid))
+                .thenReturn(List.of(rawStart, snappedStart, midPoint1, rawMid));
+        when(routeFinder.find(rawMid, rawEnd))
+                .thenReturn(List.of(rawMid, midPoint2, snappedEnd, rawEnd));
 
-        DraftSegment result = courseService.findDraftRoute(List.of(start, mid, end));
+        DraftSegment result = courseService.findDraftRoute(List.of(rawStart, rawMid, rawEnd));
 
-        // 두 구간이 하나로 합쳐지고, 연결점(mid)이 중복되지 않는다.
-        assertThat(result.coordinates()).containsExactly(start, midPoint1, mid, midPoint2, end);
-        assertThat(result.length().value()).isCloseTo(2000, withPercentage(1));
+        // 원본 첫/끝 좌표 제외, 중간 웨이포인트(rawMid)는 연결점으로 유지되며 중복 없이 병합된다
+        assertThat(result.coordinates()).containsExactly(snappedStart, midPoint1, rawMid, midPoint2, snappedEnd);
+        // snappedStart부터 midPoint1까지(250m) + midPoint1부터 rawMid까지(700m) + rawMid부터 midPoint2까지(300m) + midPoint2부터 snappedEnd까지(650m) = 1900m
+        assertThat(result.length().value()).isCloseTo(1900, withPercentage(1));
     }
 }


### PR DESCRIPTION
## 🛠️ 설명
### 현재 상황

1. 현재 안드로이드에서 코스를 그릴 때, `길을 벗어난 지점을 찍으면 첫 점과 마지막 점이 튀는 현상`이 발생합니다. 

디랙이 말씀해주신 것처럼 백엔드에서 응답으로 첫 점과 마지막 점은 보정 없는 원본을 보내기 때문입니다. 

이유는 길찾기를 할 때 사용하는 `RouteFinder` 의 `find()` 를 코스를 그릴 때도 사용했기 때문인데요. 
이 메서드에는 다음과 같은 코드가 있어서 좌표들에 맨 처음과 마지막 점에 원본 좌표를 넣어줍니다. 

```java
coordinates.addFirst(origin);
coordinates.addLast(destination);
```

2. 그래서 경로가 튀지 않도록 안드로이드에서 마지막 점은 버리는 식으로 사용해보려고 했지만, 그렇게 되더라도 `길이 아닌 좌표를 첫 점 또는 마지막 점으로 찍었을 때 총 거리에서 오차`가 나는 문제가 발생합니다. 

다음 영상을 보시면 길이 아닌 좌표에서 계속 찍었을 때 총 거리가 계속 누적이 되는 문제가 있습니다. 길에서부터 원본 좌표까지의 거리를 총 거리에 계속 누적하고 있기 때문입니다. 이러면 보이는 코스와 총 거리에 오차가 생기는 문제가 발생하게 됩니다. 

[totalLength.webm](https://github.com/user-attachments/assets/71c01c7a-63b9-42c9-befe-e43f74672bba)


### 현재 상황의 문제

1. 코스를 그릴 때 좌표가 튀어 보이는 문제가 발생합니다. 
2. 처음과 끝 점으로 길이 아닌 좌표를 찍었을 때 코스에 보이는 것과 다르게 총 거리에 오차가 발생합니다. 

### 해결하는 것

사용자가 직접 코스를 그려서 만들 때, 

1. 좌표가 튀어 보이는 문제
2. 길이 아닌 출발/도착점을 찍었을 때의 총 거리 오차가 있었던 문제를 해결합니다. 

### 해결 방법

원래는 `find()`로 원본 출발점과 도착점을 붙인 경로를 그대로 반환했는데,
그 좌표들에서 `coordinates.subList(1, coordinates.size() - 1)` 로 원본 두 점을 제외해서 반환하여 해결했습니다. 

기존 코드

```java
return draftRoute;
```

수정된 부분

```java
List<Coordinate> coordinates = draftRoute.coordinates();
return DraftSegment.of(coordinates.subList(1, coordinates.size() - 1));
```

이렇게 하면 원본 출발점과 원본 도착점을 삭제한 좌표들을 반환하게 됩니다.

## 🔗 관련 이슈

- closes #853 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 드래프트 경로의 좌표 처리 로직을 개선하여 정확한 경로 범위 계산
  * 경로의 시작점과 끝점 좌표 처리 개선으로 거리 계산 정확도 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->