### PR TITLE
CoursePickPreferences 즐겨찾기 설정 리팩터링

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/data/favorites/DefaultFavoritesRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/favorites/DefaultFavoritesRepository.kt
@@ -1,6 +1,5 @@
 package io.coursepick.coursepick.data.favorites
 
-import io.coursepick.coursepick.data.preference.FavoritesDataSource
 import io.coursepick.coursepick.domain.favorites.FavoritesRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject

--- a/android/app/src/main/java/io/coursepick/coursepick/data/favorites/DefaultFavoritesRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/favorites/DefaultFavoritesRepository.kt
@@ -1,19 +1,22 @@
 package io.coursepick.coursepick.data.favorites
 
+import io.coursepick.coursepick.data.preference.FavoritesDataSource
 import io.coursepick.coursepick.domain.favorites.FavoritesRepository
-import io.coursepick.coursepick.presentation.preference.CoursePickPreferences
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class DefaultFavoritesRepository
     @Inject
-    constructor() : FavoritesRepository {
-        override fun favoriteCourseIds(): Set<String> = CoursePickPreferences.favoritedCourseIds()
+    constructor(
+        private val favoritesDataSource: FavoritesDataSource,
+    ) : FavoritesRepository {
+        override val favoriteCourseIds: Flow<Set<String>> = favoritesDataSource.courseIds
 
-        override fun addFavoriteCourse(courseId: String) {
-            CoursePickPreferences.addFavorite(courseId)
+        override suspend fun addFavorite(courseId: String) {
+            favoritesDataSource.addFavorite(courseId)
         }
 
-        override fun removeFavoriteCourse(courseId: String) {
-            CoursePickPreferences.removeFavorite(courseId)
+        override suspend fun removeFavorite(courseId: String) {
+            favoritesDataSource.removeFavorite(courseId)
         }
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/data/favorites/FavoritesDataSource.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/favorites/FavoritesDataSource.kt
@@ -1,4 +1,4 @@
-package io.coursepick.coursepick.data.preference
+package io.coursepick.coursepick.data.favorites
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences

--- a/android/app/src/main/java/io/coursepick/coursepick/data/favorites/FavoritesDataSource.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/favorites/FavoritesDataSource.kt
@@ -1,12 +1,15 @@
 package io.coursepick.coursepick.data.favorites
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import io.coursepick.coursepick.di.Favorites
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
@@ -16,9 +19,9 @@ class FavoritesDataSource
         @Favorites private val dataStore: DataStore<Preferences>,
     ) {
         val courseIds: Flow<Set<String>> =
-            dataStore.data.map { preferences: Preferences ->
-                preferences[FAVORITE_COURSE_IDS_KEY] ?: emptySet()
-            }
+            dataStore.data
+                .catch { exception: Throwable -> if (exception is IOException) emit(emptyPreferences()) else throw exception }
+                .map { preferences: Preferences -> preferences[FAVORITE_COURSE_IDS_KEY] ?: emptySet() }
 
         suspend fun addFavorite(courseId: String) {
             dataStore.edit { preferences: MutablePreferences ->

--- a/android/app/src/main/java/io/coursepick/coursepick/data/preference/FavoritesDataSource.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/preference/FavoritesDataSource.kt
@@ -1,0 +1,38 @@
+package io.coursepick.coursepick.data.preference
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import io.coursepick.coursepick.di.Favorites
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class FavoritesDataSource
+    @Inject
+    constructor(
+        @Favorites private val dataStore: DataStore<Preferences>,
+    ) {
+        val courseIds: Flow<Set<String>> =
+            dataStore.data.map { preferences: Preferences ->
+                preferences[FAVORITE_COURSE_IDS_KEY] ?: emptySet()
+            }
+
+        suspend fun addFavorite(courseId: String) {
+            dataStore.edit { preferences: MutablePreferences ->
+                preferences[FAVORITE_COURSE_IDS_KEY] = preferences[FAVORITE_COURSE_IDS_KEY].orEmpty() + courseId
+            }
+        }
+
+        suspend fun removeFavorite(courseId: String) {
+            dataStore.edit { preferences: MutablePreferences ->
+                preferences[FAVORITE_COURSE_IDS_KEY] = preferences[FAVORITE_COURSE_IDS_KEY].orEmpty() - courseId
+            }
+        }
+
+        companion object {
+            private val FAVORITE_COURSE_IDS_KEY: Preferences.Key<Set<String>> = stringSetPreferencesKey("favorited_courses_key")
+        }
+    }

--- a/android/app/src/main/java/io/coursepick/coursepick/di/LocalDataModule.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/di/LocalDataModule.kt
@@ -2,6 +2,7 @@ package io.coursepick.coursepick.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.Module
@@ -19,9 +20,17 @@ annotation class Auth
 @Qualifier
 annotation class Settings
 
+@Qualifier
+annotation class Favorites
+
 private val Context.authDataStore: DataStore<Preferences> by preferencesDataStore(name = "auth")
 
 private val Context.preferencesDataStore: DataStore<Preferences> by preferencesDataStore(name = "preferences")
+
+private val Context.favoritesDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "favorites",
+    produceMigrations = { context: Context -> listOf(SharedPreferencesMigration(context, "${context.packageName}_preferences")) },
+)
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -44,4 +53,11 @@ object LocalDataModule {
     fun providePreferencesDataStore(
         @ApplicationContext context: Context,
     ): DataStore<Preferences> = context.preferencesDataStore
+
+    @Provides
+    @Singleton
+    @Favorites
+    fun provideFavoriteCourseDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = context.favoritesDataStore
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/di/LocalDataModule.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/di/LocalDataModule.kt
@@ -29,7 +29,15 @@ private val Context.preferencesDataStore: DataStore<Preferences> by preferencesD
 
 private val Context.favoritesDataStore: DataStore<Preferences> by preferencesDataStore(
     name = "favorites",
-    produceMigrations = { context: Context -> listOf(SharedPreferencesMigration(context, "${context.packageName}_preferences")) },
+    produceMigrations = { context: Context ->
+        listOf(
+            SharedPreferencesMigration(
+                context = context,
+                sharedPreferencesName = "${context.packageName}_preferences",
+                keysToMigrate = setOf("favorited_courses_key"),
+            ),
+        )
+    },
 )
 
 @Module

--- a/android/app/src/main/java/io/coursepick/coursepick/domain/favorites/FavoritesRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/domain/favorites/FavoritesRepository.kt
@@ -1,9 +1,11 @@
 package io.coursepick.coursepick.domain.favorites
 
+import kotlinx.coroutines.flow.Flow
+
 interface FavoritesRepository {
-    fun favoriteCourseIds(): Set<String>
+    val favoriteCourseIds: Flow<Set<String>>
 
-    fun addFavoriteCourse(courseId: String)
+    suspend fun addFavorite(courseId: String)
 
-    fun removeFavoriteCourse(courseId: String)
+    suspend fun removeFavorite(courseId: String)
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -30,8 +30,6 @@ import io.coursepick.coursepick.presentation.ui.MutableSingleLiveData
 import io.coursepick.coursepick.presentation.ui.SingleLiveData
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -90,11 +88,15 @@ class CoursesViewModel
         private val _event: MutableSingleLiveData<CoursesUiEvent> = MutableSingleLiveData()
         val event: SingleLiveData<CoursesUiEvent> get() = _event
 
+        private val favoriteCourseIds: StateFlow<Set<String>> =
+            favoritesRepository.favoriteCourseIds.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = emptySet(),
+            )
+
         var mapCoordinate: Coordinate? = null
             private set
-
-        private var writeFavoriteJob: Job? = null
-        private val pendingFavoriteWrites: MutableMap<String, Boolean> = mutableMapOf()
 
         private var page: Int = 0
         private var hasNext: Boolean = false
@@ -107,6 +109,7 @@ class CoursesViewModel
 
         init {
             checkNetwork()
+            collectFavorites()
         }
 
         fun selectExternalCourse(courseItem: CourseItem) {
@@ -156,6 +159,26 @@ class CoursesViewModel
             }
         }
 
+        private fun collectFavorites() {
+            viewModelScope.launch {
+                favoriteCourseIds.collect { courseIds: Set<String> ->
+                    _state.value =
+                        state.value?.copy(
+                            courses =
+                                state.value
+                                    ?.courses
+                                    ?.map { item: CourseListItem ->
+                                        if (item is CourseListItem.Course) {
+                                            item.copy(item = item.item.copy(favorite = courseIds.contains(item.item.id)))
+                                        } else {
+                                            item
+                                        }
+                                    }.orEmpty(),
+                        )
+                }
+            }
+        }
+
         fun switchContent(content: CoursesContent) {
             _content.value = content
         }
@@ -181,47 +204,13 @@ class CoursesViewModel
         }
 
         fun toggleFavorite(toggledCourse: CourseItem) {
-            pendingFavoriteWrites[toggledCourse.id] = !toggledCourse.favorite
-
-            state.value?.courses?.let { courses: List<CourseListItem> ->
-                val newCourses =
-                    courses.map { item: CourseListItem ->
-                        when (item) {
-                            is CourseListItem.Course -> {
-                                if (item.item.id == toggledCourse.id) {
-                                    CourseListItem.Course(item.item.copy(favorite = !item.item.favorite))
-                                } else {
-                                    item
-                                }
-                            }
-
-                            is CourseListItem.Loading -> {
-                                item
-                            }
-                        }
-                    }
-                _state.value = state.value?.copy(courses = newCourses)
-            }
-
-            updateFavorites()
-        }
-
-        private fun updateFavorites() {
-            writeFavoriteJob?.cancel()
-
-            writeFavoriteJob =
-                viewModelScope.launch {
-                    delay(DEBOUNCE_LIMIT_TIME)
-
-                    pendingFavoriteWrites.toMap().forEach { (courseId: String, favorite: Boolean) ->
-                        if (favorite) {
-                            favoritesRepository.addFavoriteCourse(courseId)
-                        } else {
-                            favoritesRepository.removeFavoriteCourse(courseId)
-                        }
-                    }
-                    pendingFavoriteWrites.clear()
+            viewModelScope.launch {
+                if (toggledCourse.favorite) {
+                    favoritesRepository.removeFavorite(toggledCourse.id)
+                } else {
+                    favoritesRepository.addFavorite(toggledCourse.id)
                 }
+            }
         }
 
         fun fetchCourses(
@@ -261,8 +250,6 @@ class CoursesViewModel
                 }.onSuccess { coursesPage: CoursesPage ->
                     Logger.log(Logger.Event.Success("fetch_courses_new"))
 
-                    val favoritedCourseIds: Set<String> = favoritesRepository.favoriteCourseIds()
-
                     val courseItems: List<CourseItem> =
                         coursesPage.courses
                             .sortedBy(Course::distance)
@@ -270,7 +257,7 @@ class CoursesViewModel
                                 CourseItem(
                                     course = course,
                                     selected = index == 0,
-                                    favorite = favoritedCourseIds.contains(course.id),
+                                    favorite = favoriteCourseIds.value.contains(course.id),
                                 )
                             }
 
@@ -349,8 +336,6 @@ class CoursesViewModel
                 }.onSuccess { coursesPage: CoursesPage ->
                     Logger.log(Logger.Event.Success("fetch_courses_next"))
 
-                    val favoritedCourseIds: Set<String> = favoritesRepository.favoriteCourseIds()
-
                     val existingCoursesWithoutLoading =
                         (state.value?.courses ?: emptyList())
                             .filterNot { courseListItem: CourseListItem -> courseListItem is CourseListItem.Loading }
@@ -361,7 +346,7 @@ class CoursesViewModel
                                 CourseItem(
                                     course = course,
                                     selected = false,
-                                    favorite = favoritedCourseIds.contains(course.id),
+                                    favorite = favoriteCourseIds.value.contains(course.id),
                                 ),
                             )
                         }
@@ -401,8 +386,7 @@ class CoursesViewModel
                     status = UiStatus.Loading,
                 )
 
-            val favoritedCourseIds: Set<String> = favoritesRepository.favoriteCourseIds()
-            if (favoritedCourseIds.isEmpty()) {
+            if (favoriteCourseIds.value.isEmpty()) {
                 _state.value =
                     state.value?.copy(
                         courses = emptyList(),
@@ -413,7 +397,7 @@ class CoursesViewModel
 
             viewModelScope.launch {
                 runCatching {
-                    courseRepository.courses(favoritedCourseIds.toList())
+                    courseRepository.courses(favoriteCourseIds.value.toList())
                 }.onSuccess { courses: List<Course> ->
                     val courseItems: List<CourseItem> =
                         courses.map { course: Course ->
@@ -746,8 +730,4 @@ class CoursesViewModel
                     courseListItem
                 }
             }
-
-        companion object {
-            private const val DEBOUNCE_LIMIT_TIME = 500L
-        }
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/preference/CoursePickPreferences.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/preference/CoursePickPreferences.kt
@@ -8,27 +8,11 @@ import io.coursepick.coursepick.R
 
 object CoursePickPreferences {
     private lateinit var preferences: SharedPreferences
-    private lateinit var favoritedCoursesKey: String
     private lateinit var doNotShowNoticesKey: String
 
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        favoritedCoursesKey = context.getString(R.string.favorited_courses_key)
         doNotShowNoticesKey = context.getString(R.string.do_not_show_notices_key)
-    }
-
-    fun favoritedCourseIds(): Set<String> = preferences.getStringSet(favoritedCoursesKey, emptySet()) ?: emptySet()
-
-    fun addFavorite(courseId: String) {
-        preferences.edit {
-            putStringSet(favoritedCoursesKey, favoritedCourseIds() + courseId)
-        }
-    }
-
-    fun removeFavorite(courseId: String) {
-        preferences.edit {
-            putStringSet(favoritedCoursesKey, favoritedCourseIds() - courseId)
-        }
     }
 
     fun shouldShowNotice(id: String): Boolean {

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeFavoritesRepository.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeFavoritesRepository.kt
@@ -1,17 +1,19 @@
 package io.coursepick.coursepick.presentation.fixtures
 
 import io.coursepick.coursepick.domain.favorites.FavoritesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class FakeFavoritesRepository : FavoritesRepository {
-    private val favoriteCourseIds: MutableSet<String> = mutableSetOf()
+    private val _favoriteCourseIds = MutableStateFlow<Set<String>>(emptySet())
+    override val favoriteCourseIds: Flow<Set<String>> = _favoriteCourseIds.asStateFlow()
 
-    override fun favoriteCourseIds(): Set<String> = favoriteCourseIds
-
-    override fun addFavoriteCourse(courseId: String) {
-        favoriteCourseIds.add(courseId)
+    override suspend fun addFavorite(courseId: String) {
+        _favoriteCourseIds.value += courseId
     }
 
-    override fun removeFavoriteCourse(courseId: String) {
-        favoriteCourseIds.remove(courseId)
+    override suspend fun removeFavorite(courseId: String) {
+        _favoriteCourseIds.value -= courseId
     }
 }


### PR DESCRIPTION
## 🛠️ 설명
- `CoursePickPreferences` 중 즐겨찾기 관련 설정이 데이터 레이어로 이동됐습니다.
- 기존 즐겨찾기 데이터가 유실되지 않도록 즐겨찾기 `DataStore`에 `SharedPreferencesMigration`을 적용했습니다.


## 🔗 관련 이슈
- closes #919


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 즐겨찾기 시스템의 아키텍처가 개선되어 즐겨찾기 추가, 제거, 조회 시 변경사항이 더욱 빠르고 반응적으로 반영됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->