### PR TITLE
코스 파일 업로드로 나의 코스 등록

### DIFF
--- a/backend/openapi-docs.gradle.kts
+++ b/backend/openapi-docs.gradle.kts
@@ -189,6 +189,76 @@ fun processOpenApiSpec(specFile: File) {
             parseExamples(requestBody["content"])
         }
 
+    // [4] Multipart 파일 업로드 API의 requestBody 자동 주입
+    // restdocs-api-spec이 requestParts를 OpenAPI requestBody로 변환하지 못하는 한계를 보완합니다.
+    // build/generated-snippets 하위의 request-parts.adoc 파일을 스캔하여 자동으로 주입합니다.
+    val snippetsDir = layout.buildDirectory.dir("generated-snippets").get().asFile
+    if (snippetsDir.exists()) {
+        // operationId → multipart part 목록 매핑 생성
+        val multipartParts = mutableMapOf<String, List<Pair<String, String>>>() // operationId → [(name, description)]
+
+        snippetsDir.listFiles()?.filter { it.isDirectory }?.forEach { snippetDir ->
+            val requestPartsFile = File(snippetDir, "request-parts.adoc")
+            val resourceFile = File(snippetDir, "resource.json")
+            if (requestPartsFile.exists() && resourceFile.exists()) {
+                // resource.json에서 operationId 추출
+                @Suppress("UNCHECKED_CAST")
+                val resource = jsonSlurper.parseText(resourceFile.readText()) as Map<String, Any?>
+                val operationId = resource["operationId"] as? String ?: return@forEach
+
+                // request-parts.adoc 파싱: |`+partName+`\n|설명 형식
+                val parts = mutableListOf<Pair<String, String>>()
+                val lines = requestPartsFile.readLines()
+                var i = 0
+                while (i < lines.size) {
+                    val partMatch = Regex("""\|`\+(.+?)\+`""").find(lines[i])
+                    if (partMatch != null && i + 1 < lines.size) {
+                        val partName = partMatch.groupValues[1]
+                        val desc = lines[i + 1].removePrefix("|").trim()
+                        parts.add(partName to desc)
+                    }
+                    i++
+                }
+                if (parts.isNotEmpty()) {
+                    multipartParts[operationId] = parts
+                }
+            }
+        }
+
+        // OpenAPI spec의 각 operation에 multipart requestBody 주입
+        if (multipartParts.isNotEmpty()) {
+            paths.values.filterIsInstance<Map<*, *>>()
+                .flatMap { it.values.filterIsInstance<MutableMap<String, Any?>>() }
+                .forEach { op ->
+                    val opId = op["operationId"] as? String ?: return@forEach
+                    val parts = multipartParts[opId] ?: return@forEach
+
+                    val properties = mutableMapOf<String, Any>()
+                    val required = mutableListOf<String>()
+                    parts.forEach { (name, desc) ->
+                        properties[name] = mutableMapOf(
+                            "type" to "string",
+                            "format" to "binary",
+                            "description" to desc
+                        )
+                        required.add(name)
+                    }
+
+                    op["requestBody"] = mutableMapOf(
+                        "content" to mutableMapOf(
+                            "multipart/form-data" to mutableMapOf(
+                                "schema" to mutableMapOf(
+                                    "type" to "object",
+                                    "properties" to properties,
+                                    "required" to required
+                                )
+                            )
+                        )
+                    )
+                }
+        }
+    }
+
     // 최종 수정된 내용을 예쁘게(pretty print) 하여 파일로 저장
     specFile.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(json)))
 }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -2,6 +2,7 @@ package coursepick.coursepick.application;
 
 import coursepick.coursepick.application.dto.CourseDetailResponse;
 import coursepick.coursepick.application.dto.CourseFile;
+import coursepick.coursepick.application.dto.CourseImportResponse;
 import coursepick.coursepick.application.dto.CourseResponse;
 import coursepick.coursepick.application.dto.CoursesResponse;
 import coursepick.coursepick.application.exception.ErrorType;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static coursepick.coursepick.application.exception.ErrorType.*;
@@ -46,16 +48,30 @@ public class CourseApplicationService {
     }
 
     @Transactional
-    public void importCustomCourseFile(MultipartFile file, String name, String userId) {
-        CourseName courseName = new CourseName(name);
-        validateDuplicatedCourseName(courseName);
+    public CourseImportResponse importCustomCourseFile(MultipartFile file, String userId) {
         User user = getUser(userId);
 
         try (CourseFile courseFile = CourseFile.from(file)) {
-            Course course = courseParserFacade.parse(courseFile, user).getFirst();
-            course.changeName(courseName.value());
+            ParsedCourses parsedCourses = courseParserFacade.parse(courseFile, user);
+            
+            List<String> successNames = new ArrayList<>();
+            List<String> skippedReasons = new ArrayList<>(parsedCourses.skippedReasons());
 
-            courseRepository.save(course);
+            for (Course course : parsedCourses.courses()) {
+                try {
+                    validateDuplicatedCourseName(course.name());
+                    courseRepository.save(course);
+                    successNames.add(course.name().value());
+                } catch (IllegalStateException e) {
+                    skippedReasons.add(String.format("코스 '%s': 중복된 이름", course.name().value()));
+                }
+            }
+            return new CourseImportResponse(
+                    successNames.size(),
+                    successNames,
+                    skippedReasons.size(),
+                    skippedReasons
+            );
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -1,7 +1,7 @@
 package coursepick.coursepick.application;
 
-
 import coursepick.coursepick.application.dto.CourseDetailResponse;
+import coursepick.coursepick.application.dto.CourseFile;
 import coursepick.coursepick.application.dto.CourseResponse;
 import coursepick.coursepick.application.dto.CoursesResponse;
 import coursepick.coursepick.application.exception.ErrorType;
@@ -17,7 +17,9 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 import static coursepick.coursepick.application.exception.ErrorType.*;
@@ -30,18 +32,35 @@ public class CourseApplicationService {
     private final CourseRepository courseRepository;
     private final UserRepository userRepository;
     private final RouteFinder routeFinder;
+    private final CourseParserFacade courseParserFacade;
     private final Alerter alerter;
     private final CourseTagGenerator courseTagGenerator;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void addCustomCourse(String name, List<Coordinate> coordinates, String userId) {
+        User user = getUser(userId);
+        Course newCourse = new Course(null, name, coordinates, user);
         CourseName courseName = new CourseName(name);
         validateDuplicatedCourseName(courseName);
         User user = getUser(userId);
 
         Course newCourse = new Course(null, courseName, coordinates, user);
         courseRepository.save(newCourse);
+    }
+
+    @Transactional
+    public void importCustomCourseFile(MultipartFile file, String courseName, String userId) {
+        User user = getUser(userId);
+
+        try (CourseFile courseFile = CourseFile.from(file)) {
+            Course course = courseParserFacade.parse(courseFile, user).getFirst();
+            course.changeName(courseName);
+
+            courseRepository.save(course);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Transactional

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -1,10 +1,6 @@
 package coursepick.coursepick.application;
 
-import coursepick.coursepick.application.dto.CourseDetailResponse;
-import coursepick.coursepick.application.dto.CourseFile;
-import coursepick.coursepick.application.dto.CourseImportResponse;
-import coursepick.coursepick.application.dto.CourseResponse;
-import coursepick.coursepick.application.dto.CoursesResponse;
+import coursepick.coursepick.application.dto.*;
 import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.course.*;
 import coursepick.coursepick.domain.course.event.ReviewAddedEvent;
@@ -53,7 +49,7 @@ public class CourseApplicationService {
 
         try (CourseFile courseFile = CourseFile.from(file)) {
             ParsedCourses parsedCourses = courseParserFacade.parse(courseFile, user);
-            
+
             List<String> successNames = new ArrayList<>();
             List<String> skippedReasons = new ArrayList<>(parsedCourses.skippedReasons());
 
@@ -63,9 +59,11 @@ public class CourseApplicationService {
                     courseRepository.save(course);
                     successNames.add(course.name().value());
                 } catch (IllegalStateException e) {
-                    skippedReasons.add(String.format("코스 '%s': 중복된 이름", course.name().value()));
+                    log.info("이미 코스 네임이 존재합니다. : {}", course.name().value());
+                    skippedReasons.add("코스 '%s': 중복된 이름".formatted(course.name().value()));
                 }
             }
+
             return new CourseImportResponse(
                     successNames.size(),
                     successNames,

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -46,12 +46,14 @@ public class CourseApplicationService {
     }
 
     @Transactional
-    public void importCustomCourseFile(MultipartFile file, String courseName, String userId) {
+    public void importCustomCourseFile(MultipartFile file, String name, String userId) {
+        CourseName courseName = new CourseName(name);
+        validateDuplicatedCourseName(courseName);
         User user = getUser(userId);
 
         try (CourseFile courseFile = CourseFile.from(file)) {
             Course course = courseParserFacade.parse(courseFile, user).getFirst();
-            course.changeName(courseName);
+            course.changeName(courseName.value());
 
             courseRepository.save(course);
         } catch (IOException e) {

--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,12 +38,9 @@ public class CourseApplicationService {
 
     @Transactional
     public void addCustomCourse(String name, List<Coordinate> coordinates, String userId) {
-        User user = getUser(userId);
-        Course newCourse = new Course(null, name, coordinates, user);
         CourseName courseName = new CourseName(name);
         validateDuplicatedCourseName(courseName);
         User user = getUser(userId);
-
         Course newCourse = new Course(null, courseName, coordinates, user);
         courseRepository.save(newCourse);
     }

--- a/backend/src/main/java/coursepick/coursepick/application/CourseParserFacade.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseParserFacade.java
@@ -1,10 +1,9 @@
 package coursepick.coursepick.application;
 
 import coursepick.coursepick.application.dto.CourseFile;
-import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseParser;
-import coursepick.coursepick.domain.user.UserProvider;
+import coursepick.coursepick.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -13,28 +12,12 @@ import java.util.List;
 
 import static coursepick.coursepick.application.exception.ErrorType.INVALID_FILE_EXTENSION;
 
-import coursepick.coursepick.domain.user.User;
-import coursepick.coursepick.domain.user.UserRepository;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class CourseParserFacade {
 
     private final List<CourseParser> parsers;
-    private final UserRepository userRepository;
-
-    public List<Course> parse(CourseFile file) {
-        CourseParser parser = findParser(file);
-        log.debug("코스 파싱을 시작합니다. 선택된 구현체={}", parser.getClass().getSimpleName());
-
-        User adminUser = userRepository.findByProviderAndProviderId(UserProvider.NONE, "admin")
-                .orElseThrow(() -> ErrorType.NOT_EXIST_USER.create("admin"));
-
-        List<Course> result = parser.parse(file, adminUser);
-        log.debug("{}개의 코스를 파싱했습니다.", result.size());
-        return result;
-    }
 
     public List<Course> parse(CourseFile file, User user) {
         CourseParser parser = findParser(file);

--- a/backend/src/main/java/coursepick/coursepick/application/CourseParserFacade.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseParserFacade.java
@@ -36,6 +36,16 @@ public class CourseParserFacade {
         return result;
     }
 
+    public List<Course> parse(CourseFile file, User user) {
+        CourseParser parser = findParser(file);
+        log.debug("코스 파싱을 시작합니다. 선택된 구현체={}", parser.getClass().getSimpleName());
+
+        List<Course> result = parser.parse(file, user);
+
+        log.debug("{}개의 코스를 파싱했습니다.", result.size());
+        return result;
+    }
+
     private CourseParser findParser(CourseFile file) {
         return parsers.stream()
                 .filter(parser -> parser.canParse(file))

--- a/backend/src/main/java/coursepick/coursepick/application/CourseParserFacade.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseParserFacade.java
@@ -3,6 +3,7 @@ package coursepick.coursepick.application;
 import coursepick.coursepick.application.dto.CourseFile;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseParser;
+import coursepick.coursepick.domain.course.ParsedCourses;
 import coursepick.coursepick.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,13 +20,13 @@ public class CourseParserFacade {
 
     private final List<CourseParser> parsers;
 
-    public List<Course> parse(CourseFile file, User user) {
+    public ParsedCourses parse(CourseFile file, User user) {
         CourseParser parser = findParser(file);
         log.debug("코스 파싱을 시작합니다. 선택된 구현체={}", parser.getClass().getSimpleName());
 
-        List<Course> result = parser.parse(file, user);
+        ParsedCourses result = parser.parse(file, user);
 
-        log.debug("{}개의 코스를 파싱했습니다.", result.size());
+        log.debug("{}개의 코스를 파싱했습니다. (스킵: {}개)", result.courses().size(), result.skippedReasons().size());
         return result;
     }
 

--- a/backend/src/main/java/coursepick/coursepick/application/admin/AdminHolder.java
+++ b/backend/src/main/java/coursepick/coursepick/application/admin/AdminHolder.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Component
 public class AdminHolder {
+
     private final UserRepository userRepository;
 
     public User getAdminId() {

--- a/backend/src/main/java/coursepick/coursepick/application/admin/AdminHolder.java
+++ b/backend/src/main/java/coursepick/coursepick/application/admin/AdminHolder.java
@@ -1,0 +1,19 @@
+package coursepick.coursepick.application.admin;
+
+import coursepick.coursepick.application.exception.ErrorType;
+import coursepick.coursepick.domain.user.User;
+import coursepick.coursepick.domain.user.UserProvider;
+import coursepick.coursepick.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class AdminHolder {
+    private final UserRepository userRepository;
+
+    public User getAdminId() {
+        return userRepository.findByProviderAndProviderId(UserProvider.NONE, "admin")
+                .orElseThrow(() -> ErrorType.NOT_EXIST_USER.create("admin"));
+    }
+}

--- a/backend/src/main/java/coursepick/coursepick/application/dto/CourseImportResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/CourseImportResponse.java
@@ -1,0 +1,11 @@
+package coursepick.coursepick.application.dto;
+
+import java.util.List;
+
+public record CourseImportResponse(
+        int successCount,
+        List<String> successNames,
+        int skippedCount,
+        List<String> skippedReasons
+) {
+}

--- a/backend/src/main/java/coursepick/coursepick/domain/course/CourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/CourseParser.java
@@ -9,5 +9,5 @@ public interface CourseParser {
 
     boolean canParse(CourseFile file);
 
-    List<Course> parse(CourseFile file, User user);
+    ParsedCourses parse(CourseFile file, User user);
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Gpx.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Gpx.java
@@ -32,49 +32,98 @@ public class Gpx {
         return new Gpx(course.id(), course.name().value(), coordinates);
     }
 
-    public static Gpx from(CourseFile file) {
+    public record GpxParseResult(
+            List<Gpx> gpxList,
+            List<String> skippedReasons
+    ) {
+    }
+
+    public static GpxParseResult from(CourseFile file) {
         try {
             XMLInputFactory xif = XMLInputFactory.newInstance();
             XMLStreamReader xsr = xif.createXMLStreamReader(file.inputStream());
-            String id = null;
-            Double lat = null, lon = null;
+            
+            List<Gpx> gpxList = new ArrayList<>();
+            List<String> skippedReasons = new ArrayList<>();
+            String globalName = null;
+            String currentId = null;
+            String currentName = null;
+            List<Coordinate> currentCoordinates = new ArrayList<>();
             boolean hasExtensions = false;
+            boolean inTrack = false;
+            boolean inMetadata = false;
 
-            List<Coordinate> coordinates = new ArrayList<>();
-
+            int trackIndex = 0;
             while (xsr.hasNext()) {
                 int event = xsr.next();
 
                 if (event == XMLStreamConstants.START_ELEMENT) {
                     String localName = xsr.getLocalName();
-                    if ("extensions".equals(localName)) {
+                    if ("metadata".equals(localName)) {
+                        inMetadata = true;
+                    } else if ("trk".equals(localName)) {
+                        inTrack = true;
+                        trackIndex++;
+                        currentId = null;
+                        currentName = null;
+                        currentCoordinates = new ArrayList<>();
+                    } else if ("name".equals(localName)) {
+                        xsr.next();
+                        if (xsr.getEventType() == XMLStreamConstants.CHARACTERS) {
+                            String nameValue = xsr.getText().trim();
+                            if (!nameValue.isEmpty()) {
+                                if (inTrack) {
+                                    currentName = nameValue;
+                                } else if (inMetadata || globalName == null) {
+                                    globalName = nameValue;
+                                }
+                            }
+                        }
+                    } else if ("extensions".equals(localName)) {
                         hasExtensions = true;
                     } else if ("trkpt".equals(localName)) {
-                        lat = Double.parseDouble(xsr.getAttributeValue(null, "lat"));
-                        lon = Double.parseDouble(xsr.getAttributeValue(null, "lon"));
+                        double lat = Double.parseDouble(xsr.getAttributeValue(null, "lat"));
+                        double lon = Double.parseDouble(xsr.getAttributeValue(null, "lon"));
+                        currentCoordinates.add(new Coordinate(lat, lon));
                     } else if ("id".equals(localName) && hasExtensions) {
                         xsr.next();
                         if (xsr.getEventType() == XMLStreamConstants.CHARACTERS) {
-                            id = xsr.getText();
+                            currentId = xsr.getText();
                         }
                     }
                 } else if (event == XMLStreamConstants.END_ELEMENT) {
                     String localName = xsr.getLocalName();
-                    if ("trkpt".equals(localName)) {
-                        if (lat != null && lon != null) {
-                            coordinates.add(new Coordinate(lat, lon));
+                    if ("trk".equals(localName)) {
+                        String finalName = extractFinalName(currentName);
+                        if (finalName != null && !currentCoordinates.isEmpty()) {
+                            gpxList.add(new Gpx(currentId, finalName, currentCoordinates));
+                        } else {
+                            String reason = String.format("%d번째 트랙: %s", 
+                                    trackIndex, (finalName == null) ? "이름 누락" : "좌표 부족");
+                            skippedReasons.add(reason);
+                            log.warn("GPX 파일에서 트랙 정보를 건너뜁니다. 파일명={}, 사유={}", file.name(), reason);
                         }
+                        inTrack = false;
+                    } else if ("metadata".equals(localName)) {
+                        inMetadata = false;
                     } else if ("extensions".equals(localName)) {
                         hasExtensions = false;
                     }
                 }
             }
 
-            return new Gpx(id, file.name(), coordinates);
+            return new GpxParseResult(gpxList, skippedReasons);
         } catch (XMLStreamException e) {
             log.warn("[EXCEPTION] CourseFile -> Gpx 변환에 실패했습니다.", LogContent.exception(e));
             throw new IllegalArgumentException(e);
         }
+    }
+
+    private static String extractFinalName(String trackName) {
+        if (trackName == null || trackName.isBlank()) {
+            return null;
+        }
+        return trackName;
     }
 
     public String toXmlContent() {

--- a/backend/src/main/java/coursepick/coursepick/domain/course/ParsedCourses.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/ParsedCourses.java
@@ -1,0 +1,9 @@
+package coursepick.coursepick.domain.course;
+
+import java.util.List;
+
+public record ParsedCourses(
+        List<Course> courses,
+        List<String> skippedReasons
+) {
+}

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/parser/GpxCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/parser/GpxCourseParser.java
@@ -5,6 +5,7 @@ import coursepick.coursepick.application.dto.CourseFileExtension;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseParser;
 import coursepick.coursepick.domain.course.Gpx;
+import coursepick.coursepick.domain.course.ParsedCourses;
 import coursepick.coursepick.domain.user.User;
 import org.springframework.stereotype.Component;
 
@@ -19,7 +20,13 @@ public class GpxCourseParser implements CourseParser {
     }
 
     @Override
-    public List<Course> parse(CourseFile file, User user) {
-        return Gpx.from(file).toCourses(user);
+    public ParsedCourses parse(CourseFile file, User user) {
+        Gpx.GpxParseResult result = Gpx.from(file);
+
+        List<Course> courses = result.gpxList().stream()
+                .flatMap(gpx -> gpx.toCourses(user).stream())
+                .toList();
+
+        return new ParsedCourses(courses, result.skippedReasons());
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/infrastructure/parser/KmlCourseParser.java
+++ b/backend/src/main/java/coursepick/coursepick/infrastructure/parser/KmlCourseParser.java
@@ -7,6 +7,7 @@ import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.Course;
 import coursepick.coursepick.domain.course.CourseName;
 import coursepick.coursepick.domain.course.CourseParser;
+import coursepick.coursepick.domain.course.ParsedCourses;
 import coursepick.coursepick.domain.user.User;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -33,8 +34,9 @@ public class KmlCourseParser implements CourseParser {
     }
 
     @Override
-    public List<Course> parse(CourseFile file, User user) {
+    public ParsedCourses parse(CourseFile file, User user) {
         List<Course> courses = new ArrayList<>();
+        List<String> skippedReasons = new ArrayList<>();
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         NodeList placemarks;
 
@@ -53,10 +55,15 @@ public class KmlCourseParser implements CourseParser {
                 Course course = parseCourse(placemarkElement, user);
                 if (course != null) {
                     courses.add(course);
+                } else {
+                    String parsedName = parseCourseName(placemarkElement);
+                    String reason = String.format("%d번째 트랙: %s", 
+                            i + 1, (parsedName == null || parsedName.isBlank()) ? "이름 누락" : "좌표 부족");
+                    skippedReasons.add(reason);
                 }
             }
         }
-        return courses;
+        return new ParsedCourses(courses, skippedReasons);
     }
 
     private Course parseCourse(Element placemark, User user) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
@@ -112,8 +112,8 @@ public class AdminWebController {
         User adminUser = adminHolder.getAdminId();
         for (MultipartFile file : files) {
             try (CourseFile courseFile = CourseFile.from(file)) {
-                List<Course> courses = courseParserFacade.parse(courseFile, adminUser);
-                courseRepository.saveAll(courses);
+                ParsedCourses result = courseParserFacade.parse(courseFile, adminUser);
+                courseRepository.saveAll(result.courses());
             }
         }
     }

--- a/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
@@ -6,6 +6,7 @@ import coursepick.coursepick.application.dto.CourseFile;
 import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.course.*;
 import coursepick.coursepick.domain.user.User;
+import coursepick.coursepick.domain.user.UserProvider;
 import coursepick.coursepick.domain.user.UserRepository;
 import coursepick.coursepick.presentation.dto.*;
 import jakarta.validation.Valid;
@@ -107,7 +108,7 @@ public class AdminWebController {
 
     @PostMapping("/admin/api/import")
     public void importFiles(@RequestParam("files") List<MultipartFile> files) throws IOException {
-        User user = userRepository.findByProviderAndProviderId(null, "ADMIN")
+        User user = userRepository.findByProviderAndProviderId(UserProvider.NONE, "admin")
             .orElseThrow(() -> ErrorType.NOT_EXIST_USER.create("admin"));
 
         for (MultipartFile file : files) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
@@ -2,6 +2,7 @@ package coursepick.coursepick.presentation;
 
 
 import coursepick.coursepick.application.CourseParserFacade;
+import coursepick.coursepick.application.admin.AdminHolder;
 import coursepick.coursepick.application.dto.CourseFile;
 import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.course.*;
@@ -35,7 +36,7 @@ public class AdminWebController {
     private final CourseRepository courseRepository;
     private final CourseParserFacade courseParserFacade;
     private final CoordinateSnapper coordinateSnapper;
-    private final UserRepository userRepository;
+    private final AdminHolder adminHolder;
 
     @Value("${admin.token}")
     private String adminToken;
@@ -108,12 +109,10 @@ public class AdminWebController {
 
     @PostMapping("/admin/api/import")
     public void importFiles(@RequestParam("files") List<MultipartFile> files) throws IOException {
-        User user = userRepository.findByProviderAndProviderId(UserProvider.NONE, "admin")
-            .orElseThrow(() -> ErrorType.NOT_EXIST_USER.create("admin"));
-
+        User adminUser = adminHolder.getAdminId();
         for (MultipartFile file : files) {
             try (CourseFile courseFile = CourseFile.from(file)) {
-                List<Course> courses = courseParserFacade.parse(courseFile, user);
+                List<Course> courses = courseParserFacade.parse(courseFile, adminUser);
                 courseRepository.saveAll(courses);
             }
         }

--- a/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/AdminWebController.java
@@ -5,6 +5,8 @@ import coursepick.coursepick.application.CourseParserFacade;
 import coursepick.coursepick.application.dto.CourseFile;
 import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.domain.course.*;
+import coursepick.coursepick.domain.user.User;
+import coursepick.coursepick.domain.user.UserRepository;
 import coursepick.coursepick.presentation.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ public class AdminWebController {
     private final CourseRepository courseRepository;
     private final CourseParserFacade courseParserFacade;
     private final CoordinateSnapper coordinateSnapper;
+    private final UserRepository userRepository;
 
     @Value("${admin.token}")
     private String adminToken;
@@ -104,9 +107,12 @@ public class AdminWebController {
 
     @PostMapping("/admin/api/import")
     public void importFiles(@RequestParam("files") List<MultipartFile> files) throws IOException {
+        User user = userRepository.findByProviderAndProviderId(null, "ADMIN")
+            .orElseThrow(() -> ErrorType.NOT_EXIST_USER.create("admin"));
+
         for (MultipartFile file : files) {
             try (CourseFile courseFile = CourseFile.from(file)) {
-                List<Course> courses = courseParserFacade.parse(courseFile);
+                List<Course> courses = courseParserFacade.parse(courseFile, user);
                 courseRepository.saveAll(courses);
             }
         }

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
@@ -12,6 +12,7 @@ import coursepick.coursepick.security.UserId;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -113,6 +114,18 @@ public class CourseV1WebController {
         return DraftRouteWebResponse.of(route.coordinates(), route.length());
     }
 
+    @Login
+    @PostMapping("/courses/file")
+    public String importFilesToCustomCourse(
+            @RequestParam("file") MultipartFile multipartFile,
+            @RequestParam("name") String name,
+            @UserId String userId
+    ) {
+        courseApplicationService.importCustomCourseFile(multipartFile, name, userId);
+        return "파일 추가 성공";
+    }
+
+    @Override
     @Login
     @PostMapping("/courses/{id}/report")
     public void reportCourse(@PathVariable("id") String id, @UserId String userId) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
@@ -116,13 +116,12 @@ public class CourseV1WebController {
 
     @Login
     @PostMapping("/courses/file")
-    public String importFilesToCustomCourse(
+    public void importFilesToCustomCourse(
             @RequestParam("file") MultipartFile multipartFile,
             @RequestParam("name") String name,
             @UserId String userId
     ) {
         courseApplicationService.importCustomCourseFile(multipartFile, name, userId);
-        return "파일 추가 성공";
     }
 
     @Override

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
@@ -2,6 +2,7 @@ package coursepick.coursepick.presentation;
 
 import coursepick.coursepick.application.CourseApplicationService;
 import coursepick.coursepick.application.dto.CourseDetailResponse;
+import coursepick.coursepick.application.dto.CourseImportResponse;
 import coursepick.coursepick.application.dto.CoursesResponse;
 import coursepick.coursepick.domain.course.Coordinate;
 import coursepick.coursepick.domain.course.CourseFindCondition;
@@ -116,15 +117,14 @@ public class CourseV1WebController {
 
     @Login
     @PostMapping("/courses/file")
-    public void importFilesToCustomCourse(
+    public CourseImportWebResponse importFilesToCustomCourse(
             @RequestParam("file") MultipartFile multipartFile,
-            @RequestParam("name") String name,
             @UserId String userId
     ) {
-        courseApplicationService.importCustomCourseFile(multipartFile, name, userId);
+        CourseImportResponse response = courseApplicationService.importCustomCourseFile(multipartFile, userId);
+        return CourseImportWebResponse.from(response);
     }
 
-    @Override
     @Login
     @PostMapping("/courses/{id}/report")
     public void reportCourse(@PathVariable("id") String id, @UserId String userId) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseImportWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseImportWebResponse.java
@@ -1,0 +1,20 @@
+package coursepick.coursepick.presentation.dto;
+
+import coursepick.coursepick.application.dto.CourseImportResponse;
+import java.util.List;
+
+public record CourseImportWebResponse(
+        int successCount,
+        List<String> successNames,
+        int skippedCount,
+        List<String> skippedReasons
+) {
+    public static CourseImportWebResponse from(CourseImportResponse response) {
+        return new CourseImportWebResponse(
+                response.successCount(),
+                response.successNames(),
+                response.skippedCount(),
+                response.skippedReasons()
+        );
+    }
+}

--- a/backend/src/main/resources/static/docs/openapi3.json
+++ b/backend/src/main/resources/static/docs/openapi3.json
@@ -109,7 +109,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-custom1555334040"
+                                    "$ref": "#/components/schemas/v1-courses1555334040"
                                 },
                                 "examples": {
                                     "course-find-nearby": {
@@ -145,13 +145,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-find-nearby-400": {
                                         "value": {
                                             "message": "Required request parameter 'scope' for method parameter type int is not present",
-                                            "timestamp": "2026-05-29T23:15:10.873152"
+                                            "timestamp": "2026-05-30T01:30:01.390750"
                                         }
                                     }
                                 }
@@ -255,13 +255,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-add-custom-409": {
                                         "value": {
                                             "message": "'\ub098\ub9cc\uc758 \ud55c\uac15 \ub7ec\ub2dd \ucf54\uc2a4'\uc740(\ub294) \uc774\ubbf8 \uc874\uc7ac\ud558\ub294 \ucf54\uc2a4 \uc774\ub984\uc785\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:11.003053"
+                                            "timestamp": "2026-05-30T01:30:01.536881"
                                         }
                                     }
                                 }
@@ -273,13 +273,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-add-custom-401": {
                                         "value": {
                                             "message": "\uc778\uc99d\uc5d0 \uc2e4\ud328\ud558\uc600\uc2b5\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:10.980054"
+                                            "timestamp": "2026-05-30T01:30:01.512807"
                                         }
                                     }
                                 }
@@ -291,19 +291,19 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-add-custom-400-name": {
                                         "value": {
                                             "message": "\uc774\ub984\uc740 2-30\uc790 \uc0ac\uc774\uc774\uc5b4\uc57c \ud569\ub2c8\ub2e4. \uc785\ub825\uac12=a",
-                                            "timestamp": "2026-05-29T23:15:11.093711"
+                                            "timestamp": "2026-05-30T01:30:01.637597"
                                         }
                                     },
                                     "course-add-custom-400-count": {
                                         "value": {
                                             "message": "\ucf54\uc2a4\ub294 \ucd9c\ubc1c\uc9c0\uc640 \ub3c4\ucc29\uc9c0 \ub4f1 \ucd5c\uc18c 2\uac1c \uc774\uc0c1\uc758 \uc88c\ud45c\uac00 \ud544\uc694\ud569\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:11.116952"
+                                            "timestamp": "2026-05-30T01:30:01.662315"
                                         }
                                     }
                                 }
@@ -388,13 +388,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-find-custom-401": {
                                         "value": {
                                             "message": "\uc778\uc99d\uc5d0 \uc2e4\ud328\ud558\uc600\uc2b5\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:11.020786"
+                                            "timestamp": "2026-05-30T01:30:01.557922"
                                         }
                                     }
                                 }
@@ -406,7 +406,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-custom1555334040"
+                                    "$ref": "#/components/schemas/v1-courses1555334040"
                                 },
                                 "examples": {
                                     "course-find-custom": {
@@ -462,13 +462,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-favorites-400": {
                                         "value": {
                                             "message": "Required request parameter 'courseIds' for method parameter type List is not present",
-                                            "timestamp": "2026-05-29T23:15:10.809198"
+                                            "timestamp": "2026-05-30T01:30:01.329188"
                                         }
                                     }
                                 }
@@ -533,13 +533,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-detail-404": {
                                         "value": {
                                             "message": "\ucf54\uc2a4\uac00 \uc874\uc7ac\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ucf54\uc2a4id=invalid-id",
-                                            "timestamp": "2026-05-29T23:15:10.786205"
+                                            "timestamp": "2026-05-30T01:30:01.307937"
                                         }
                                     }
                                 }
@@ -632,13 +632,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "user-sign-400": {
                                         "value": {
                                             "message": "\uc561\uc138\uc2a4 \ud1a0\ud070\uc740 \ud544\uc218\uc785\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:11.428400"
+                                            "timestamp": "2026-05-30T01:30:02.015599"
                                         }
                                     }
                                 }
@@ -742,13 +742,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-draft-route-400": {
                                         "value": {
                                             "message": "\uc704\ub3c4\ub294 -90 \uc774\uc0c1, 90 \uc774\ud558\uc774\uc5b4\uc57c \ud569\ub2c8\ub2e4. \uc785\ub825\uac12=100.0",
-                                            "timestamp": "2026-05-29T23:15:10.762265"
+                                            "timestamp": "2026-05-30T01:30:01.285281"
                                         }
                                     }
                                 }
@@ -804,13 +804,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-closest-coordinate-404": {
                                         "value": {
                                             "message": "\ucf54\uc2a4\uac00 \uc874\uc7ac\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ucf54\uc2a4id=invalid-id",
-                                            "timestamp": "2026-05-29T23:15:11.038260"
+                                            "timestamp": "2026-05-30T01:30:01.576540"
                                         }
                                     }
                                 }
@@ -867,13 +867,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-report-404": {
                                         "value": {
                                             "message": "\ucf54\uc2a4\uac00 \uc874\uc7ac\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ucf54\uc2a4id=invalid-id",
-                                            "timestamp": "2026-05-29T23:15:10.852724"
+                                            "timestamp": "2026-05-30T01:30:01.370475"
                                         }
                                     }
                                 }
@@ -885,13 +885,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-report-401": {
                                         "value": {
                                             "message": "\uc778\uc99d\uc5d0 \uc2e4\ud328\ud558\uc600\uc2b5\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:10.830645"
+                                            "timestamp": "2026-05-30T01:30:01.349831"
                                         }
                                     }
                                 }
@@ -981,25 +981,25 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-add-review-400-rating": {
                                         "value": {
                                             "message": "\ub9ac\ubdf0 \ud3c9\uc810\uc740 1\uc774\uc0c1 5\uc774\ud558\uc5ec\uc57c \ud569\ub2c8\ub2e4. \uc785\ub825\uac12=6",
-                                            "timestamp": "2026-05-29T23:15:11.135431"
+                                            "timestamp": "2026-05-30T01:30:01.679947"
                                         }
                                     },
                                     "course-add-review-400-length": {
                                         "value": {
                                             "message": "\ub9ac\ubdf0 \ub0b4\uc6a9\uc740 1\uc790 \uc774\uc0c1 500\uc790 \uc774\ud558\uc5ec\uc57c \ud569\ub2c8\ub2e4. \uc785\ub825 \uae38\uc774=0",
-                                            "timestamp": "2026-05-29T23:15:10.454282"
+                                            "timestamp": "2026-05-30T01:30:00.889805"
                                         }
                                     },
                                     "course-add-review-400-duplicate": {
                                         "value": {
                                             "message": "\uc774\ubbf8 \ud574\ub2f9 \ucf54\uc2a4\uc5d0 \ub9ac\ubdf0\ub97c \uc791\uc131\ud588\uc2b5\ub2c8\ub2e4. \ucf54\uc2a4id=689c3143182cecc6353cca7b, \uc720\uc800id=user-id",
-                                            "timestamp": "2026-05-29T23:15:11.151989"
+                                            "timestamp": "2026-05-30T01:30:01.696903"
                                         }
                                     }
                                 }
@@ -1011,13 +1011,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-add-review-401": {
                                         "value": {
                                             "message": "\uc778\uc99d\uc5d0 \uc2e4\ud328\ud558\uc600\uc2b5\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:11.055909"
+                                            "timestamp": "2026-05-30T01:30:01.596160"
                                         }
                                     }
                                 }
@@ -1029,13 +1029,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-add-review-404": {
                                         "value": {
                                             "message": "\ucf54\uc2a4\uac00 \uc874\uc7ac\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ucf54\uc2a4id=invalid-id",
-                                            "timestamp": "2026-05-29T23:15:11.072267"
+                                            "timestamp": "2026-05-30T01:30:01.615095"
                                         }
                                     }
                                 }
@@ -1094,13 +1094,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-route-404": {
                                         "value": {
                                             "message": "\ucf54\uc2a4\uac00 \uc874\uc7ac\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ucf54\uc2a4id=invalid-id",
-                                            "timestamp": "2026-05-29T23:15:10.709999"
+                                            "timestamp": "2026-05-30T01:30:01.232079"
                                         }
                                     }
                                 }
@@ -1173,13 +1173,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-delete-review-401": {
                                         "value": {
                                             "message": "\uc778\uc99d\uc5d0 \uc2e4\ud328\ud558\uc600\uc2b5\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:10.892274"
+                                            "timestamp": "2026-05-30T01:30:01.413827"
                                         }
                                     }
                                 }
@@ -1191,13 +1191,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-delete-review-404": {
                                         "value": {
                                             "message": "\ub9ac\ubdf0\uac00 \uc874\uc7ac\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ub9ac\ubdf0id=review-id",
-                                            "timestamp": "2026-05-29T23:15:10.911341"
+                                            "timestamp": "2026-05-30T01:30:01.438160"
                                         }
                                     }
                                 }
@@ -1250,13 +1250,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-report-review-404": {
                                         "value": {
                                             "message": "\ub9ac\ubdf0\uac00 \uc874\uc7ac\ud558\uc9c0 \uc54a\uc2b5\ub2c8\ub2e4. \ub9ac\ubdf0id=review-id",
-                                            "timestamp": "2026-05-29T23:15:10.950650"
+                                            "timestamp": "2026-05-30T01:30:01.479092"
                                         }
                                     }
                                 }
@@ -1271,13 +1271,13 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/v1-courses-draft-route593469975"
+                                    "$ref": "#/components/schemas/v1-courses593469975"
                                 },
                                 "examples": {
                                     "course-report-review-401": {
                                         "value": {
                                             "message": "\uc778\uc99d\uc5d0 \uc2e4\ud328\ud558\uc600\uc2b5\ub2c8\ub2e4.",
-                                            "timestamp": "2026-05-29T23:15:10.931483"
+                                            "timestamp": "2026-05-30T01:30:01.458738"
                                         }
                                     }
                                 }
@@ -1518,7 +1518,7 @@
                     }
                 }
             },
-            "v1-courses-draft-route593469975": {
+            "v1-courses593469975": {
                 "required": [
                     "message",
                     "timestamp"
@@ -1552,7 +1552,7 @@
                     }
                 }
             },
-            "v1-courses-custom1555334040": {
+            "v1-courses1555334040": {
                 "required": [
                     "hasNext"
                 ],

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -358,6 +358,111 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
     }
 
     @Nested
+    class 파일_코스_임포트 {
+
+        @Test
+        void 파일을_통해_여러_코스를_한번에_저장한다() {
+            var content = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <gpx version="1.1" creator="Coursepick" xmlns="http://www.topografix.com/GPX/1/1">
+                        <trk>
+                            <name>코스1</name>
+                            <trkseg>
+                                <trkpt lat="37.48" lon="126.92"/>
+                                <trkpt lat="37.49" lon="126.93"/>
+                            </trkseg>
+                        </trk>
+                        <trk>
+                            <name>코스2</name>
+                            <trkseg>
+                                <trkpt lat="37.5" lon="127.0"/>
+                                <trkpt lat="37.51" lon="127.1"/>
+                            </trkseg>
+                        </trk>
+                    </gpx>
+                    """;
+            var file = new org.springframework.mock.web.MockMultipartFile("file", "test.gpx", "application/gpx+xml", content.getBytes());
+
+            var response = sut.importCustomCourseFile(file, TEST_USER.id());
+
+            assertThat(response.successCount()).isEqualTo(2);
+            assertThat(response.successNames()).containsExactlyInAnyOrder("코스1", "코스2");
+            assertThat(dbUtil.findCourseByName("코스1")).isNotNull();
+            assertThat(dbUtil.findCourseByName("코스2")).isNotNull();
+        }
+
+        @Test
+        void 이름이_중복된_코스는_건너뛰고_나머지만_저장한다() {
+            // Given
+            sut.addCustomCourse("이미있는코스", 한강_좌표, TEST_USER.id());
+
+            var content = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <gpx version="1.1" creator="Coursepick" xmlns="http://www.topografix.com/GPX/1/1">
+                        <trk>
+                            <name>이미있는코스</name>
+                            <trkseg>
+                                <trkpt lat="37.4" lon="126.9"/>
+                                <trkpt lat="37.41" lon="126.91"/>
+                            </trkseg>
+                        </trk>
+                        <trk>
+                            <name>새로운코스</name>
+                            <trkseg>
+                                <trkpt lat="37.5" lon="127.0"/>
+                                <trkpt lat="37.51" lon="127.1"/>
+                            </trkseg>
+                        </trk>
+                    </gpx>
+                    """;
+            var file = new org.springframework.mock.web.MockMultipartFile("file", "test.gpx", "application/gpx+xml", content.getBytes());
+
+            // When
+            var response = sut.importCustomCourseFile(file, TEST_USER.id());
+
+            // Then
+            assertThat(response.successCount()).isEqualTo(1);
+            assertThat(response.successNames()).containsExactly("새로운코스");
+            assertThat(response.skippedCount()).isEqualTo(1);
+            assertThat(response.skippedReasons().get(0)).contains("중복된 이름");
+            assertThat(dbUtil.findCourseByName("새로운코스")).isNotNull();
+        }
+
+        @Test
+        void 이름이_없는_트랙은_제외하고_저장한다() {
+            // Given
+            var content = """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <gpx version="1.1" creator="Coursepick" xmlns="http://www.topografix.com/GPX/1/1">
+                        <trk>
+                            <name>정상코스</name>
+                            <trkseg>
+                                <trkpt lat="37.4" lon="126.9"/>
+                                <trkpt lat="37.41" lon="126.91"/>
+                            </trkseg>
+                        </trk>
+                        <trk>
+                            <trkseg>
+                                <trkpt lat="37.5" lon="127.0"/>
+                                <trkpt lat="37.51" lon="127.1"/>
+                            </trkseg>
+                        </trk>
+                    </gpx>
+                    """;
+            var file = new org.springframework.mock.web.MockMultipartFile("file", "test.gpx", "application/gpx+xml", content.getBytes());
+
+            // When
+            var response = sut.importCustomCourseFile(file, TEST_USER.id());
+
+            // Then
+            assertThat(response.successCount()).isEqualTo(1);
+            assertThat(response.successNames()).containsExactly("정상코스");
+            assertThat(response.skippedCount()).isEqualTo(1);
+            assertThat(response.skippedReasons().get(0)).contains("이름 누락");
+        }
+    }
+
+    @Nested
     class 리뷰_추가_삭제_신고 {
 
         private String courseId;

--- a/backend/src/test/java/coursepick/coursepick/application/FindDraftRouteTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/FindDraftRouteTest.java
@@ -23,7 +23,7 @@ class FindDraftRouteTest {
     @BeforeEach
     void setUp() {
         routeFinder = mock(RouteFinder.class);
-        courseService = new CourseApplicationService(null, null, routeFinder, null, null, null);
+        courseService = new CourseApplicationService(null, null, routeFinder, null, null, null, null);
     }
 
 

--- a/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
+++ b/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
@@ -33,6 +33,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -629,7 +631,7 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
                             preprocessResponse(prettyPrint()),
                             resource(ResourceSnippetParameters.builder()
                                     .tag(TAG)
-                                    .summary("유저 코스 파일 저장")
+                                    .summary("커스텀 코스 파일 생성")
                                     .description("GPX 또는 KML 파일을 업로드하여 커스텀 코스들을 생성합니다. (로그인 필요)")
                                     .responseFields(
                                             fieldWithPath("successCount").description("성공적으로 저장된 코스 개수"),
@@ -637,7 +639,10 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
                                             fieldWithPath("skippedCount").description("제외된 코스 개수"),
                                             fieldWithPath("skippedReasons[]").description("코스 제외 사유 리스트")
                                     )
-                                    .build())));
+                                    .build()),
+                            requestParts(
+                                    partWithName("file").description("업로드할 GPX 또는 KML 파일")
+                            )));
         }
     }
 

--- a/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
+++ b/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
@@ -3,6 +3,7 @@ package coursepick.coursepick.docs;
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import coursepick.coursepick.application.dto.CourseDetailResponse;
+import coursepick.coursepick.application.dto.CourseImportResponse;
 import coursepick.coursepick.application.dto.CourseResponse;
 import coursepick.coursepick.application.dto.CoursesResponse;
 import coursepick.coursepick.application.dto.ReviewResponse;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.ResultHandler;
 
@@ -598,6 +600,45 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
                                                     .attributes(key("example").value("review-id")))
                                     .build())));
         }
+
+        @Test
+        void 코스_파일_임포트_API() throws Exception {
+            var response = new CourseImportResponse(
+                    2,
+                    List.of("남산 코스", "한강 코스"),
+                    1,
+                    List.of("3번째 트랙: 이름 누락")
+            );
+            given(courseApplicationService.importCustomCourseFile(any(), anyString()))
+                    .willReturn(response);
+
+            var file = new MockMultipartFile(
+                    "file",
+                    "course.gpx",
+                    "application/gpx+xml",
+                    "test content".getBytes()
+            );
+
+            mockMvc.perform(multipart("/v1/courses/file")
+                            .file(file)
+                            .header("Authorization", "Bearer " + "test.jwt.token")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andDo(MockMvcRestDocumentationWrapper.document("course-import-file",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag(TAG)
+                                    .summary("유저 코스 파일 저장")
+                                    .description("GPX 또는 KML 파일을 업로드하여 커스텀 코스들을 생성합니다. (로그인 필요)")
+                                    .responseFields(
+                                            fieldWithPath("successCount").description("성공적으로 저장된 코스 개수"),
+                                            fieldWithPath("successNames[]").description("저장된 코스 이름 리스트"),
+                                            fieldWithPath("skippedCount").description("제외된 코스 개수"),
+                                            fieldWithPath("skippedReasons[]").description("코스 제외 사유 리스트")
+                                    )
+                                    .build())));
+        }
     }
 
     @Nested
@@ -796,6 +837,45 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isUnauthorized())
                     .andDo(documentUnauthorized("course-find-custom-401", "내 커스텀 코스 조회"));
+        }
+
+        @Test
+        void 코스_파일_임포트_API_400_에러() throws Exception {
+            doThrow(ErrorType.INVALID_FILE_EXTENSION.create())
+                    .when(courseApplicationService).importCustomCourseFile(any(), anyString());
+
+            var file = new MockMultipartFile(
+                    "file",
+                    "invalid.txt",
+                    "text/plain",
+                    "invalid content".getBytes()
+            );
+
+            mockMvc.perform(multipart("/v1/courses/file")
+                            .file(file)
+                            .header("Authorization", "Bearer " + "test.jwt.token")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andDo(documentBadRequest("course-import-file-400"));
+        }
+
+        @Test
+        void 코스_파일_임포트_API_401_에러() throws Exception {
+            doThrow(ErrorType.AUTHENTICATION_FAIL.create())
+                    .when(courseApplicationService).importCustomCourseFile(any(), anyString());
+
+            var file = new MockMultipartFile(
+                    "file",
+                    "course.gpx",
+                    "application/gpx+xml",
+                    "test content".getBytes()
+            );
+
+            mockMvc.perform(multipart("/v1/courses/file")
+                            .file(file)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(documentUnauthorized("course-import-file-401", "코스 파일 임포트"));
         }
 
         @Test

--- a/backend/src/test/java/coursepick/coursepick/domain/course/GpxTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/GpxTest.java
@@ -22,7 +22,7 @@ class GpxTest {
         );
         var courseFile = new CourseFile("테스트코스", CourseFileExtension.GPX, inputStream);
 
-        var sut = Gpx.from(courseFile);
+        var sut = Gpx.from(courseFile).gpxList().getFirst();
 
         assertThat(sut.toXmlContent().strip()).containsIgnoringWhitespaces(
                 """

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
@@ -23,10 +23,9 @@ class GpxCourseParserTest {
                 new Coordinate(37.4869515, 126.9230875),
                 new Coordinate(37.4845100, 126.9255380));
 
-        var courses = sut.parse(new CourseFile("테스트코스", CourseFileExtension.GPX, inputStream), ADMIN_USER);
+        var result = sut.parse(new CourseFile("테스트코스", CourseFileExtension.GPX, inputStream), ADMIN_USER);
 
-        assertThat(courses.size()).isEqualTo(1);
-        assertThat(courses).extracting(course -> course.name().value())
-                .contains("테스트코스");
+        assertThat(result.courses().size()).isEqualTo(1);
+        assertThat(result.courses().get(0).name().value()).isEqualTo("test-course");
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/GpxCourseParserTest.java
@@ -28,4 +28,26 @@ class GpxCourseParserTest {
         assertThat(result.courses().size()).isEqualTo(1);
         assertThat(result.courses().get(0).name().value()).isEqualTo("test-course");
     }
+
+    @Test
+    void 이름이_없는_트랙은_무시하고_사유를_남긴다() {
+        var gpxContent = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <gpx version="1.1" creator="Coursepick" xmlns="http://www.topografix.com/GPX/1/1">
+                    <trk>
+                        <trkseg>
+                            <trkpt lat="37.48" lon="126.92"/>
+                            <trkpt lat="37.49" lon="126.93"/>
+                        </trkseg>
+                    </trk>
+                </gpx>
+                """;
+        var inputStream = new java.io.ByteArrayInputStream(gpxContent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        var result = sut.parse(new CourseFile("테스트코스", CourseFileExtension.GPX, inputStream), ADMIN_USER);
+
+        assertThat(result.courses()).isEmpty();
+        assertThat(result.skippedReasons()).hasSize(1);
+        assertThat(result.skippedReasons().get(0)).contains("이름 누락");
+    }
 }

--- a/backend/src/test/java/coursepick/coursepick/infrastructure/KmlCourseParserTest.java
+++ b/backend/src/test/java/coursepick/coursepick/infrastructure/KmlCourseParserTest.java
@@ -40,10 +40,10 @@ class KmlCourseParserTest {
                 """;
         var inputStream = new ByteArrayInputStream(kmlContent.getBytes(StandardCharsets.UTF_8));
 
-        var courses = sut.parse(new CourseFile("테스트코스", CourseFileExtension.KML, inputStream), ADMIN_USER);
+        var result = sut.parse(new CourseFile("테스트코스", CourseFileExtension.KML, inputStream), ADMIN_USER);
 
-        assertThat(courses).hasSize(1);
-        var course = courses.getFirst();
+        assertThat(result.courses()).hasSize(1);
+        var course = result.courses().get(0);
         assertThat(course.name().value()).isEqualTo("테스트코스");
         var firstCoordinate = course.coordinates().getFirst();
         assertThat(firstCoordinate.latitude()).isEqualTo(37.5224898);
@@ -51,7 +51,7 @@ class KmlCourseParserTest {
     }
 
     @Test
-    void 좌표가_없는_Placemark는_무시한다() {
+    void 좌표가_없는_Placemark는_무시하고_사유를_남긴다() {
         var kmlContent = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <kml xmlns="http://www.opengis.net/kml/2.2">
@@ -64,8 +64,10 @@ class KmlCourseParserTest {
                 """;
         var inputStream = new ByteArrayInputStream(kmlContent.getBytes(StandardCharsets.UTF_8));
 
-        var courses = sut.parse(new CourseFile("테스트코스", CourseFileExtension.KML, inputStream), ADMIN_USER);
+        var result = sut.parse(new CourseFile("테스트코스", CourseFileExtension.KML, inputStream), ADMIN_USER);
 
-        assertThat(courses).isEmpty();
+        assertThat(result.courses()).isEmpty();
+        assertThat(result.skippedReasons()).hasSize(1);
+        assertThat(result.skippedReasons().get(0)).contains("좌표 부족");
     }
 }


### PR DESCRIPTION
## 🛠️ 설명
일반 유저도 코스 파일(GPX/KML)을 업로드하여 자신의 커스텀 코스를 등록할 수 있는 기능을 추가했습니다.

### 주요 변경 사항
- 유저 커스텀 코스 파일 등록 API 추가 (`importFilesToCustomCourse`, multipart/form-data)
- `CourseApplicationService.importCustomCourseFile()` 서비스 로직 구현
- `CourseParserFacade.parse()` 시그니처를 `(CourseFile, User)`로 통일했습니다. 
  - 기존 어드민 전용에서 일반 유저까지 확장
  - `AdminWebController`도 admin 유저를 직접 전달하도록 수정했습니다. 
- GPX 파일 업로드 정상 흐름 및 예외 케이스에 대한 통합 테스트 추가했습니다.

## 🔍 리뷰 요청사항
- Kml 통합 테스트도 추가해보려고 했는데, 깔끔한 작성을 위해 KmlTestUtil도 만들다 보니, 오버 엔지니어링인 느낌이 들어서 `GPX_파일로_코스_등록` 까지만 테스트 코드로 넣었습니다. 괜찮은지 확인 부탁드립니다. 
- 아래에 코드래빗이 지적해준 부분이 있는데, 지금은 코스 파싱을 할 때 사용자가 파일을 하나만 올릴 거라고 가정을 해서, `Course course = courseParserFacade.parse(courseFile, user).getFirst();`로 올린 파일들 중 가장 첫번째 것만 가져오도록 되어있습니다. 이 부분 괜찮은지 확인 부탁드립니다. 

## ✅ 체크리스트
- [ ] `application*.yml`에 새 환경변수(`${...}`)를 추가했나요?
  - [ ] 홈서버의 `.env.home-prod` / `.env.home-dev`에도 동일한 키를 추가했나요?
 > 해당사항 없습니다.

## 🔗 관련 이슈
- closes #826 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * GPX/KML 파일 업로드로 사용자 정의 코스를 한 번에 가져오기 가능 (여러 트랙 지원)
  * 업로드 결과로 성공한 코스 목록과 건너뛴 코스 및 사유를 구조화된 응답으로 반환

* **문서**
  * 파일 업로드 API(multipart) 요청/응답 문서가 추가·보완됨

* **테스트**
  * 파일 임포트 및 파싱 예외(중복/이름·좌표 누락) 관련 통합·단위 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->