### PR TITLE
네이버 지도 UI가 검은색으로 표시되는 현상 수정

### DIFF
--- a/android/app/src/main/res/values-v31/themes.xml
+++ b/android/app/src/main/res/values-v31/themes.xml
@@ -2,8 +2,6 @@
 <resources>
 
     <style name="Base.Theme.CoursePick" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="android:textColor">@color/black</item>
-        <item name="tint">@color/black</item>
         <item name="android:windowSplashScreenBackground">@color/point_primary</item>
         <!-- Customize your light theme here. -->
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="black">#1A1A1A</color>
-    <color name="white">#FAFAF9</color>
     <color name="transparent">#00FFFFFF</color>
 
     <color name="gray1">#F0F0EF</color>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,8 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.CoursePick" parent="Theme.Material3.DayNight.NoActionBar">
-        <item name="android:textColor">@color/black</item>
-        <item name="tint">@color/black</item>
         <item name="android:windowSplashScreenBackground" tools:targetApi="31">
             @color/point_primary
         </item>


### PR DESCRIPTION
## 🛠️ 설명
네이버 지도 UI가 검은색으로 표시되는 현상이 수정됐습니다.

`themes.xml`에 적용된 검은색 `tint` 값이 네이버 지도 UI에도 적용되기 때문에, 네이버 지도 로고 등 지도 UI가검은색으로 표시되는 현상이 있었습니다. `themes.xml`에서 `tint` 값을 제거해 색상이 정상적으로 표시되도록 수정했습니다.

프로젝트 초기에는 `themes.xml`에 지정한 `tint` 및 `textColor` 기본값에 의존했지만, 현재는 `item_primary` 등의 색상을 명시적으로 지정해주는 방식을 사용하고 있습니다.


## 📸 스크린샷 / 동영상
<table>
  <tr>
    <th>As-is</th>
    <th>To-be</th>
  </tr>
  <tr>
    <td><img alt="image" src="https://github.com/user-attachments/assets/f747bd65-f24d-4b09-b5df-bce636e3b369"></td>
    <td><img alt="image" src="https://github.com/user-attachments/assets/ca034588-6c7f-4cbe-b696-713219e8b774"></td>
  </tr>
</table>


## 🔗 관련 이슈
- closes #885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 앱의 기본 테마 색상 설정이 개선되었습니다.
  * 시스템 기본값을 기반으로 다양한 환경에서 더 일관된 시각적 표현을 제공합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->