### PR TITLE
나의 코스 UI 관련 오류 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -355,7 +355,7 @@ class CoursesActivity :
                     viewModel.showCourses()
                     viewModel.switchContent(CoursesContent.CUSTOM_COURSE)
                     viewModel.checkAuthForCustomCourse {
-                        customCourseViewModel.fetchCustomCourses(viewModel.mapCoordinate)
+                        customCourseViewModel.fetchCustomCourses()
                     }
                     true
                 }
@@ -580,7 +580,7 @@ class CoursesActivity :
                         }
 
                         CoursesContent.CUSTOM_COURSE -> {
-                            customCourseViewModel.fetchCustomCourses(viewModel.mapCoordinate)
+                            customCourseViewModel.fetchCustomCourses()
                         }
                     }
                 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
@@ -1,6 +1,8 @@
 package io.coursepick.coursepick.presentation.customcourse
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -59,7 +62,10 @@ fun CustomCourseScreen(
                 ),
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-            Header(stringResource(R.string.custom_courses_header))
+            Header(
+                text = stringResource(R.string.custom_courses_header),
+                modifier = Modifier.scrollable(rememberScrollState(), Orientation.Vertical),
+            )
 
             when (status.status) {
                 UiStatus.Success -> {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
@@ -9,6 +9,7 @@ import io.coursepick.coursepick.domain.auth.AuthRepository
 import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.course.CoursesPage
 import io.coursepick.coursepick.domain.customcourse.CustomCourseRepository
+import io.coursepick.coursepick.domain.location.LocationRepository
 import io.coursepick.coursepick.presentation.Logger
 import io.coursepick.coursepick.presentation.auth.AuthFeature
 import io.coursepick.coursepick.presentation.course.CourseItem
@@ -30,6 +31,7 @@ class CustomCourseViewModel
     constructor(
         private val authRepository: AuthRepository,
         private val customCourseRepository: CustomCourseRepository,
+        private val locationRepository: LocationRepository,
         private val networkMonitor: NetworkMonitor,
     ) : ViewModel() {
         private val _uiEvent = MutableSharedFlow<CustomCourseUiEvent>()
@@ -71,7 +73,7 @@ class CustomCourseViewModel
             }
         }
 
-        fun fetchCustomCourses(userCoordinate: Coordinate?) {
+        fun fetchCustomCourses() {
             viewModelScope.launch {
                 if (!networkMonitor.isConnected()) {
                     _state.update { currentState ->
@@ -95,7 +97,8 @@ class CustomCourseViewModel
                 }
 
                 runCatching {
-                    customCourseRepository.customCourses(userCoordinate = userCoordinate)
+                    val userCoordinate: Coordinate? = locationRepository.currentLocation()?.coordinate
+                    customCourseRepository.customCourses(userCoordinate)
                 }.onSuccess { coursesPage: CoursesPage ->
                     Logger.log(Logger.Event.Success("fetch_custom_courses_new"))
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -68,7 +68,6 @@ class CustomCoursesFragment(
         _binding = FragmentCustomCoursesBinding.inflate(inflater, container, false)
         binding.customCourses.apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            isNestedScrollingEnabled = true
             setContent {
                 val nestedScrollInterop = rememberNestedScrollInteropConnection()
                 val customCourseState =

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -50,14 +50,14 @@ class CustomCoursesFragment(
         registerForActivityResult(
             ActivityResultContracts.StartActivityForResult(),
         ) { result ->
-            if (result.resultCode == Activity.RESULT_OK) fetchCustomCourses()
+            if (result.resultCode == Activity.RESULT_OK) customCourseViewModel.fetchCustomCourses()
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setUpCollectors()
 
-        fetchCustomCourses()
+        customCourseViewModel.fetchCustomCourses()
     }
 
     override fun onCreateView(
@@ -128,7 +128,7 @@ class CustomCoursesFragment(
                             }
 
                             CustomCourseUiEvent.RequestFetch -> {
-                                fetchCustomCourses()
+                                customCourseViewModel.fetchCustomCourses()
                             }
 
                             CustomCourseUiEvent.UnauthorizedUser -> {
@@ -170,8 +170,6 @@ class CustomCoursesFragment(
         val intent: Intent = CreateCustomCourseActivity.intent(requireContext(), initialCoordinate)
         createCustomCourseLauncher.launch(intent)
     }
-
-    private fun fetchCustomCourses() = customCourseViewModel.fetchCustomCourses(coursesViewModel.mapCoordinate)
 
     private fun showToastMessage(resId: Int) =
         Toast

--- a/android/app/src/main/res/layout/fragment_custom_courses.xml
+++ b/android/app/src/main/res/layout/fragment_custom_courses.xml
@@ -4,6 +4,5 @@
     <androidx.compose.ui.platform.ComposeView
         android:id="@+id/customCourses"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:nestedScrollingEnabled="true" />
+        android:layout_height="match_parent" />
 </layout>


### PR DESCRIPTION
## 🛠️ 설명
- 나의 코스 메뉴에서 `0m만큼 떨어짐` 표시가 사용자의 위치가 아닌 지도 위치를 기준으로 표시되는 오류가 수정됐습니다.
- 나의 코스 메뉴가 선택된 상태에서 나의 코스 UI를 아래로 스와이프해도 바텀 시트를 내릴 수 없는 현상이 수정됐습니다.


## 📸 스크린샷 / 동영상
<table>
  <tr>
    <th>As-is</th>
    <th>To-be</th>
  </tr>
  <tr>
    <td><video src="https://github.com/user-attachments/assets/e13d53a6-b879-4a1c-9d1b-15682c3c0ccf"></video></td>
    <td><video src="https://github.com/user-attachments/assets/bf47cf68-cbe9-4f47-8abc-c1775d1c7a32"></video></td>
  </tr>
</table>


## 🔗 관련 이슈

- closes #899 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 커스텀 코스 화면의 헤더에 세로 스크롤 기능 추가
  * 현재 위치 기반 코스 조회 처리 개선
  * 스크롤 동작 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->