### PR TITLE
api 예외 문서 명시

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -102,7 +102,7 @@ public enum ErrorType {
             IllegalStateException::new
     ),
     INVALID_REVIEW_RATING(
-            "리뷰 평점은 1이상 5이하여야 합니다. 입력값=%d",
+            "리뷰 평점은 1이상 5이하여야 합니다. 입력값=%s",
             IllegalArgumentException::new
     );
 
@@ -116,6 +116,10 @@ public enum ErrorType {
 
     public RuntimeException create(Object... messageArgs) {
         return exceptionConstructor.apply(message(messageArgs));
+    }
+
+    public Class<? extends RuntimeException> getExceptionClass() {
+        return create("N", "N", "N").getClass();
     }
 
     public String message(Object... messageArgs) {

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -118,11 +118,24 @@ public enum ErrorType {
         return exceptionConstructor.apply(message(messageArgs));
     }
 
-    public Class<? extends RuntimeException> getExceptionClass() {
-        return create("N", "N", "N").getClass();
-    }
-
     public String message(Object... messageArgs) {
         return this.message.formatted(messageArgs);
+    }
+
+    /**
+     * API 문서(Swagger) 생성 시, 발생 가능한 에러의 HTTP 상태 코드(400, 404 등)를
+     * 매핑하기 위해 예외 클래스 타입을 가져오는 용도로 사용됩니다.
+     * ({@link coursepick.coursepick.presentation.api.OpenApiConfig} 참조)
+     */
+    public Class<? extends RuntimeException> getExceptionClass() {
+        return exceptionConstructor.apply("").getClass();
+    }
+
+    /**
+     * API 문서(Swagger)에 표시할 에러 메시지를 생성합니다.
+     * %s 파라미터를 "{입력값}"으로 치환하여 사람이 읽기 쉬운 형태로 변환합니다.
+     */
+    public String getMessageForApiDoc() {
+        return this.message.replace("%s", "{입력값}");
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/ApiErrorExceptionsExample.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/ApiErrorExceptionsExample.java
@@ -1,0 +1,14 @@
+package coursepick.coursepick.presentation.api;
+
+import coursepick.coursepick.application.exception.ErrorType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorExceptionsExample {
+    ErrorType[] value() default {};
+}

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/CourseWebApi.java
@@ -1,5 +1,6 @@
 package coursepick.coursepick.presentation.api;
 
+import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.presentation.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,7 +9,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -17,20 +17,12 @@ import java.util.List;
 @Tag(name = "러닝 코스 (Course)")
 public interface CourseWebApi {
 
-    @Operation(summary = "좌표 근처 코스 전체 조회")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "위도가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_LATITUDE_RANGE"
-                    ),
-                    @ExampleObject(
-                            name = "경도가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_LONGITUDE_RANGE"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.INVALID_LATITUDE_RANGE,
+            ErrorType.INVALID_LONGITUDE_RANGE
     })
+    @Operation(summary = "좌표 근처 코스 전체 조회")
+    @ApiResponse(responseCode = "200")
     CoursesWebResponse findNearbyCourses(
             @Parameter(description = "지도 중심의 위도(-90 ~ 90)", example = "37.5165004", required = true) double mapLatitude,
             @Parameter(description = "지도 중심의 경도(-180 ~ 180)", example = "127.1040109", required = true) double mapLongitude,
@@ -42,156 +34,76 @@ public interface CourseWebApi {
             @Parameter(description = "페이지 번호", example = "1") Integer page
     );
 
-    @Operation(summary = "좌표에서 가장 가까운 코스 위 좌표 조회")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "위도가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_LATITUDE_RANGE"
-                    ),
-                    @ExampleObject(
-                            name = "경도가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_LONGITUDE_RANGE"
-                    ),
-            })),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.INVALID_LATITUDE_RANGE,
+            ErrorType.INVALID_LONGITUDE_RANGE,
+            ErrorType.NOT_EXIST_COURSE
     })
+    @Operation(summary = "좌표에서 가장 가까운 코스 위 좌표 조회")
+    @ApiResponse(responseCode = "200")
     CoordinateWebResponse findClosestCoordinate(
             @Parameter(description = "코스 ID", example = "689c3143182cecc6353cca7b", required = true) String id,
             @Parameter(description = "사용자 위도(-90 ~ 90)", example = "37.5165004", required = true) double latitude,
             @Parameter(description = "사용자 경도(-180 ~ 180)", example = "127.1040109", required = true) double longitude
     );
 
-    @Operation(summary = "특정 코스까지의 길찾기")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "위도가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_LATITUDE_RANGE"
-                    ),
-                    @ExampleObject(
-                            name = "경도가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_LONGITUDE_RANGE"
-                    ),
-            })),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.INVALID_LATITUDE_RANGE,
+            ErrorType.INVALID_LONGITUDE_RANGE,
+            ErrorType.NOT_EXIST_COURSE
     })
+    @Operation(summary = "특정 코스까지의 길찾기")
+    @ApiResponse(responseCode = "200")
     List<CoordinateWebResponse> routeToCourse(
             @Parameter(description = "코스 ID", example = "689c3143182cecc6353cca7b", required = true) String id,
             @Parameter(description = "사용자 위도(-90 ~ 90)", example = "37.5165004", required = true) double latitude,
             @Parameter(description = "사용자 경도(-180 ~ 180)", example = "127.1040109", required = true) double longitude
     );
 
-    @Operation(summary = "코스 상세 조회 (리뷰 포함)")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.NOT_EXIST_COURSE
     })
+    @Operation(summary = "코스 상세 조회 (리뷰 포함)")
+    @ApiResponse(responseCode = "200")
     CourseDetailWebResponse findCourseDetail(
             @Parameter(description = "코스 ID", example = "689c3143182cecc6353cca7b", required = true) String id
     );
 
-    @Operation(summary = "코스 리뷰 작성", security = {@SecurityRequirement(name = "BearerAuth")})
-    @ApiResponses({
-            @ApiResponse(responseCode = "201"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "리뷰 내용 길이가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_REVIEW_CONTENT_LENGTH"
-                    )
-            })),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "인증에 실패한 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.INVALID_REVIEW_CONTENT_LENGTH,
+            ErrorType.INVALID_REVIEW_RATING,
+            ErrorType.NOT_EXIST_COURSE,
+            ErrorType.AUTHENTICATION_FAIL
     })
+    @Operation(summary = "코스 리뷰 작성", security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponse(responseCode = "201")
     void addReview(
             @Parameter(description = "코스 ID", example = "689c3143182cecc6353cca7b", required = true) String id,
             @Parameter(hidden = true) String userId,
             CreateReviewWebRequest request
     );
 
-    @Operation(summary = "코스 리뷰 삭제", security = {@SecurityRequirement(name = "BearerAuth")})
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "리뷰 삭제 완료"),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "인증에 실패한 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    ),
-                    @ExampleObject(
-                            name = "본인 리뷰가 아닌 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    ),
-                    @ExampleObject(
-                            name = "리뷰가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_REVIEW"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.AUTHENTICATION_FAIL,
+            ErrorType.NOT_EXIST_COURSE,
+            ErrorType.NOT_EXIST_REVIEW
     })
+    @Operation(summary = "코스 리뷰 삭제", security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponse(responseCode = "200", description = "리뷰 삭제 완료")
     void deleteReview(
             @Parameter(description = "코스 ID", required = true) String courseId,
             @Parameter(description = "삭제할 리뷰 ID", required = true) String reviewId,
             @Parameter(hidden = true) String userId
     );
 
-    @Operation(summary = "리뷰 신고", security = {@SecurityRequirement(name = "BearerAuth")})
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "리뷰 신고 완료"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "이미 신고한 리뷰인 경우",
-                            ref = "#/components/examples/ALREADY_REPORTED_REVIEW"
-                    )
-            })),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "인증에 실패한 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    ),
-                    @ExampleObject(
-                            name = "리뷰가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_REVIEW"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.ALREADY_REPORTED_REVIEW,
+            ErrorType.AUTHENTICATION_FAIL,
+            ErrorType.NOT_EXIST_COURSE,
+            ErrorType.NOT_EXIST_REVIEW
     })
+    @Operation(summary = "리뷰 신고", security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponse(responseCode = "200", description = "리뷰 신고 완료")
     void reportCourseReview(
             @Parameter(description = "신고할 리뷰의 코스 ID", required = true) String courseId,
             @Parameter(description = "신고할 리뷰 ID", required = true) String reviewId,
@@ -210,32 +122,14 @@ public interface CourseWebApi {
             List<String> coursesId
     );
 
-    @Operation(summary = "유저 커스텀 코스 등록", security = {@SecurityRequirement(name = "BearerAuth")})
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "코스 등록 성공"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "이름 길이가 범위 외인 경우",
-                            ref = "#/components/examples/INVALID_NAME_LENGTH"
-                    ),
-                    @ExampleObject(
-                            name = "좌표 개수가 부족한 경우",
-                            ref = "#/components/examples/INVALID_COORDINATE_COUNT"
-                    )
-            })),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "인증에 실패한 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
-            @ApiResponse(responseCode = "409", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "이미 존재하는 코스 이름인 경우",
-                            ref = "#/components/examples/DUPLICATED_COURSE_NAME"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.INVALID_NAME_LENGTH,
+            ErrorType.INVALID_COORDINATE_COUNT,
+            ErrorType.AUTHENTICATION_FAIL,
+            ErrorType.DUPLICATED_COURSE_NAME
     })
+    @Operation(summary = "유저 커스텀 코스 등록", security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponse(responseCode = "200", description = "코스 등록 성공")
     String addCustomCourses(
             @RequestBody(
                     description = "커스텀 코스 생성 요청 데이터",
@@ -253,55 +147,30 @@ public interface CourseWebApi {
             String userId
     );
 
-    @Operation(summary = "코스 생성 시 직전 포인트와 새 포인트 사이의 경로 및 거리 조회 (첫 점인 경우 origin과 destination을 동일하게 전송)")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "좌표 개수가 부족한 경우",
-                            ref = "#/components/examples/INVALID_COORDINATE_COUNT"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.INVALID_COORDINATE_COUNT
     })
+    @Operation(summary = "코스 생성 시 직전 포인트와 새 포인트 사이의 경로 및 거리 조회 (첫 점인 경우 origin과 destination을 동일하게 전송)")
+    @ApiResponse(responseCode = "200")
     DraftRouteWebResponse findDraftRoute(FindDraftRouteWebRequest request);
 
-    @Operation(summary = "코스 신고", security = {@SecurityRequirement(name = "BearerAuth")})
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "코스 신고 완료"),
-            @ApiResponse(responseCode = "400", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "이미 신고한 코스인 경우",
-                            ref = "#/components/examples/ALREADY_REPORTED_COURSE"
-                    )
-            })),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "인증에 실패한 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
-            @ApiResponse(responseCode = "404", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "코스가 존재하지 않는 경우",
-                            ref = "#/components/examples/NOT_EXIST_COURSE"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.ALREADY_REPORTED_COURSE,
+            ErrorType.AUTHENTICATION_FAIL,
+            ErrorType.NOT_EXIST_COURSE
     })
+    @Operation(summary = "코스 신고", security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponse(responseCode = "200", description = "코스 신고 완료")
     void reportCourse(
             @Parameter(description = "신고할 코스 ID", required = true) String id,
             @Parameter(hidden = true) String userId
     );
 
-    @Operation(summary = "나의 코스 조회(생성순)", security = {@SecurityRequirement(name = "BearerAuth")})
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "인증에 실패한 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.AUTHENTICATION_FAIL
     })
+    @Operation(summary = "나의 코스 조회(생성순)", security = {@SecurityRequirement(name = "BearerAuth")})
+    @ApiResponse(responseCode = "200")
     CoursesWebResponse findCustomCourse(
             @Parameter(description = "사용자 위치의 위도(-90 ~ 90)", example = "38.5165004") Double userLatitude,
             @Parameter(description = "사용자 위치의 경도(-180 ~ 180)", example = "126.1040109") Double userLongitude,

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/NoticeWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/NoticeWebApi.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "노티스 (Notice)")
 public interface NoticeWebApi {
 
+    @ApiErrorExceptionsExample()
     @Operation(summary = "공지사항 목록 조회", description = "사용자에게 필요한 공지사항 목록을 조회하는 API입니다.")
     @ApiResponse(responseCode = "200")
     NoticesWebResponse getNotices();

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
@@ -1,27 +1,23 @@
 package coursepick.coursepick.presentation.api;
 
+import coursepick.coursepick.application.exception.ErrorType;
+import coursepick.coursepick.application.exception.QueryTimeoutException;
+import coursepick.coursepick.application.exception.UnauthorizedException;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
-
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.AnnotatedElementUtils;
-import lombok.extern.slf4j.Slf4j;
-
-import coursepick.coursepick.application.exception.ErrorType;
-import io.swagger.v3.oas.models.responses.ApiResponse;
-import io.swagger.v3.oas.models.responses.ApiResponses;
-
-import coursepick.coursepick.application.exception.QueryTimeoutException;
-import coursepick.coursepick.application.exception.UnauthorizedException;
 
 import java.lang.reflect.Method;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -31,13 +27,7 @@ import java.util.stream.Collectors;
 @Profile("!prod")
 @Slf4j
 @OpenAPIDefinition(info = @Info(title = "코스픽 API"))
-@SecurityScheme(
-        name = "BearerAuth",
-        type = SecuritySchemeType.HTTP,
-        scheme = "bearer",
-        bearerFormat = "JWT",
-        description = "JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다."
-)
+@SecurityScheme(name = "BearerAuth", type = SecuritySchemeType.HTTP, scheme = "bearer", bearerFormat = "JWT", description = "JWT 토큰을 입력하세요. 'Bearer ' 접두사는 자동으로 추가됩니다.")
 @Configuration
 public class OpenApiConfig {
 
@@ -58,15 +48,17 @@ public class OpenApiConfig {
                 try {
                     Method interfaceMethod = CourseWebApi.class.getMethod(
                             handlerMethod.getMethod().getName(), handlerMethod.getMethod().getParameterTypes());
-                    apiErrorExceptionsExample = AnnotatedElementUtils.findMergedAnnotation(interfaceMethod, ApiErrorExceptionsExample.class);
-                    log.info("Found on interface: {}", (apiErrorExceptionsExample != null));
-                } catch (Exception e) {}
+                    apiErrorExceptionsExample = AnnotatedElementUtils.findMergedAnnotation(interfaceMethod,
+                            ApiErrorExceptionsExample.class);
+                } catch (Exception e) {
+                }
             }
             if (apiErrorExceptionsExample != null) {
                 generateErrorResponseExample(operation, apiErrorExceptionsExample.value());
             }
 
-            if ((operation.getParameters() != null && !operation.getParameters().isEmpty()) || operation.getRequestBody() != null) {
+            if ((operation.getParameters() != null && !operation.getParameters().isEmpty())
+                    || operation.getRequestBody() != null) {
                 addDefaultValidationError(operation);
             }
 
@@ -93,11 +85,17 @@ public class OpenApiConfig {
 
     private String getStatusCode(ErrorType errorType) {
         Class<? extends RuntimeException> exceptionClass = errorType.getExceptionClass();
-        if (IllegalArgumentException.class.isAssignableFrom(exceptionClass)) return "400";
-        if (NoSuchElementException.class.isAssignableFrom(exceptionClass)) return "404";
-        if (SecurityException.class.isAssignableFrom(exceptionClass) || UnauthorizedException.class.isAssignableFrom(exceptionClass)) return "401";
-        if (IllegalStateException.class.isAssignableFrom(exceptionClass)) return "409";
-        if (QueryTimeoutException.class.isAssignableFrom(exceptionClass)) return "503";
+        if (IllegalArgumentException.class.isAssignableFrom(exceptionClass))
+            return "400";
+        if (NoSuchElementException.class.isAssignableFrom(exceptionClass))
+            return "404";
+        if (SecurityException.class.isAssignableFrom(exceptionClass)
+                || UnauthorizedException.class.isAssignableFrom(exceptionClass))
+            return "401";
+        if (IllegalStateException.class.isAssignableFrom(exceptionClass))
+            return "409";
+        if (QueryTimeoutException.class.isAssignableFrom(exceptionClass))
+            return "503";
         return "500";
     }
 
@@ -115,7 +113,7 @@ public class OpenApiConfig {
 
             StringBuilder description = new StringBuilder("발생 가능한 " + statusCode + " 에러:\n");
             for (ErrorType errorType : errors) {
-                description.append("- ").append(errorType.message("N", "N", "N")).append("\n");
+                description.append("- ").append(errorType.getMessageForApiDoc()).append("\n");
             }
 
             apiResponse.setDescription(description.toString());

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/OpenApiConfig.java
@@ -4,21 +4,32 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.examples.Example;
-import org.springdoc.core.customizers.OpenApiCustomizer;
+
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import lombok.extern.slf4j.Slf4j;
 
+import coursepick.coursepick.application.exception.ErrorType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+import coursepick.coursepick.application.exception.QueryTimeoutException;
+import coursepick.coursepick.application.exception.UnauthorizedException;
+
+import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
-
-import static coursepick.coursepick.application.exception.ErrorType.values;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Profile("!prod")
+@Slf4j
 @OpenAPIDefinition(info = @Info(title = "코스픽 API"))
 @SecurityScheme(
         name = "BearerAuth",
@@ -30,32 +41,85 @@ import static coursepick.coursepick.application.exception.ErrorType.values;
 @Configuration
 public class OpenApiConfig {
 
-    private static final String TIMESTAMP = LocalDateTime.now().toString();
-
     @Bean
     public GroupedOpenApi v1Api() {
         return GroupedOpenApi.builder()
                 .group("v1")
                 .pathsToMatch("/v1/**")
+                .addOperationCustomizer(customizeOperation())
                 .build();
     }
 
-    @Bean
-    public OpenApiCustomizer customize() {
-        return openApi -> {
-            Components components = openApi.getComponents();
+    public OperationCustomizer customizeOperation() {
+        return (operation, handlerMethod) -> {
+            ApiErrorExceptionsExample apiErrorExceptionsExample = AnnotatedElementUtils.findMergedAnnotation(
+                    handlerMethod.getMethod(), ApiErrorExceptionsExample.class);
+            if (apiErrorExceptionsExample == null) {
+                try {
+                    Method interfaceMethod = CourseWebApi.class.getMethod(
+                            handlerMethod.getMethod().getName(), handlerMethod.getMethod().getParameterTypes());
+                    apiErrorExceptionsExample = AnnotatedElementUtils.findMergedAnnotation(interfaceMethod, ApiErrorExceptionsExample.class);
+                    log.info("Found on interface: {}", (apiErrorExceptionsExample != null));
+                } catch (Exception e) {}
+            }
+            if (apiErrorExceptionsExample != null) {
+                generateErrorResponseExample(operation, apiErrorExceptionsExample.value());
+            }
 
-            Arrays.stream(values()).forEach(
-                    errorType -> {
-                        Example example = new Example()
-                                .value(Map.of(
-                                        "message", errorType.message("{}", "{}", "{}"),
-                                        "timestamp", TIMESTAMP
-                                ));
-                        components.addExamples(errorType.name(), example);
+            if ((operation.getParameters() != null && !operation.getParameters().isEmpty()) || operation.getRequestBody() != null) {
+                addDefaultValidationError(operation);
+            }
 
-                    }
-            );
+            return operation;
         };
+    }
+
+    private void addDefaultValidationError(io.swagger.v3.oas.models.Operation operation) {
+        ApiResponses responses = operation.getResponses();
+        ApiResponse apiResponse = responses.getOrDefault("400", new ApiResponse());
+
+        String defaultMessage = "- 잘못된 파라미터 (예: 필수 파라미터 누락, null 값, 형식 오류 등)\n";
+        String existingDescription = apiResponse.getDescription();
+
+        if (existingDescription == null) {
+            existingDescription = "발생 가능한 400 에러:\n";
+        }
+
+        if (!existingDescription.contains("잘못된 파라미터")) {
+            apiResponse.setDescription(existingDescription + defaultMessage);
+            responses.addApiResponse("400", apiResponse);
+        }
+    }
+
+    private String getStatusCode(ErrorType errorType) {
+        Class<? extends RuntimeException> exceptionClass = errorType.getExceptionClass();
+        if (IllegalArgumentException.class.isAssignableFrom(exceptionClass)) return "400";
+        if (NoSuchElementException.class.isAssignableFrom(exceptionClass)) return "404";
+        if (SecurityException.class.isAssignableFrom(exceptionClass) || UnauthorizedException.class.isAssignableFrom(exceptionClass)) return "401";
+        if (IllegalStateException.class.isAssignableFrom(exceptionClass)) return "409";
+        if (QueryTimeoutException.class.isAssignableFrom(exceptionClass)) return "503";
+        return "500";
+    }
+
+    private void generateErrorResponseExample(io.swagger.v3.oas.models.Operation operation, ErrorType[] errorTypes) {
+        ApiResponses responses = operation.getResponses();
+
+        Map<String, List<ErrorType>> statusToErrors = Arrays.stream(errorTypes)
+                .collect(Collectors.groupingBy(this::getStatusCode));
+
+        for (Map.Entry<String, List<ErrorType>> entry : statusToErrors.entrySet()) {
+            String statusCode = entry.getKey();
+            List<ErrorType> errors = entry.getValue();
+
+            ApiResponse apiResponse = responses.getOrDefault(statusCode, new ApiResponse());
+
+            StringBuilder description = new StringBuilder("발생 가능한 " + statusCode + " 에러:\n");
+            for (ErrorType errorType : errors) {
+                description.append("- ").append(errorType.message("N", "N", "N")).append("\n");
+            }
+
+            apiResponse.setDescription(description.toString());
+            responses.addApiResponse(statusCode, apiResponse);
+        }
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/presentation/api/UserWebApi.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/api/UserWebApi.java
@@ -1,28 +1,21 @@
 package coursepick.coursepick.presentation.api;
 
+import coursepick.coursepick.application.exception.ErrorType;
 import coursepick.coursepick.presentation.dto.SignWebRequest;
 import coursepick.coursepick.presentation.dto.SignWebResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "회원 (User)")
 public interface UserWebApi {
 
-    @Operation(summary = "싸인")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200"),
-            @ApiResponse(responseCode = "401", content = @Content(examples = {
-                    @ExampleObject(
-                            name = "로그인에 실패한 경우",
-                            ref = "#/components/examples/AUTHENTICATION_FAIL"
-                    )
-            })),
+    @ApiErrorExceptionsExample({
+            ErrorType.AUTHENTICATION_FAIL
     })
+    @Operation(summary = "싸인")
+    @ApiResponse(responseCode = "200")
     SignWebResponse sign(
             @RequestBody(
                     required = true,


### PR DESCRIPTION
## 🛠️ 설명
- api 문서 400, 401 등에 예외가 발생하는 상황을 명시했습니다.
- 서버에서 사용하는 설명을 그대로 사용합니다.
- @ApiErrorExceptionsExample을 만들어 사용하고 기존 작성 됐던 예외 설명들을 제거했습니다.


## 📸 스크린샷 / 동영상
<img width="1102" height="476" alt="image" src="https://github.com/user-attachments/assets/f59afe1e-45bb-4965-a2e1-8158e8d27c9e" />


## ✅ 체크리스트

- [ ] `application*.yml`에 새 환경변수(`${...}`)를 추가했나요?
  - [ ] 홈서버의 `.env.home-prod` / `.env.home-dev`에도 동일한 키를 추가했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 문서의 오류 응답 정보가 더 명확하고 일관성 있게 표시됩니다.
  * API 스키마 문서에서 각 엔드포인트의 가능한 오류 케이스를 더 정확하게 확인할 수 있습니다.

* **Refactor**
  * API 문서 생성 방식을 개선하여 운영 효율성을 높였습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->