### PR TITLE
로컬 로깅 변경

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
@@ -25,7 +25,7 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
         long duration = System.currentTimeMillis() - startTime;
 
         if (!request.getRequestURI().startsWith("/actuator")) {
-            log.info("[HTTP] {} | {} | {} | {} | {}", LogContent.http(requestWrapper, response.getStatus(), duration));
+            log.info("[HTTP] ", LogContent.http(requestWrapper, response.getStatus(), duration));
         }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
@@ -16,7 +16,8 @@ import java.io.IOException;
 public class HttpLoggingFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
         ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
 
         long startTime = System.currentTimeMillis();
@@ -24,7 +25,7 @@ public class HttpLoggingFilter extends OncePerRequestFilter {
         long duration = System.currentTimeMillis() - startTime;
 
         if (!request.getRequestURI().startsWith("/actuator")) {
-            log.info("[HTTP]", LogContent.http(requestWrapper, response, duration));
+            log.info("[HTTP] {} | {} | {} | {} | {}", LogContent.http(requestWrapper, response.getStatus(), duration));
         }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/HttpLoggingFilter.java
@@ -16,8 +16,7 @@ import java.io.IOException;
 public class HttpLoggingFilter extends OncePerRequestFilter {
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(request);
 
         long startTime = System.currentTimeMillis();

--- a/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
@@ -1,9 +1,6 @@
 package coursepick.coursepick.logging;
 
-import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import java.nio.charset.StandardCharsets;
@@ -14,12 +11,12 @@ import java.util.regex.Pattern;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.left;
 
-@Slf4j
 public class LogContent {
 
     private static final int MAX_BODY_LENGTH = 500;
     private static final Set<Pattern> SENSITIVE_URI_PATTERNS = Set.of(
-            Pattern.compile("^/admin/login$"));
+            Pattern.compile("^/admin/login$")
+    );
 
 
     public static Object[] http(ContentCachingRequestWrapper request, int status, long duration) {

--- a/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
@@ -2,6 +2,8 @@ package coursepick.coursepick.logging;
 
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
 import java.nio.charset.StandardCharsets;

--- a/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
+++ b/backend/src/main/java/coursepick/coursepick/logging/LogContent.java
@@ -1,6 +1,6 @@
 package coursepick.coursepick.logging;
 
-import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 
@@ -12,36 +12,41 @@ import java.util.regex.Pattern;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.left;
 
+@Slf4j
 public class LogContent {
 
+    private static final int MAX_BODY_LENGTH = 500;
     private static final Set<Pattern> SENSITIVE_URI_PATTERNS = Set.of(
-            Pattern.compile("^/admin/login$")
-    );
+            Pattern.compile("^/admin/login$"));
 
-    public static Object[] http(ContentCachingRequestWrapper request, HttpServletResponse response, long duration) {
-        String method = request.getMethod();
-        String uri = extractUriWithQueryString(request);
-        String headers = extractHeaderString(request);
-        String requestBody = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8).strip();
-        if (isSensitivePath(request)) {
-            requestBody = "[this is sensitive data]";
-        }
-        int status = response.getStatus();
 
+    public static Object[] http(ContentCachingRequestWrapper request, int status, long duration) {
+        boolean sensitive = isSensitivePath(request);
         return new Object[]{
-                kv("method", method),
-                kv("uri", uri),
+                kv("method", request.getMethod()),
+                kv("uri", extractUriWithQueryString(request)),
                 kv("status", status),
+                kv("req_headers", extractHeaderString(request)),
                 kv("duration_ms", duration),
-                kv("req_headers", headers),
-                kv("req_body", left(requestBody, 100))
+                kv("req_body", extractRequestBody(request, sensitive))
         };
+    }
+
+    private static String extractRequestBody(ContentCachingRequestWrapper request, boolean isSensitive) {
+        if (isSensitive) {
+            return "[민감 정보 - 마스킹됨]";
+        }
+        String body = new String(request.getContentAsByteArray(), StandardCharsets.UTF_8).strip();
+        if (body.isEmpty()) {
+            return "(없음)";
+        }
+        return left(body, MAX_BODY_LENGTH) + (body.length() > MAX_BODY_LENGTH ? "...(생략)" : "");
     }
 
     private static boolean isSensitivePath(ContentCachingRequestWrapper request) {
         String uri = request.getRequestURI();
         return SENSITIVE_URI_PATTERNS.stream()
-                .anyMatch(path -> path.matcher(uri).matches());
+                .anyMatch(pattern -> pattern.matcher(uri).matches());
     }
 
     public static Object[] exception(Document document, Exception e) {
@@ -64,7 +69,6 @@ public class LogContent {
     private static String extractUriWithQueryString(ContentCachingRequestWrapper request) {
         String requestURI = request.getRequestURI();
         String queryString = request.getQueryString();
-
         if (queryString != null) {
             requestURI += "?" + queryString;
         }

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -3,6 +3,27 @@
     <springProfile name="local">
         <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
         <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+        <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <timestamp/>
+                    <loggerName/>
+                    <logLevel/>
+                    <mdc/>
+                    <message/>
+                    <arguments>
+                        <includeStructuredArguments>true</includeStructuredArguments>
+                        <includeNonStructuredArguments>false</includeNonStructuredArguments>
+                    </arguments>
+                </providers>
+            </encoder>
+        </appender>
+
+        <logger name="coursepick.coursepick.logging.HttpLoggingFilter" level="INFO" additivity="false">
+            <appender-ref ref="JSON_CONSOLE"/>
+        </logger>
+
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -16,6 +16,7 @@
                         <includeStructuredArguments>true</includeStructuredArguments>
                         <includeNonStructuredArguments>false</includeNonStructuredArguments>
                     </arguments>
+                    <stackTrace/>
                 </providers>
             </encoder>
         </appender>


### PR DESCRIPTION
## 🛠️ 설명
로깅을 json 형식이 나오도록 logback 설정을 교체했습니다.
## 📸 스크린샷 / 동영상
```
[2026-05-20 16:23:22.757] INFO: [HTTP]  
{
  "@timestamp": "2026-05-20T16:23:22.757782+09:00",
  "client_id": "Unknown",
  "duration_ms": 650,
  "level": "INFO",
  "logger_name": "coursepick.coursepick.logging.HttpLoggingFilter",
  "message": "[HTTP] ",
  "method": "GET",
  "req_body": "(없음)",
  "req_headers": "[api-key: OMpqVWAH.UC80wyXTtPwhDgAUdCTx6] [user-agent: PostmanRuntime/7.54.0] [accept: */*] [cache-control: no-cache] [postman-token: 63ec6d4a-d244-450d-94c9-f9f95bf8235f] [host: localhost:8080] [accept-encoding: gzip, deflate, br] [connection: keep-alive] ",
  "status": 200,
  "uri": "/v1/courses?mapLat=37.487031&mapLng=127.101429&scope=3000"
}

```

## 🔍 리뷰 요청사항

## ✅ 체크리스트

- [ ] `application*.yml`에 새 환경변수(`${...}`)를 추가했나요?
  - [ ] 홈서버의 `.env.home-prod` / `.env.home-dev`에도 동일한 키를 추가했나요?




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * HTTP 요청/응답 로깅의 구조 및 출력 형식이 개선되어 상태 코드와 처리 시간 중심으로 로깅됩니다.

* **New Features**
  * 로컬 환경 콘솔에 JSON 형식 로그 출력 기능 추가.

* **Bug Fixes**
  * 민감 경로의 요청 본문을 마스킹하고, 본문 길이 제한·트리밍을 적용하여 개인정보 유출 위험을 감소시켰습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->