### PR TITLE
나의 코스 추가 관련 UI 및 로직 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/Logger.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/Logger.kt
@@ -92,6 +92,18 @@ object Logger {
             override val name: String = "${target}_failure"
         }
 
+        class Add(
+            target: String,
+        ) : Event() {
+            override val name: String = "${target}_add"
+        }
+
+        class Remove(
+            target: String,
+        ) : Event() {
+            override val name: String = "${target}_remove"
+        }
+
         class PreferenceChange(
             target: String,
         ) : Event() {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
@@ -159,7 +159,8 @@ class CreateCustomCourseViewModel
                 }
 
                 runCatching {
-                    customCourseRepository.submitCourse(DraftCourse(courseName, waypoints))
+                    val coordinates: List<Coordinate> = segments.value.flatMap(DraftSegment::coordinates)
+                    customCourseRepository.submitCourse(DraftCourse(courseName, coordinates))
                 }.onSuccess {
                     Logger.log(
                         Logger.Event.Success("create_custom_course_submit"),

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
@@ -75,7 +75,11 @@ class CreateCustomCourseViewModel
                         .onSuccess { Logger.log(Logger.Event.Add("create_custom_course_waypoint")) }
                         .getOrElse { exception: Throwable ->
                             Logger.log(Logger.Event.Failure("create_custom_course_waypoint"), "exception" to exception.message.orEmpty())
-                            if (exception is NoNetworkException) _event.emit(CreateCustomCourseUiEvent.NoNetwork)
+                            when (exception) {
+                                is CancellationException -> throw exception
+                                is NoNetworkException -> _event.emit(CreateCustomCourseUiEvent.NoNetwork)
+                                else -> _event.emit(CreateCustomCourseUiEvent.UnknownError)
+                            }
                             return@launch
                         }
                 val adjustedSegment: DraftSegment =

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
@@ -72,9 +72,9 @@ class CreateCustomCourseViewModel
                 val origin: Coordinate = waypoints.lastOrNull() ?: waypoint
                 val rawSegment: DraftSegment =
                     runCatching { customCourseRepository.draftSegment(origin, waypoint) }
-                        .onSuccess { Logger.log(Logger.Event.Success("create_custom_course_add_waypoint")) }
+                        .onSuccess { Logger.log(Logger.Event.Add("create_custom_course_waypoint")) }
                         .getOrElse { exception: Throwable ->
-                            Logger.log(Logger.Event.Failure("create_custom_course_add_waypoint"))
+                            Logger.log(Logger.Event.Failure("create_custom_course_waypoint"), "exception" to exception.message.orEmpty())
                             if (exception is NoNetworkException) _event.emit(CreateCustomCourseUiEvent.NoNetwork)
                             return@launch
                         }
@@ -96,7 +96,7 @@ class CreateCustomCourseViewModel
         }
 
         fun removeLastWaypoint() {
-            Logger.log(Logger.Event.Success("create_custom_course_remove_waypoint"))
+            Logger.log(Logger.Event.Remove("create_custom_course_waypoint"))
             viewModelScope.launch {
                 _segments.value = segments.value.dropLast(1)
                 _event.emit(CreateCustomCourseUiEvent.RemoveLastWaypoint)
@@ -109,13 +109,13 @@ class CreateCustomCourseViewModel
                     _event.emit(CreateCustomCourseUiEvent.CourseLengthTooShort)
                 }
             } else {
-                Logger.log(Logger.Event.Success("create_custom_course_show_submit_dialog"))
+                Logger.log(Logger.Event.Enter("create_custom_course_submit_dialog"))
                 _showSubmitDialog.value = true
             }
         }
 
         fun dismissSubmitDialog() {
-            Logger.log(Logger.Event.Success("create_custom_course_dismiss_submit_dialog"))
+            Logger.log(Logger.Event.Exit("create_custom_course_submit_dialog"))
             _showSubmitDialog.value = false
             _courseName.value = ""
             _isCourseNameOutOfBounds.value = false
@@ -127,13 +127,13 @@ class CreateCustomCourseViewModel
                     _event.emit(CreateCustomCourseUiEvent.Exit)
                 }
             } else {
-                Logger.log(Logger.Event.Success("create_custom_course_show_discard_dialog"))
+                Logger.log(Logger.Event.Enter("create_custom_course_discard_dialog"))
                 _showDiscardDialog.value = true
             }
         }
 
         fun dismissExitDialog() {
-            Logger.log(Logger.Event.Success("create_custom_course_dismiss_discard_dialog"))
+            Logger.log(Logger.Event.Exit("create_custom_course_discard_dialog"))
             _showDiscardDialog.value = false
         }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
@@ -80,7 +80,6 @@ class CreateCustomCourseViewModel
                         }
                 val adjustedSegment: DraftSegment =
                     rawSegment
-                        .copy(coordinates = rawSegment.coordinates.dropLast(1))
                         .let { segment: DraftSegment ->
                             if (waypoints.isEmpty()) {
                                 val initialWaypoint = segment.coordinates.lastOrNull() ?: return@launch

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
@@ -166,11 +166,7 @@ class CreateCustomCourseViewModel
                     val coordinates: List<Coordinate> = segments.value.flatMap(DraftSegment::coordinates)
                     customCourseRepository.submitCourse(DraftCourse(courseName, coordinates))
                 }.onSuccess {
-                    Logger.log(
-                        Logger.Event.Success("create_custom_course_submit"),
-                        "course_name" to courseName,
-                        "waypoints_count" to waypoints.size,
-                    )
+                    Logger.log(Logger.Event.Success("create_custom_course_submit"))
                     _event.emit(CreateCustomCourseUiEvent.CreateCustomCourseSuccess)
                 }.onFailure { exception: Throwable ->
                     Logger.log(Logger.Event.Failure("create_custom_course_submit"), "exception" to exception.message.orEmpty())

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
@@ -133,7 +133,7 @@ class CreateCustomCourseViewModel
         }
 
         fun dismissExitDialog() {
-            Logger.log(Logger.Event.Success("create_custom_course_show_discard_dialog"))
+            Logger.log(Logger.Event.Success("create_custom_course_dismiss_discard_dialog"))
             _showDiscardDialog.value = false
         }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/CreateCustomCourseViewModel.kt
@@ -11,6 +11,7 @@ import io.coursepick.coursepick.domain.course.Length
 import io.coursepick.coursepick.domain.customcourse.CustomCourseRepository
 import io.coursepick.coursepick.domain.customcourse.DraftCourse
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
+import io.coursepick.coursepick.presentation.Logger
 import io.coursepick.coursepick.presentation.auth.AuthFeature
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -70,10 +71,13 @@ class CreateCustomCourseViewModel
             viewModelScope.launch {
                 val origin: Coordinate = waypoints.lastOrNull() ?: waypoint
                 val rawSegment: DraftSegment =
-                    runCatching { customCourseRepository.draftSegment(origin, waypoint) }.getOrElse { exception: Throwable ->
-                        if (exception is NoNetworkException) _event.emit(CreateCustomCourseUiEvent.NoNetwork)
-                        return@launch
-                    }
+                    runCatching { customCourseRepository.draftSegment(origin, waypoint) }
+                        .onSuccess { Logger.log(Logger.Event.Success("create_custom_course_add_waypoint")) }
+                        .getOrElse { exception: Throwable ->
+                            Logger.log(Logger.Event.Failure("create_custom_course_add_waypoint"))
+                            if (exception is NoNetworkException) _event.emit(CreateCustomCourseUiEvent.NoNetwork)
+                            return@launch
+                        }
                 val adjustedSegment: DraftSegment =
                     rawSegment
                         .copy(coordinates = rawSegment.coordinates.dropLast(1))
@@ -92,6 +96,7 @@ class CreateCustomCourseViewModel
         }
 
         fun removeLastWaypoint() {
+            Logger.log(Logger.Event.Success("create_custom_course_remove_waypoint"))
             viewModelScope.launch {
                 _segments.value = segments.value.dropLast(1)
                 _event.emit(CreateCustomCourseUiEvent.RemoveLastWaypoint)
@@ -104,11 +109,13 @@ class CreateCustomCourseViewModel
                     _event.emit(CreateCustomCourseUiEvent.CourseLengthTooShort)
                 }
             } else {
+                Logger.log(Logger.Event.Success("create_custom_course_show_submit_dialog"))
                 _showSubmitDialog.value = true
             }
         }
 
         fun dismissSubmitDialog() {
+            Logger.log(Logger.Event.Success("create_custom_course_dismiss_submit_dialog"))
             _showSubmitDialog.value = false
             _courseName.value = ""
             _isCourseNameOutOfBounds.value = false
@@ -120,11 +127,13 @@ class CreateCustomCourseViewModel
                     _event.emit(CreateCustomCourseUiEvent.Exit)
                 }
             } else {
+                Logger.log(Logger.Event.Success("create_custom_course_show_discard_dialog"))
                 _showDiscardDialog.value = true
             }
         }
 
         fun dismissExitDialog() {
+            Logger.log(Logger.Event.Success("create_custom_course_show_discard_dialog"))
             _showDiscardDialog.value = false
         }
 
@@ -150,23 +159,42 @@ class CreateCustomCourseViewModel
                     return@launch
                 }
 
-                try {
+                runCatching {
                     customCourseRepository.submitCourse(DraftCourse(courseName, waypoints))
-                    _event.emit(CreateCustomCourseUiEvent.CreateCustomCourseSuccess)
-                } catch (_: NoNetworkException) {
-                    _event.emit(CreateCustomCourseUiEvent.NoNetwork)
-                } catch (exception: HttpException) {
-                    _event.emit(
-                        when (exception.code()) {
-                            400 -> CreateCustomCourseUiEvent.InvalidCourseName
-                            401 -> CreateCustomCourseUiEvent.UnauthorizedUser
-                            409 -> CreateCustomCourseUiEvent.DuplicateCourseName
-                            else -> CreateCustomCourseUiEvent.UnknownError
-                        },
+                }.onSuccess {
+                    Logger.log(
+                        Logger.Event.Success("create_custom_course_submit"),
+                        "course_name" to courseName,
+                        "waypoints_count" to waypoints.size,
                     )
-                } catch (exception: Throwable) {
-                    if (exception is CancellationException) throw exception
-                    _event.emit(CreateCustomCourseUiEvent.UnknownError)
+                    _event.emit(CreateCustomCourseUiEvent.CreateCustomCourseSuccess)
+                }.onFailure { exception: Throwable ->
+                    Logger.log(Logger.Event.Failure("create_custom_course_submit"), "exception" to exception.message.orEmpty())
+
+                    when (exception) {
+                        is CancellationException -> {
+                            throw exception
+                        }
+
+                        is NoNetworkException -> {
+                            _event.emit(CreateCustomCourseUiEvent.NoNetwork)
+                        }
+
+                        is HttpException -> {
+                            _event.emit(
+                                when (exception.code()) {
+                                    400 -> CreateCustomCourseUiEvent.InvalidCourseName
+                                    401 -> CreateCustomCourseUiEvent.UnauthorizedUser
+                                    409 -> CreateCustomCourseUiEvent.DuplicateCourseName
+                                    else -> CreateCustomCourseUiEvent.UnknownError
+                                },
+                            )
+                        }
+
+                        else -> {
+                            _event.emit(CreateCustomCourseUiEvent.UnknownError)
+                        }
+                    }
                 }
             }
         }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/SubmitCustomCourseDialog.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/createcustomcourse/SubmitCustomCourseDialog.kt
@@ -10,7 +10,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -24,6 +27,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -95,9 +99,9 @@ fun SubmitCustomCourseDialog(
                     TextFieldDefaults.colors(
                         focusedTextColor = colorResource(R.color.item_primary),
                         unfocusedTextColor = colorResource(R.color.item_tertiary),
-                        focusedContainerColor = colorResource(R.color.background_primary),
+                        focusedContainerColor = colorResource(R.color.background_secondary),
                         unfocusedContainerColor = colorResource(R.color.background_tertiary),
-                        errorContainerColor = colorResource(R.color.background_primary),
+                        errorContainerColor = colorResource(R.color.background_secondary),
                         focusedIndicatorColor = Color.Transparent,
                         unfocusedIndicatorColor = Color.Transparent,
                         errorIndicatorColor = Color.Transparent,
@@ -105,7 +109,26 @@ fun SubmitCustomCourseDialog(
                 modifier = Modifier.focusRequester(focusRequester),
             )
 
-            Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(10.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    painter = painterResource(R.drawable.icon_info),
+                    contentDescription = null,
+                    tint = colorResource(R.color.item_secondary),
+                    modifier = Modifier.size(18.dp),
+                )
+
+                Spacer(Modifier.width(10.dp))
+
+                Text(
+                    text = stringResource(R.string.custom_course_submit_dialog_warning),
+                    color = colorResource(R.color.item_secondary),
+                    fontSize = 14.sp,
+                )
+            }
+
+            Spacer(Modifier.height(10.dp))
 
             Row(
                 horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/component/CourseLengthChip.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/component/CourseLengthChip.kt
@@ -1,6 +1,5 @@
 package io.coursepick.coursepick.presentation.customcourse.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Row

--- a/android/app/src/main/res/drawable/icon_info.xml
+++ b/android/app/src/main/res/drawable/icon_info.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@color/item_primary"
+        android:pathData="M440,680h80v-240h-80v240ZM508.5,348.5Q520,337 520,320t-11.5,-28.5Q497,280 480,280t-28.5,11.5Q440,303 440,320t11.5,28.5Q463,360 480,360t28.5,-11.5ZM480,880q-83,0 -156,-31.5T197,763q-54,-54 -85.5,-127T80,480q0,-83 31.5,-156T197,197q54,-54 127,-85.5T480,80q83,0 156,31.5T763,197q54,54 85.5,127T880,480q0,83 -31.5,156T763,763q-54,54 -127,85.5T480,880ZM480,800q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93ZM480,480Z" />
+</vector>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="custom_course_submit_dialog_course_name_prompt_title">코스에 이름을 붙여주세요.</string>
     <string name="custom_course_submit_dialog_course_name_placeholder">이름을 붙여주세요</string>
     <string name="custom_course_submit_dialog_course_name_out_of_bounds_message">코스 이름은 2~30자로 붙여주세요.</string>
+    <string name="custom_course_submit_dialog_warning">등록된 코스는 다른 사용자에게 공개되며, 삭제가 어려울 수 있어요.</string>
     <string name="custom_course_submit_dialog_cancel_button">취소</string>
     <string name="custom_course_submit_dialog_confirm_button">확인</string>
 


### PR DESCRIPTION
## 🛠️ 설명
- `나의 코스`를 등록하는 다이얼로그에 경고 문구가 추가됐습니다.
  - 등록된 코스는 다른 사용자에게도 공개됨
  - 등록된 코스는 삭제가 어려움
- `나의 코스` 화면 안에서 사용자의 플로우를 파악할 수 있도록 로깅이 추가됐습니다.
  - 예를 들어, 등록 다이얼로그까지 갔다가 이탈하는 유저가 많다면 `전체 공개`나 `삭제 제한`이 부담돼서 이탈했음을 의심해볼 수 있을 것 같습니다.
- 보정되지 않은 좌표는 [백엔드 단에서 버리도록 변경](https://github.com/woowacourse-teams/2025-course-pick/pull/854)됐으므로, `DraftSegment`에서 마지막 좌표를 버리는 로직이 제거됐습니다.
- 코스를 등록할 때 `DraftSegment`의 좌표 목록이 아닌 waypoints의 목록을 사용해 코스가 정상적으로 그려지지 않는 현상을 수정됐습니다.


## 📸 스크린샷 / 동영상
<table>
  <tr>
    <th>As-is</th>
    <th>To-be</th>
  </tr>
  <tr>
    <td><img alt="image" src="https://github.com/user-attachments/assets/cfc9ed68-3d88-4f7f-9228-faabc4f715b1"></td>
    <td><img alt="image" src="https://github.com/user-attachments/assets/24dfead9-c6d5-4147-864b-becd2f3abbf6"></td>
  </tr>
</table>


## 🔗 관련 이슈

- closes #882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 커스텀 코스 제출 시 등록된 코스가 다른 사용자와 공유되며 삭제가 어려울 수 있다는 경고 메시지 추가

* **개선 사항**
  * 제출 대화상자에 정보 아이콘과 함께 경고 알림 표시
  * 네트워크 작업 로깅 강화로 안정성 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/883)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->