### PR TITLE
PR 템플릿 스크린샷/동영상 테이블 수정

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,27 @@
 ## 🛠️ 설명
 
 ## 📸 스크린샷 / 동영상
+<table>
+  <tr>
+    <th>As-is</th>
+    <th>To-be</th>
+  </tr>
+  <tr>
+    <td><img alt="image" src=""></td>
+    <td><img alt="image" src=""></td>
+  </tr>
+</table>
 
-| AS-IS | TO-BE |
-|-------|-------|
-| 전     | 후     |
+<table>
+  <tr>
+    <th>As-is</th>
+    <th>To-be</th>
+  </tr>
+  <tr>
+    <td><video src=""></video></td>
+    <td><video src=""></video></td>
+  </tr>
+</table>
 
 ## 🔍 리뷰 요청사항
 


### PR DESCRIPTION
## 🛠️ 설명

현재 PR 템플릿에서 사용하는 마크다운 테이블에는 동영상을 첨부할 수 없습니다.

PR 템플릿의 `스크린샷 / 동영상` 부분에 수정 전/후 동영상을 테이블 형식으로 첨부하기 수월하도록 마크다운 테이블을 HTML 테이블로 교체했습니다.

RP에 이미지/동영상을 첨부하면 생기는 링크를 테이블의 `src` attribute로 넣어서 사용할 수 있습니다.

### 예시:
<img width="1620" height="434" alt="image" src="https://github.com/user-attachments/assets/de431732-0a7d-4057-8be0-f2f7358ef216" />


## 🔗 관련 이슈

- closes #875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Pull Request 템플릿을 개선하여 스크린샷 및 비디오 섹션의 구조를 명확하게 정리했습니다. "As-is"와 "To-be" 열을 포함한 HTML 테이블 형식으로 변경하여 변경 전후 비교를 더 쉽게 볼 수 있도록 개선했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/876)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->