### PR TITLE
코스 리뷰 삭제 api

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -124,6 +124,9 @@ public class CourseApplicationService {
     @Transactional
     public void addReview(String courseId, String userId, String content, int rating) {
         User user = getUser(userId);
+        Course course = getCourse(courseId);
+        course.verifyWriteReviewEligibility(user);
+
         courseRepository.pushReview(courseId, new Review(user, content, rating));
     }
 
@@ -131,9 +134,9 @@ public class CourseApplicationService {
     public void deleteReview(String courseId, String reviewId, String userId) {
         Course course = getCourse(courseId);
         Review review = course.getReview(reviewId);
+        course.verifyRemovableReview(review, userId);
 
-        course.removeReview(review, userId);
-        courseRepository.save(course);
+        courseRepository.deleteReview(courseId, reviewId);
     }
 
     @Transactional

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -124,9 +124,7 @@ public class CourseApplicationService {
     @Transactional
     public void addReview(String courseId, String userId, String content, int rating) {
         User user = getUser(userId);
-        Course course = getCourse(courseId);
-        course.addReview(user, content, rating);
-        courseRepository.save(course);
+        courseRepository.pushReview(courseId, new Review(user, content, rating));
     }
 
     @Transactional

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -130,6 +130,15 @@ public class CourseApplicationService {
     }
 
     @Transactional
+    public void deleteReview(String courseId, String reviewId, String userId) {
+        Course course = getCourse(courseId);
+        Review review = course.getReview(reviewId);
+
+        course.removeReview(review, userId);
+        courseRepository.save(course);
+    }
+
+    @Transactional
     public void reportReview(String courseId, String reviewId, String userId) {
         User user = getUser(userId);
         Course course = getCourse(courseId);

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -120,19 +120,16 @@ public class Course {
         this.name = new CourseName(courseName);
     }
 
-    public void addReview(User author, String content, int reviewRating) {
+    public void verifyWriteReviewEligibility(User author) {
         if (reviews.stream().anyMatch(review -> review.userId().equals(author.id()))) {
             throw ALREADY_REVIEWED_COURSE.create(this.id, author.id());
         }
-        reviews.add(new Review(author, content, reviewRating));
     }
 
-    public void removeReview(Review review, String userId) {
+    public void verifyRemovableReview(Review review, String userId) {
         if (!review.userId().equals(userId)) {
             throw AUTHENTICATION_FAIL.create();
         }
-
-        reviews.remove(review);
     }
 
     public void addReport(User user) {

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -45,6 +45,8 @@ public class Course {
 
     private List<Review> reviews;
 
+    private double averageRating;
+
     private String creatorId;
 
     private Set<String> reportUserIds;
@@ -58,6 +60,7 @@ public class Course {
         this.simplifiedCoordinates = simplifyCoordinates(this.coordinates);
         this.length = calculateLength(coordinates);
         this.reviews = new ArrayList<>();
+        this.averageRating = 0.0;
         this.creatorId = user.id();
         this.reportUserIds = new HashSet<>();
         this.createdAt = LocalDateTime.now();

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -45,8 +45,6 @@ public class Course {
 
     private List<Review> reviews;
 
-    private double averageRating;
-
     private String creatorId;
 
     private Set<String> reportUserIds;
@@ -60,7 +58,6 @@ public class Course {
         this.simplifiedCoordinates = simplifyCoordinates(this.coordinates);
         this.length = calculateLength(coordinates);
         this.reviews = new ArrayList<>();
-        this.averageRating = 0.0;
         this.creatorId = user.id();
         this.reportUserIds = new HashSet<>();
         this.createdAt = LocalDateTime.now();

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -124,7 +124,11 @@ public class Course {
         reviews.add(new Review(author, content, reviewRating));
     }
 
-    public void removeReview(Review review) {
+    public void removeReview(Review review, String userId) {
+        if (!review.userId().equals(userId)) {
+            throw UNAUTHORIZED_REVIEW_DELETE.create(review.id(), userId);
+        }
+
         reviews.remove(review);
     }
 

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -126,7 +126,7 @@ public class Course {
 
     public void removeReview(Review review, String userId) {
         if (!review.userId().equals(userId)) {
-            throw UNAUTHORIZED_REVIEW_DELETE.create(review.id(), userId);
+            throw AUTHENTICATION_FAIL.create();
         }
 
         reviews.remove(review);

--- a/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
@@ -26,4 +26,6 @@ public interface CourseRepository {
     boolean existByCourseName(CourseName courseName);
 
     void pushReview(String courseId, Review review);
+
+    void deleteReview(String courseId, String reviewId);
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/CourseRepository.java
@@ -24,4 +24,6 @@ public interface CourseRepository {
     void delete(Course course);
 
     boolean existByCourseName(CourseName courseName);
+
+    void pushReview(String courseId, Review review);
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
@@ -2,7 +2,6 @@ package coursepick.coursepick.infrastructure.mongodb;
 
 import com.mongodb.MongoExecutionTimeoutException;
 import com.mongodb.MongoTimeoutException;
-import com.mongodb.client.result.UpdateResult;
 import coursepick.coursepick.domain.course.*;
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
-import static coursepick.coursepick.application.exception.ErrorType.NOT_EXIST_COURSE;
 import static coursepick.coursepick.application.exception.ErrorType.QUERY_TIMEOUT;
 
 @Repository
@@ -39,7 +37,7 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
         /*
         배치 삽입을 통해 성능을 높일 수 있다. 단, 현재 새벽2시에만 호출되는 메서드라, 크게 필요해보이지는 않는다.
         또한, 현재 메모리 문제가 더 크므로 일단은 넘긴다. 필요한 경우 아래 코드를 참고할 것
-        BulkOperations ops = mongoTemplate.bulkOps(BulkMode.UNORDERED, Course.class);
+        BulkOperations ops = mongoTemplate.bulkOps(BulkMode.UNORDERED, mongoTemplate.getCollectionName(Course.class));
         ops.insert(courses);
         ops.execute();
          */
@@ -160,14 +158,24 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
 
         Update update = new Update().push("reviews", reviewDoc);
 
-        UpdateResult updateResult = mongoTemplate.updateFirst(
+        mongoTemplate.updateFirst(
                 query,
                 update,
-                Course.class
+                mongoTemplate.getCollectionName(Course.class)
         );
+    }
 
-        if (updateResult.getModifiedCount() <= 0) {
-            throw NOT_EXIST_COURSE.create(courseId);
-        }
+    @Override
+    public void deleteReview(String courseId, String reviewId) {
+
+        Query query = new Query(Criteria.where("_id").is(courseId));
+
+        Update update = new Update().pull("reviews", new Document("id", reviewId));
+
+        mongoTemplate.updateFirst(
+                query,
+                update,
+                mongoTemplate.getCollectionName(Course.class)
+        );
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
@@ -2,11 +2,10 @@ package coursepick.coursepick.infrastructure.mongodb;
 
 import com.mongodb.MongoExecutionTimeoutException;
 import com.mongodb.MongoTimeoutException;
-import coursepick.coursepick.domain.course.Course;
-import coursepick.coursepick.domain.course.CourseFindCondition;
-import coursepick.coursepick.domain.course.CourseName;
-import coursepick.coursepick.domain.course.CourseRepository;
+import com.mongodb.client.result.UpdateResult;
+import coursepick.coursepick.domain.course.*;
 import lombok.RequiredArgsConstructor;
+import org.bson.Document;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
@@ -14,12 +13,14 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.geo.GeoJsonPoint;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
 
+import static coursepick.coursepick.application.exception.ErrorType.NOT_EXIST_COURSE;
 import static coursepick.coursepick.application.exception.ErrorType.QUERY_TIMEOUT;
 
 @Repository
@@ -142,5 +143,31 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
     @Override
     public boolean existByCourseName(CourseName courseName) {
         return mongoTemplate.exists(Query.query(Criteria.where("name").is(courseName.value())), Course.class);
+    }
+
+    @Override
+    public void pushReview(String courseId, Review review) {
+        Query query = new Query(Criteria.where("_id").is(courseId));
+
+        Document reviewDoc = new Document()
+                .append("id", review.id())
+                .append("userId", review.userId())
+                .append("authorNickname", review.authorNickname())
+                .append("content", review.content())
+                .append("rating", review.rating())
+                .append("reportUserIds", review.reportUserIds())
+                .append("createdAt", review.createdAt());
+
+        Update update = new Update().push("reviews", reviewDoc);
+
+        UpdateResult updateResult = mongoTemplate.updateFirst(
+                query,
+                update,
+                Course.class
+        );
+
+        if (updateResult.getModifiedCount() <= 0) {
+            throw NOT_EXIST_COURSE.create(courseId);
+        }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
@@ -90,6 +90,17 @@ public class CourseV1WebController implements CourseWebApi {
 
     @Override
     @Login
+    @DeleteMapping("/courses/{courseId}/reviews/{reviewId}")
+    public void deleteReview(
+            @PathVariable("courseId") String courseId,
+            @PathVariable("reviewId") String reviewId,
+            @UserId String userId
+    ) {
+        courseApplicationService.deleteReview(courseId, reviewId, userId);
+    }
+
+    @Override
+    @Login
     @PostMapping("/courses/{courseId}/reviews/{reviewId}/report")
     public void reportCourseReview(
             @PathVariable("courseId") String courseId,

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -136,16 +136,67 @@ public interface CourseWebApi {
             CreateReviewWebRequest request
     );
 
+    @Operation(summary = "코스 리뷰 삭제", security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 삭제 완료"),
+            @ApiResponse(responseCode = "401", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "인증에 실패한 경우",
+                            ref = "#/components/examples/AUTHENTICATION_FAIL"
+                    )
+            })),
+            @ApiResponse(responseCode = "401", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "본인 리뷰가 아닌 경우",
+                            ref = "#/components/examples/UNAUTHORIZED_REVIEW_DELETE"
+                    )
+            })),
+            @ApiResponse(responseCode = "404", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "코스가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                    ),
+                    @ExampleObject(
+                            name = "리뷰가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_REVIEW"
+                    )
+            })),
+    })
+    void deleteReview(
+            @Parameter(description = "코스 ID", required = true) String courseId,
+            @Parameter(description = "삭제할 리뷰 ID", required = true) String reviewId,
+            @Parameter(hidden = true) String userId
+    );
+
     @Operation(summary = "리뷰 신고", security = {@SecurityRequirement(name = "BearerAuth")})
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 신고 완료"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 코스"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 리뷰"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저")
+            @ApiResponse(responseCode = "400", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "이미 신고한 리뷰인 경우",
+                            ref = "#/components/examples/ALREADY_REPORTED_REVIEW"
+                    )
+            })),
+            @ApiResponse(responseCode = "401", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "인증에 실패한 경우",
+                            ref = "#/components/examples/AUTHENTICATION_FAIL"
+                    )
+            })),
+            @ApiResponse(responseCode = "404", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "코스가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                    ),
+                    @ExampleObject(
+                            name = "리뷰가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_REVIEW"
+                    )
+            })),
     })
     void reportCourseReview(
-            @Parameter(description = "신고할 리뷰의 코스 ID") String courseId,
-            @Parameter(description = "신고할 리뷰 ID") String reviewId,
+            @Parameter(description = "신고할 리뷰의 코스 ID", required = true) String courseId,
+            @Parameter(description = "신고할 리뷰 ID", required = true) String reviewId,
             @Parameter(hidden = true) String userId
     );
 
@@ -164,8 +215,28 @@ public interface CourseWebApi {
     @Operation(summary = "유저 커스텀 코스 등록", security = {@SecurityRequirement(name = "BearerAuth")})
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "코스 등록 성공"),
-            @ApiResponse(responseCode = "400", description = "입력값 검증 실패 (null 등)"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "400", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "이름 길이가 범위 외인 경우",
+                            ref = "#/components/examples/INVALID_NAME_LENGTH"
+                    ),
+                    @ExampleObject(
+                            name = "좌표 개수가 부족한 경우",
+                            ref = "#/components/examples/INVALID_COORDINATE_COUNT"
+                    )
+            })),
+            @ApiResponse(responseCode = "401", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "인증에 실패한 경우",
+                            ref = "#/components/examples/AUTHENTICATION_FAIL"
+                    )
+            })),
+            @ApiResponse(responseCode = "409", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "이미 존재하는 코스 이름인 경우",
+                            ref = "#/components/examples/DUPLICATED_COURSE_NAME"
+                    )
+            })),
     })
     String addCustomCourses(
             @RequestBody(
@@ -185,28 +256,51 @@ public interface CourseWebApi {
     );
 
     @Operation(summary = "코스 생성 시 직전 포인트와 새 포인트 사이의 경로 및 거리 조회 (첫 점인 경우 origin과 destination을 동일하게 전송)")
-    @ApiResponse(responseCode = "200")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "좌표 개수가 부족한 경우",
+                            ref = "#/components/examples/INVALID_COORDINATE_COUNT"
+                    )
+            })),
+    })
     DraftRouteWebResponse findDraftRoute(FindDraftRouteWebRequest request);
 
     @Operation(summary = "코스 신고", security = {@SecurityRequirement(name = "BearerAuth")})
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "코스 신고 완료"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 코스"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저")
+            @ApiResponse(responseCode = "400", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "이미 신고한 코스인 경우",
+                            ref = "#/components/examples/ALREADY_REPORTED_COURSE"
+                    )
+            })),
+            @ApiResponse(responseCode = "401", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "인증에 실패한 경우",
+                            ref = "#/components/examples/AUTHENTICATION_FAIL"
+                    )
+            })),
+            @ApiResponse(responseCode = "404", content = @Content(examples = {
+                    @ExampleObject(
+                            name = "코스가 존재하지 않는 경우",
+                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                    )
+            })),
     })
     void reportCourse(
-            @Parameter(description = "신고할 코스 ID") String id,
+            @Parameter(description = "신고할 코스 ID", required = true) String id,
             @Parameter(hidden = true) String userId
     );
 
     @Operation(summary = "나의 코스 조회(생성순)", security = {@SecurityRequirement(name = "BearerAuth")})
     @ApiResponses({
             @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
+            @ApiResponse(responseCode = "401", content = @Content(examples = {
                     @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
+                            name = "인증에 실패한 경우",
+                            ref = "#/components/examples/AUTHENTICATION_FAIL"
                     )
             })),
     })

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -143,9 +143,7 @@ public interface CourseWebApi {
                     @ExampleObject(
                             name = "인증에 실패한 경우",
                             ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
+                    ),
                     @ExampleObject(
                             name = "본인 리뷰가 아닌 경우",
                             ref = "#/components/examples/AUTHENTICATION_FAIL"

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -148,7 +148,7 @@ public interface CourseWebApi {
             @ApiResponse(responseCode = "401", content = @Content(examples = {
                     @ExampleObject(
                             name = "본인 리뷰가 아닌 경우",
-                            ref = "#/components/examples/UNAUTHORIZED_REVIEW_DELETE"
+                            ref = "#/components/examples/AUTHENTICATION_FAIL"
                     )
             })),
             @ApiResponse(responseCode = "404", content = @Content(examples = {

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -484,12 +484,21 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
             assertThatThrownBy(() -> sut.addReview("notExistCourseId", reviewer.id(), "좋은 코스입니다", 4))
                     .isInstanceOf(NoSuchElementException.class);
         }
+
+        @Test
+        void 이미_리뷰를_작성한_유저가_추가하면_예외가_발생한다() {
+            sut.addReview(courseId, reviewer.id(), "좋은 코스입니다", 4);
+
+            assertThatThrownBy(() -> sut.addReview(courseId, reviewer.id(), "또 쓰는 리뷰", 3))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     @Nested
     class 리뷰_삭제 {
 
         private User reviewer;
+        private User otherUser;
         private String courseId;
         private String reviewId;
 
@@ -497,6 +506,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
         void setUp() {
             User courseCreator = dbUtil.saveUser(new User(UserProvider.KAKAO, "creatorProviderId"));
             reviewer = dbUtil.saveUser(new User(UserProvider.KAKAO, "reviewerProviderId"));
+            otherUser = dbUtil.saveUser(new User(UserProvider.KAKAO, "otherProviderId"));
 
             Course course = new Course(null, new CourseName("테스트 코스"), List.of(
                     new Coordinate(37.5180, 127.0280),
@@ -507,7 +517,7 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
             courseId = dbUtil.saveCourse(course).id();
             sut.addReview(courseId, reviewer.id(), "좋은 코스입니다", 5);
-            reviewId = dbUtil.findCourseById(courseId).reviews().get(0).id();
+            reviewId = dbUtil.findCourseById(courseId).reviews().getFirst().id();
         }
 
         @Test
@@ -516,14 +526,6 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
 
             Course result = dbUtil.findCourseById(courseId);
             assertThat(result.reviews()).isEmpty();
-        }
-
-        @Test
-        void 리뷰를_삭제하면_averageRating이_0으로_재계산된다() {
-            sut.deleteReview(courseId, reviewId, reviewer.id());
-
-            Course result = dbUtil.findCourseById(courseId);
-            assertThat(result.averageRating()).isEqualTo(0.0);
         }
 
         @Test
@@ -537,75 +539,11 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
             assertThatThrownBy(() -> sut.deleteReview(courseId, "notExistReviewId", reviewer.id()))
                     .isInstanceOf(NoSuchElementException.class);
         }
-    }
-
-    @Nested
-    class 리뷰_신고 {
-
-        private User reporter;
-        private String courseId;
-        private String reviewId;
-
-        @BeforeEach
-        void setUp() {
-            User courseCreator = dbUtil.saveUser(new User(UserProvider.KAKAO, "creatorProviderId"));
-            reporter = dbUtil.saveUser(new User(UserProvider.KAKAO, "reporterProviderId"));
-
-            Course course = new Course(null, new CourseName("테스트 코스3"), List.of(
-                    new Coordinate(37.5180, 127.0280),
-                    new Coordinate(37.5175, 127.0270),
-                    new Coordinate(37.5170, 127.0265),
-                    new Coordinate(37.5180, 127.0280)
-            ), courseCreator);
-
-            courseId = dbUtil.saveCourse(course).id();
-
-            sut.addReview(courseId, courseCreator.id(), "좋은 코스입니다", 5);
-
-            reviewId = dbUtil.findCourseById(courseId).reviews().get(0).id();
-        }
 
         @Test
-        void 리뷰_신고가_DB에_저장된다() {
-            Course course = dbUtil.findCourseById(courseId);
-
-            sut.reportReview(courseId, reviewId, reporter.id());
-
-            var result = dbUtil.findCourseById(courseId);
-            Review review = result.getReview(reviewId);
-            assertThat(review.reportUserIds()).containsExactly(reporter.id());
-        }
-
-        @Test
-        void 두_명이_신고하면_두_개의_신고가_DB에_저장된다() {
-            User reporter2 = dbUtil.saveUser(new User(UserProvider.KAKAO, "reporter2ProviderId"));
-
-            sut.reportReview(courseId, reviewId, reporter.id());
-            sut.reportReview(courseId, reviewId, reporter2.id());
-
-            Course result = dbUtil.findCourseById(courseId);
-            Review review = result.getReview(reviewId);
-            assertThat(review.reportUserIds()).hasSize(2)
-                    .containsExactlyInAnyOrder(reporter.id(), reporter2.id());
-        }
-
-        @Test
-        void 리뷰를_신고하면_알람이_간다() {
-            sut.reportReview(courseId, reviewId, reporter.id());
-
-            verify(courseAlerter, times(1)).alert(any(AlertContext.class));
-        }
-
-        @Test
-        void 리뷰를_두번_신고하면_알람이_두번_간다() {
-            User reporter2 = dbUtil.saveUser(new User(UserProvider.KAKAO, "reporter2ProviderId"));
-
-            sut.reportReview(courseId, reviewId, reporter.id());
-            sut.reportReview(courseId, reviewId, reporter2.id());
-
-            verify(courseAlerter, times(2)).alert(any(AlertContext.class));
+        void 작성자가_아닌_경우_삭제하면_예외가_발생한다() {
+            assertThatThrownBy(() -> sut.deleteReview(courseId, reviewId, otherUser.id()))
+                    .isInstanceOf(UnauthorizedException.class);
         }
     }
-
-
 }

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -498,14 +498,6 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
             assertThatThrownBy(() -> sut.deleteReview(courseId, "notExistReviewId", reviewer.id()))
                     .isInstanceOf(NoSuchElementException.class);
         }
-
-        @Test
-        void 본인이_작성하지_않은_리뷰를_삭제하면_예외가_발생한다() {
-            User otherUser = dbUtil.saveUser(new User(UserProvider.KAKAO, "otherProviderId"));
-
-            assertThatThrownBy(() -> sut.deleteReview(courseId, reviewId, otherUser.id()))
-                    .isInstanceOf(SecurityException.class);
-        }
     }
 
     @Nested

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -448,6 +448,45 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
     }
 
     @Nested
+    class 리뷰_추가 {
+
+        private User reviewer;
+        private String courseId;
+
+        @BeforeEach
+        void setUp() {
+            User courseCreator = dbUtil.saveUser(new User(UserProvider.KAKAO, "creatorProviderId"));
+            reviewer = dbUtil.saveUser(new User(UserProvider.KAKAO, "reviewerProviderId"));
+
+            Course course = new Course(null, new CourseName("테스트 코스"), List.of(
+                    new Coordinate(37.5180, 127.0280),
+                    new Coordinate(37.5175, 127.0270),
+                    new Coordinate(37.5170, 127.0265),
+                    new Coordinate(37.5180, 127.0280)
+            ), courseCreator);
+
+            courseId = dbUtil.saveCourse(course).id();
+        }
+
+        @Test
+        void 리뷰를_추가하면_DB에_저장된다() {
+            sut.addReview(courseId, reviewer.id(), "좋은 코스입니다", 4);
+
+            Course result = dbUtil.findCourseById(courseId);
+            assertThat(result.reviews()).hasSize(1);
+            assertThat(result.reviews().get(0).userId()).isEqualTo(reviewer.id());
+            assertThat(result.reviews().get(0).content()).isEqualTo("좋은 코스입니다");
+            assertThat(result.reviews().get(0).rating()).isEqualTo(4);
+        }
+
+        @Test
+        void 존재하지_않는_코스에_리뷰를_추가하면_예외가_발생한다() {
+            assertThatThrownBy(() -> sut.addReview("notExistCourseId", reviewer.id(), "좋은 코스입니다", 4))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+    }
+
+    @Nested
     class 리뷰_삭제 {
 
         private User reviewer;

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -448,6 +448,67 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
     }
 
     @Nested
+    class 리뷰_삭제 {
+
+        private User reviewer;
+        private String courseId;
+        private String reviewId;
+
+        @BeforeEach
+        void setUp() {
+            User courseCreator = dbUtil.saveUser(new User(UserProvider.KAKAO, "creatorProviderId"));
+            reviewer = dbUtil.saveUser(new User(UserProvider.KAKAO, "reviewerProviderId"));
+
+            Course course = new Course(null, new CourseName("테스트 코스"), List.of(
+                    new Coordinate(37.5180, 127.0280),
+                    new Coordinate(37.5175, 127.0270),
+                    new Coordinate(37.5170, 127.0265),
+                    new Coordinate(37.5180, 127.0280)
+            ), courseCreator);
+
+            courseId = dbUtil.saveCourse(course).id();
+            sut.addReview(courseId, reviewer.id(), "좋은 코스입니다", 5);
+            reviewId = dbUtil.findCourseById(courseId).reviews().get(0).id();
+        }
+
+        @Test
+        void 리뷰를_삭제하면_DB에서_제거된다() {
+            sut.deleteReview(courseId, reviewId, reviewer.id());
+
+            Course result = dbUtil.findCourseById(courseId);
+            assertThat(result.reviews()).isEmpty();
+        }
+
+        @Test
+        void 리뷰를_삭제하면_averageRating이_0으로_재계산된다() {
+            sut.deleteReview(courseId, reviewId, reviewer.id());
+
+            Course result = dbUtil.findCourseById(courseId);
+            assertThat(result.averageRating()).isEqualTo(0.0);
+        }
+
+        @Test
+        void 존재하지_않는_코스의_리뷰를_삭제하면_예외가_발생한다() {
+            assertThatThrownBy(() -> sut.deleteReview("notExistCourseId", reviewId, reviewer.id()))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        void 존재하지_않는_리뷰를_삭제하면_예외가_발생한다() {
+            assertThatThrownBy(() -> sut.deleteReview(courseId, "notExistReviewId", reviewer.id()))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        void 본인이_작성하지_않은_리뷰를_삭제하면_예외가_발생한다() {
+            User otherUser = dbUtil.saveUser(new User(UserProvider.KAKAO, "otherProviderId"));
+
+            assertThatThrownBy(() -> sut.deleteReview(courseId, reviewId, otherUser.id()))
+                    .isInstanceOf(SecurityException.class);
+        }
+    }
+
+    @Nested
     class 리뷰_신고 {
 
         private User reporter;

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
@@ -1,5 +1,6 @@
 package coursepick.coursepick.domain.course;
 
+import coursepick.coursepick.application.exception.UnauthorizedException;
 import coursepick.coursepick.domain.user.Nickname;
 import coursepick.coursepick.domain.user.User;
 import coursepick.coursepick.domain.user.UserProvider;
@@ -125,6 +126,18 @@ class CourseTest {
 
         assertThatThrownBy(() -> course.addReport(user1))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    @Test
+    void 다른_유저가_리뷰를_삭제하면_예외가_발생한다() {
+        var course = new Course(null, new CourseName("코스"), of(new Coordinate(0, 0), new Coordinate(2, 2)), ADMIN_USER);
+        course.addReview(TEST_USER, "좋아요", 5);
+        Review review = course.reviews().getFirst();
+        User otherUser = new User(UserProvider.KAKAO, "otherProviderId");
+
+        assertThatThrownBy(() -> course.removeReview(review, otherUser.id()))
+                .isInstanceOf(UnauthorizedException.class);
     }
 
     @Test

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
@@ -14,7 +14,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static coursepick.coursepick.test_util.CoordinateTestUtil.*;
-import static coursepick.coursepick.test_util.UserFixture.*;
+import static coursepick.coursepick.test_util.UserFixture.ADMIN_USER;
+import static coursepick.coursepick.test_util.UserFixture.TEST_USER;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.data.Percentage.withPercentage;

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
@@ -132,11 +132,11 @@ class CourseTest {
     @Test
     void 다른_유저가_리뷰를_삭제하면_예외가_발생한다() {
         var course = new Course(null, new CourseName("코스"), of(new Coordinate(0, 0), new Coordinate(2, 2)), ADMIN_USER);
-        course.addReview(TEST_USER, "좋아요", 5);
+        course.reviews().add(new Review(TEST_USER, "content", 5));
         Review review = course.reviews().getFirst();
         User otherUser = new User(UserProvider.KAKAO, "otherProviderId");
 
-        assertThatThrownBy(() -> course.removeReview(review, otherUser.id()))
+        assertThatThrownBy(() -> course.verifyRemovableReview(review, otherUser.id()))
                 .isInstanceOf(UnauthorizedException.class);
     }
 
@@ -144,10 +144,9 @@ class CourseTest {
     void 한_유저가_같은_코스에_두_번_리뷰를_남기면_예외가_발생한다() {
         Course course = new Course(null, new CourseName("코스"), List.of(new Coordinate(0, 0), new Coordinate(10, 10)), ADMIN_USER);
         User user1 = new User("user1", UserProvider.KAKAO, "providerId", Nickname.random());
+        course.reviews().add(new Review(user1, "content", 5));
 
-        course.addReview(user1, "첫 번째 리뷰", 5);
-
-        assertThatThrownBy(() -> course.addReview(user1, "두 번째 리뷰", 3))
+        assertThatThrownBy(() -> course.verifyWriteReviewEligibility(user1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("이미 해당 코스에 리뷰를 작성했습니다");
     }


### PR DESCRIPTION
## 🛠️ 설명
> 이 브랜치는 feat/870-course-rating을 기반으로 합니다. 
- 코스 리뷰 삭제 기능을 추가합니다.

### 변경사항
#### 새 API
- `DELETE /v1/courses/{courseId}/reviews/{reviewId}` : 본인이 작성한 리뷰를 삭제합니다. 인증이 필요합니다. 
#### 도메인
- `Course.removeReview(Review, String userId)` : 소유자 검증을 도메인 레이어에서 수행합니다. 
- `ErrorType.UNAUTHORIZED_REVIEW_DELETE` : 타인이 작성한 리뷰 삭제 시 401을 반환합니다. 
#### API 명세
- 기존에 단순 description 문자열로만 작성되어있던 `@ApiResponse`들을 `@ExampleObject ref` 형식으로 통일하였습니다. 
- 실제 예외 핸들러 동작과 맞지 않던 응답 코드를 수정하였습니다. 기존의 존재하지 않은 유저를 404로 처리했는데 401로 수정하였습니다. 

## 🔍 리뷰 요청사항
- 소유자 검증 위치: 권한 체크를 서비스가 아닌 `Course.removeReview` 도메인에서 수행하도록 했습니다. 이 방향이 괜찮은지 확인 부탁드립니다.
- `CourseWebApi` 에서 `UNAUTHORIZED_REVIEW_DELETE`: 현재 SecurityException을 사용해 핸들러에서 401로 반환됩니다. 인증 실패(401)가 아닌 인가 실패(403)가 더 적절할 수도 있을 것 같기도 한데 의견 주시면 감사하겠습니다.
- `@ApiResponse`의 에러 예시를 기존 `description` 문자열 대신  `@ExampleObject(ref = "#/components/examples/...")` 형식으로 통일했는데, 가독성 면에서 불편하시면 편하게 이야기해주세요!

## 🔗 관련 이슈

- closes #872 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 자신이 작성한 강의 리뷰를 삭제할 수 있는 기능 추가
  * 리뷰 추가 시 중복 작성 검증 도입 및 리뷰를 개별 항목으로 저장하는 방식으로 변경

* **API 개선**
  * 리뷰 삭제용 인증된 DELETE 엔드포인트 추가 및 관련 응답/예시 문서 보강
  * 신고·생성 등 일부 API의 오류 응답 문서화 개선

* **테스트**
  * 리뷰 추가/삭제의 성공·실패 케이스를 검증하는 단위 테스트 추가 및 보강

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/877)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->