### PR TITLE
누락된 discord-webhook-url 추가

### DIFF
--- a/backend/etc/docker_compose/docker-compose.home-dev.yml
+++ b/backend/etc/docker_compose/docker-compose.home-dev.yml
@@ -31,6 +31,7 @@ services:
       - ADMIN_KAKAO_MAP_API_KEY=${ADMIN_KAKAO_MAP_API_KEY}
       - OSRM_URL=${OSRM_URL}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
     volumes:
       - /var/lib/coursepick/logs/home-dev:/var/lib/coursepick/logs
     depends_on:

--- a/backend/etc/docker_compose/docker-compose.home-prod.yml
+++ b/backend/etc/docker_compose/docker-compose.home-prod.yml
@@ -31,6 +31,7 @@ services:
       - ADMIN_KAKAO_MAP_API_KEY=${ADMIN_KAKAO_MAP_API_KEY}
       - OSRM_URL=${OSRM_URL}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+      - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
     volumes:
       - /var/lib/coursepick/logs/home-prod:/var/lib/coursepick/logs
     depends_on:


### PR DESCRIPTION
## 🛠️ 설명
- 병합 과정 중 누락된 docker compose(dev, prod)에 discord-webhook-url 설정을 추가했습니다
- env 파일에는 적용돼있습니다!







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Chores**
  * 개발 및 프로덕션 환경에서 Discord 웹훅 URL을 환경 변수로 설정할 수 있도록 구성이 업데이트되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->