### PR TITLE
공지가 표시되지 않는 현상 수정

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/data/notice/DefaultNoticeRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/notice/DefaultNoticeRepository.kt
@@ -11,7 +11,7 @@ class DefaultNoticeRepository
         private val dataSource: NoticeDataSource,
     ) : NoticeRepository {
         override suspend fun notices(): List<Notice> {
-            val activeNotices: List<NoticeDto> = service.notices()
+            val activeNotices: List<NoticeDto> = service.notices().notices
 
             val activeNoticeIds: Set<String> = activeNotices.map(NoticeDto::id).toSet()
             dataSource.removeStaleNoticeIds(activeNoticeIds)

--- a/android/app/src/main/java/io/coursepick/coursepick/data/notice/NoticeDto.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/notice/NoticeDto.kt
@@ -1,7 +1,6 @@
 package io.coursepick.coursepick.data.notice
 
 import io.coursepick.coursepick.domain.notice.Notice
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,7 +9,7 @@ data class NoticeDto(
     private val imageUrl: String,
     private val title: String,
     private val description: String,
-    @SerialName("url") private val targetUrl: String,
+    private val targetUrl: String? = null,
 ) {
     fun toNotice(): Notice =
         Notice(

--- a/android/app/src/main/java/io/coursepick/coursepick/data/notice/NoticeResponseDto.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/notice/NoticeResponseDto.kt
@@ -1,0 +1,8 @@
+package io.coursepick.coursepick.data.notice
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NoticeResponseDto(
+    val notices: List<NoticeDto>,
+)

--- a/android/app/src/main/java/io/coursepick/coursepick/data/notice/NoticeService.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/notice/NoticeService.kt
@@ -4,5 +4,5 @@ import retrofit2.http.GET
 
 interface NoticeService {
     @GET("notices")
-    suspend fun notices(): List<NoticeDto>
+    suspend fun notices(): NoticeResponseDto
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/domain/notice/Notice.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/domain/notice/Notice.kt
@@ -7,5 +7,5 @@ data class Notice(
     val imageUrl: String,
     val title: String,
     val description: String,
-    val targetUrl: String,
+    val targetUrl: String?,
 ) : Serializable

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/notice/NoticeDialog.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/notice/NoticeDialog.kt
@@ -38,25 +38,25 @@ fun NoticeDialog(
 ) {
     Dialog(onDismissRequest = { onDismissRequest(notice.id) }) {
         Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(color = colorResource(R.color.background_primary))
-                    .padding(top = 20.dp, start = 20.dp, end = 20.dp),
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(color = colorResource(R.color.background_primary))
+                .padding(top = 20.dp, start = 20.dp, end = 20.dp),
         ) {
-            Column(modifier = Modifier.clickable { onOpenUrl(notice.targetUrl) }) {
+            Column(
+                Modifier.clickable(notice.targetUrl != null) {
+                    notice.targetUrl?.let { url: String -> onOpenUrl(url) }
+                },
+            ) {
                 AsyncImage(
                     model = notice.imageUrl,
                     contentDescription = null,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .height(200.dp),
-                    contentScale = ContentScale.Crop,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxWidth(),
                 )
 
-                Spacer(modifier = Modifier.height(20.dp))
+                Spacer(Modifier.height(20.dp))
 
                 Text(
                     text = notice.title,
@@ -67,7 +67,7 @@ fun NoticeDialog(
                     modifier = Modifier.fillMaxWidth(),
                 )
 
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(Modifier.height(12.dp))
 
                 Text(
                     text = notice.description,
@@ -78,13 +78,12 @@ fun NoticeDialog(
                 )
             }
 
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(Modifier.height(12.dp))
 
             Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(IntrinsicSize.Min),
+                Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Min),
             ) {
                 TextButton(
                     onClick = {
@@ -113,7 +112,7 @@ fun NoticeDialog(
     }
 }
 
-@PreviewLightDark()
+@PreviewLightDark
 @Composable
 private fun NoticeDialogPreview() {
     CoursePickTheme {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/notice/NoticeDialog.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/notice/NoticeDialog.kt
@@ -45,7 +45,7 @@ fun NoticeDialog(
                 .padding(top = 20.dp, start = 20.dp, end = 20.dp),
         ) {
             Column(
-                Modifier.clickable(notice.targetUrl != null) {
+                Modifier.clickable(enabled = !notice.targetUrl.isNullOrBlank()) {
                     notice.targetUrl?.let { url: String -> onOpenUrl(url) }
                 },
             ) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -135,7 +135,7 @@
     <string name="selected_route_finder_application_confirm_button">확인</string>
 
     <!--  공지 다이얼로그  -->
-    <string name="notice_dialog_do_not_show_again_button">다시 보지 않음</string>
+    <string name="notice_dialog_do_not_show_again_button">다시 보지 않기</string>
     <string name="notice_dialog_close_button">닫기</string>
     <string name="notice_open_link_failure_message">링크를 열지 못했습니다.</string>
 


### PR DESCRIPTION
## 🛠️ 설명
- 백엔드가 내려주는 실제 공지 응답과 안드로이드가 기대하는 응답의 형식이 달라 공지가 표시되지 않는 현상이 수정됐습니다.
- 공지 `targetUrl`의 기본값이 `null`로 변경됐습니다.
- 공지 이미지의 `ContentScale`을 `Crop`에서 `Fit`으로 변경했습니다.


## 🔗 관련 이슈
- closes #927


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 링크가 없는 공지사항의 배너 클릭 이벤트 비활성화 처리 추가
  * 공지사항 배너 이미지 표시 방식 개선 (화면 너비 맞춤 및 스케일링 방식 변경)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->