### PR TITLE
로그인 응답에 userId 추가

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/domain/user/Authentication.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/user/Authentication.java
@@ -12,13 +12,27 @@ import java.util.Date;
 import static coursepick.coursepick.application.exception.ErrorType.AUTHENTICATION_FAIL;
 
 public record Authentication(
+        String userId,
         String accessToken
 ) {
     private static final Duration TOKEN_VALIDITY = Duration.ofDays(30);
 
     public static Authentication auth(SecretKey key, User user) {
         String accessToken = createAccessToken(key, user);
-        return new Authentication(accessToken);
+        return new Authentication(user.id(), accessToken);
+    }
+
+    public static Authentication parse(SecretKey key, String accessToken) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(accessToken)
+                    .getPayload();
+            return new Authentication(claims.getSubject(), accessToken);
+        } catch (JwtException e) {
+            throw AUTHENTICATION_FAIL.create();
+        }
     }
 
     private static String createAccessToken(SecretKey key, User user) {
@@ -31,18 +45,5 @@ public record Authentication(
                 .expiration(Date.from(expiration))
                 .signWith(key)
                 .compact();
-    }
-
-    public String validateAndGetUserId(SecretKey key) {
-        try {
-            Claims claims = Jwts.parser()
-                    .verifyWith(key)
-                    .build()
-                    .parseSignedClaims(accessToken)
-                    .getPayload();
-            return claims.getSubject();
-        } catch (JwtException e) {
-            throw AUTHENTICATION_FAIL.create();
-        }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/UserV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/UserV1WebController.java
@@ -22,6 +22,6 @@ public class UserV1WebController implements UserWebApi {
     @PostMapping("/login/kakao")
     public SignWebResponse sign(@RequestBody SignWebRequest request) {
         Authentication authentication = userApplicationService.registerOrLoginAndGetAuthentication(request.accessToken());
-        return new SignWebResponse(authentication.accessToken());
+        return new SignWebResponse(authentication.userId(), authentication.accessToken());
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/SignWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/SignWebResponse.java
@@ -3,6 +3,8 @@ package coursepick.coursepick.presentation.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record SignWebResponse(
+        @Schema(description = "사용자 ID", example = "65f0c2a7e1b1c2a3b4c5d6e7")
+        String userId,
         @Schema(description = "런세권 엑세스토큰", example = "123456789")
         String accessToken
 ) {

--- a/backend/src/main/java/coursepick/coursepick/security/LoginInterceptor.java
+++ b/backend/src/main/java/coursepick/coursepick/security/LoginInterceptor.java
@@ -43,9 +43,8 @@ public class LoginInterceptor implements HandlerInterceptor {
 
         String token = authorizationHeader.substring("Bearer ".length());
 
-        Authentication authentication = new Authentication(token);
-        String userId = authentication.validateAndGetUserId(secretKey);
-        request.setAttribute(AUTH_USER_ID, userId);
+        Authentication authentication = Authentication.parse(secretKey, token);
+        request.setAttribute(AUTH_USER_ID, authentication.userId());
         return true;
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/domain/user/AuthenticationTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/user/AuthenticationTest.java
@@ -76,8 +76,8 @@ class AuthenticationTest {
     void 토큰에서_사용자_ID를_추출한다() {
         var authentication = Authentication.auth(TEST_KEY, TEST_USER);
 
-        var userId = authentication.validateAndGetUserId(TEST_KEY);
+        var parsed = Authentication.parse(TEST_KEY, authentication.accessToken());
 
-        assertThat(userId).isEqualTo(TEST_USER.id());
+        assertThat(parsed.userId()).isEqualTo(TEST_USER.id());
     }
 }


### PR DESCRIPTION
## 🛠️ 설명
- 코스 상세 화면에서 "내 리뷰"와 "다른 사람의 리뷰"를 구별할 수 있도록, 로그인 응답(`POST /v1/login/kakao`)에 `userId` 필드를 추가했습니다.
  - 안드로이드 쪽에서 로그인 시 받은 `userId`를 저장해두고, 리뷰의 `authorId`와 비교해 "내 리뷰" 여부를 판단할 수 있도록 했습니다.
  - 비로그인 사용자는 저장된 `userId`가 없으므로 자연스럽게 "내 리뷰" 표시가 꺼집니다.
- `Authentication` record가 `(userId, accessToken)` 쌍을 항상 보장하도록 정리했습니다.
  - 인스턴스 메서드 `validateAndGetUserId(key)` → 정적 팩토리 `Authentication.parse(key, token)`로 변경했습니다.
- `LoginInterceptor`에서도 새로운 `parse`를 사용하도록 수정했습니다.

## 📸 스크린샷 / 동영상
응답 예시:
수정 전
```json
{
  "accessToken": "eyJhbGciOiJIUzI1NiJ9..."
}
```
적용 후
```json
{
  "userId": "65f0c2a7e1b1c2a3b4c5d6e7",
  "accessToken": "eyJhbGciOiJIUzI1NiJ9..."
}
```


## 🔍 리뷰 요청사항
- `Authentication`을 `(userId, accessToken)` 쌍으로 묶고 `parse` 정적 팩토리로 통일했는데 괜찮은지 확인 부탁드립니다!

## ✅ 체크리스트

- [ ] `application*.yml`에 새 환경변수(`${...}`)를 추가했나요?
  - [ ] 홈서버의 `.env.home-prod` / `.env.home-dev`에도 동일한 키를 추가했나요?


## 🔗 관련 이슈

- closes #918