### PR TITLE
리뷰 ID를 ObjectId로 변경

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
@@ -6,7 +6,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.Accessors;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.Instant;
@@ -31,7 +30,7 @@ public class Review {
     private final Instant createdAt;
 
     public Review(User author, String content, int rating) {
-        this(RandomStringUtils.insecure().next(10, true, true), author.id(), author.nickname().value(), content, rating, new HashSet<>(), Instant.now());
+        this(new org.bson.types.ObjectId().toHexString(), author.id(), author.nickname().value(), content, rating, new HashSet<>(), Instant.now());
         validateContent(content);
         validateRating(rating);
     }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Review.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.Accessors;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.Instant;
@@ -30,7 +31,7 @@ public class Review {
     private final Instant createdAt;
 
     public Review(User author, String content, int rating) {
-        this(new org.bson.types.ObjectId().toHexString(), author.id(), author.nickname().value(), content, rating, new HashSet<>(), Instant.now());
+        this(new ObjectId().toHexString(), author.id(), author.nickname().value(), content, rating, new HashSet<>(), Instant.now());
         validateContent(content);
         validateRating(rating);
     }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseReader.java
@@ -103,7 +103,7 @@ public class CourseReader implements Converter<Document, Course> {
         for (Document reviewDoc : reviewDocs) {
             Set<String> reportUserIds = new HashSet<>(reviewDoc.getList("reportUserIds", String.class, List.of()));
 
-            String id = reviewDoc.getString("id");
+            String id = reviewDoc.getObjectId("id").toHexString();
             String userId = reviewDoc.getString("userId");
             String authorNickname = reviewDoc.getString("authorNickname");
             String content = reviewDoc.getString("content");

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseRepositoryMongoTemplateImpl.java
@@ -5,6 +5,7 @@ import com.mongodb.MongoTimeoutException;
 import coursepick.coursepick.domain.course.*;
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
@@ -148,7 +149,7 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
         Query query = new Query(Criteria.where("_id").is(courseId));
 
         Document reviewDoc = new Document()
-                .append("id", review.id())
+                .append("id", new ObjectId(review.id()))
                 .append("userId", review.userId())
                 .append("authorNickname", review.authorNickname())
                 .append("content", review.content())
@@ -170,7 +171,7 @@ public class CourseRepositoryMongoTemplateImpl implements CourseRepository {
 
         Query query = new Query(Criteria.where("_id").is(courseId));
 
-        Update update = new Update().pull("reviews", new Document("id", reviewId));
+        Update update = new Update().pull("reviews", new Document("id", new ObjectId(reviewId)));
 
         mongoTemplate.updateFirst(
                 query,

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/mongodb/CourseWriter.java
@@ -49,7 +49,7 @@ public class CourseWriter implements Converter<Course, Document> {
         return reviews.stream()
                 .map(review -> {
                     Document reviewDoc = new Document();
-                    reviewDoc.put("id", review.id());
+                    reviewDoc.put("id", new ObjectId(review.id()));
                     reviewDoc.put("userId", review.userId());
                     reviewDoc.put("authorNickname", review.authorNickname());
                     reviewDoc.put("content", review.content());

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/mongodb/CourseWriterTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/mongodb/CourseWriterTest.java
@@ -59,7 +59,7 @@ class CourseWriterTest {
         assertThat(reviews).hasSize(1);
         Document reviewDoc = reviews.get(0);
         Review originalReview = course.reviews().get(0);
-        assertThat(reviewDoc.getString("id")).isEqualTo(originalReview.id());
+        assertThat(reviewDoc.getObjectId("id").toHexString()).isEqualTo(originalReview.id());
         assertThat(reviewDoc.getString("userId")).isEqualTo(originalReview.userId());
         assertThat(reviewDoc.getString("authorNickname")).isEqualTo(originalReview.authorNickname());
         assertThat(reviewDoc.getString("content")).isEqualTo(originalReview.content());


### PR DESCRIPTION
## 🛠️ 설명
리팩토링 해 보았습니다. 
리뷰 ID 생성 방식을 랜덤 문자열에서 MongoDB ObjectId로 변경합니다.

기존에는 `RandomStringUtils`로 10자리 랜덤 문자열을 생성해 String 타입으로 저장했으나,
MongoDB의 표준 ID 타입인 ObjectId로 통일합니다.

**변경 내용**
- `Review`: ID 생성을 `RandomStringUtils` → `new ObjectId().toHexString()`으로 변경
- `CourseWriter`: 리뷰 저장 시 `id` 필드를 String → ObjectId 타입으로 직렬화
- `CourseReader`: 리뷰 조회 시 `getObjectId("id").toHexString()`으로 역직렬화
- `CourseRepositoryMongoTemplateImpl`: `pushReview`, `deleteReview`에서 id를 ObjectId 타입으로 쿼리
- 도메인 레이어(`Review.id`)는 String 타입 유지 — API 응답 포맷 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 리뷰 ID 생성 및 저장 방식을 변경해 데이터베이스 내 ID 표현을 일관되게 맞추고 무결성을 개선했습니다.
  * 리뷰 데이터의 조회·삭제 시 ID 타입 처리를 통일하여 동작 안정성을 높였습니다.
* **Tests**
  * 변경된 ID 매핑에 맞춰 관련 테스트를 업데이트하여 검증을 보강했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->