### PR TITLE
설정 화면 뒤에 있는 UI를 클릭할 수 있는 현상 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/setting/SettingsScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/setting/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -31,83 +32,86 @@ fun SettingsScreen(
     onCopyInstallationId: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
-                .fillMaxSize()
-                .background(colorResource(R.color.background_primary))
-                .padding(20.dp)
-                .statusBarsPadding(),
+    Surface(
+        modifier
+            .fillMaxSize()
+            .background(colorResource(R.color.background_primary)),
     ) {
         Column(
-            modifier =
-                Modifier
-                    .weight(1F)
-                    .verticalScroll(rememberScrollState()),
+            Modifier
+                .padding(horizontal = 20.dp, vertical = 10.dp)
+                .statusBarsPadding(),
         ) {
-            Text(
-                text = "설정",
-                fontSize = 16.sp,
-                color = colorResource(R.color.item_primary),
+            Column(
                 modifier =
                     Modifier
-                        .clickable { onNavigateToPreferences() }
-                        .fillMaxWidth()
-                        .height(50.dp)
-                        .wrapContentHeight(Alignment.CenterVertically)
-                        .padding(horizontal = 10.dp),
-            )
+                        .weight(1F)
+                        .verticalScroll(rememberScrollState()),
+            ) {
+                Text(
+                    text = "설정",
+                    fontSize = 16.sp,
+                    color = colorResource(R.color.item_primary),
+                    modifier =
+                        Modifier
+                            .clickable { onNavigateToPreferences() }
+                            .fillMaxWidth()
+                            .height(50.dp)
+                            .wrapContentHeight(Alignment.CenterVertically)
+                            .padding(horizontal = 10.dp),
+                )
+
+                Text(
+                    text = "사용자 피드백 창구",
+                    fontSize = 16.sp,
+                    color = colorResource(R.color.item_primary),
+                    modifier =
+                        Modifier
+                            .clickable { onNavigateToFeedback() }
+                            .fillMaxWidth()
+                            .height(50.dp)
+                            .wrapContentHeight(Alignment.CenterVertically)
+                            .padding(horizontal = 10.dp),
+                )
+
+                Text(
+                    text = "개인정보처리방침",
+                    fontSize = 16.sp,
+                    color = colorResource(R.color.item_primary),
+                    modifier =
+                        Modifier
+                            .clickable { onNavigateToPrivacyPolicy() }
+                            .fillMaxWidth()
+                            .height(50.dp)
+                            .wrapContentHeight(Alignment.CenterVertically)
+                            .padding(horizontal = 10.dp),
+                )
+
+                Text(
+                    text = "오픈소스 라이선스 고지",
+                    fontSize = 16.sp,
+                    color = colorResource(R.color.item_primary),
+                    modifier =
+                        Modifier
+                            .clickable { onNavigateToOpenSourceNotice() }
+                            .fillMaxWidth()
+                            .height(50.dp)
+                            .wrapContentHeight(Alignment.CenterVertically)
+                            .padding(horizontal = 10.dp),
+                )
+            }
 
             Text(
-                text = "사용자 피드백 창구",
-                fontSize = 16.sp,
+                text = "사용자 ID: $installationId",
+                fontSize = 14.sp,
                 color = colorResource(R.color.item_primary),
                 modifier =
                     Modifier
-                        .clickable { onNavigateToFeedback() }
                         .fillMaxWidth()
-                        .height(50.dp)
-                        .wrapContentHeight(Alignment.CenterVertically)
-                        .padding(horizontal = 10.dp),
-            )
-
-            Text(
-                text = "개인정보처리방침",
-                fontSize = 16.sp,
-                color = colorResource(R.color.item_primary),
-                modifier =
-                    Modifier
-                        .clickable { onNavigateToPrivacyPolicy() }
-                        .fillMaxWidth()
-                        .height(50.dp)
-                        .wrapContentHeight(Alignment.CenterVertically)
-                        .padding(horizontal = 10.dp),
-            )
-
-            Text(
-                text = "오픈소스 라이선스 고지",
-                fontSize = 16.sp,
-                color = colorResource(R.color.item_primary),
-                modifier =
-                    Modifier
-                        .clickable { onNavigateToOpenSourceNotice() }
-                        .fillMaxWidth()
-                        .height(50.dp)
-                        .wrapContentHeight(Alignment.CenterVertically)
-                        .padding(horizontal = 10.dp),
+                        .padding(top = 10.dp)
+                        .clickable { onCopyInstallationId() },
             )
         }
-
-        Text(
-            text = "사용자 ID: $installationId",
-            fontSize = 14.sp,
-            color = colorResource(R.color.item_primary),
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(top = 10.dp)
-                    .clickable { onCopyInstallationId() },
-        )
     }
 }
 


### PR DESCRIPTION
## 🛠️ 설명
`CoursesActivity`에서 설정 화면이 표시될 때, 패딩 영역을 클릭하면 설정 화면 뒤에 있는 UI가 클릭되는 현상이 수정됐습니다.

## 📸 스크린샷 / 동영상
<table>
  <tr>
    <th>As-is</th>
    <th>To-be</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/d9a6bdf1-19bb-4e70-9635-7a2cfb3d08dc"></video></td>
    <td><video src="https://github.com/user-attachments/assets/3db4a9e6-f6f9-4618-8f04-1adfc9d88c5b"></video></td>
  </tr>
</table>


## 🔗 관련 이슈

- closes #892
