### PR TITLE
리뷰 관련 UI에 사용자 ID가 반영되도록 변경

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/data/auth/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/auth/DefaultAuthRepository.kt
@@ -43,8 +43,8 @@ class DefaultAuthRepository
             return cachedAccessToken
         }
 
-        override suspend fun clearAccessToken() {
-            tokenLocalDataSource.clearAccessToken()
+        override suspend fun clearCredentials() {
+            tokenLocalDataSource.clearCredentials()
             cachedAccessToken = null
         }
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/data/auth/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/auth/DefaultAuthRepository.kt
@@ -20,8 +20,12 @@ class DefaultAuthRepository
             socialToken: SocialToken,
         ): String {
             val token = TokenDto(socialToken.accessToken)
-            return service.sign(socialType, token).accessToken
+            val signResponse: SignResponseDto = service.sign(socialType, token)
+            tokenLocalDataSource.saveUserId(signResponse.userId)
+            return signResponse.accessToken
         }
+
+        override suspend fun userId(): String? = tokenLocalDataSource.userId()
 
         override suspend fun saveAccessToken(token: String) {
             cachedAccessToken = token

--- a/android/app/src/main/java/io/coursepick/coursepick/data/auth/SignResponseDto.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/auth/SignResponseDto.kt
@@ -1,0 +1,9 @@
+package io.coursepick.coursepick.data.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SignResponseDto(
+    val userId: String,
+    val accessToken: String,
+)

--- a/android/app/src/main/java/io/coursepick/coursepick/data/auth/SignService.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/auth/SignService.kt
@@ -9,5 +9,5 @@ interface SignService {
     suspend fun sign(
         @Path("socialType") socialType: String,
         @Body socialToken: TokenDto,
-    ): TokenDto
+    ): SignResponseDto
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/data/auth/TokenLocalDataSource.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/auth/TokenLocalDataSource.kt
@@ -18,26 +18,35 @@ class TokenLocalDataSource
         @AuthDataStore private val dataStore: DataStore<Preferences>,
         private val aead: Aead,
     ) {
-        private val tokenSecurity: ByteArray = BuildConfig.TOKEN_SECURITY.toByteArray()
-        private val accessToken: Preferences.Key<String> = stringPreferencesKey("access_token")
+        suspend fun userId(): String? = dataStore.data.first()[userIdKey]
+
+        suspend fun saveUserId(userId: String) {
+            dataStore.edit { preferences: MutablePreferences -> preferences[userIdKey] = userId }
+        }
+
+        suspend fun accessToken(): String? {
+            val encryptedToken: String = dataStore.data.first()[accessTokenKey] ?: return null
+            val decoded: ByteArray = Base64.decode(encryptedToken, Base64.NO_WRAP)
+            return String(aead.decrypt(decoded, tokenSecurity))
+        }
 
         suspend fun saveAccessToken(token: String) {
             val ciphertext: ByteArray = aead.encrypt(token.toByteArray(), tokenSecurity)
             val encryptedToken: String = Base64.encodeToString(ciphertext, Base64.NO_WRAP)
             dataStore.edit { preferences: MutablePreferences ->
-                preferences[accessToken] = encryptedToken
+                preferences[accessTokenKey] = encryptedToken
             }
-        }
-
-        suspend fun accessToken(): String? {
-            val encryptedToken: String = dataStore.data.first()[accessToken] ?: return null
-            val decoded: ByteArray = Base64.decode(encryptedToken, Base64.NO_WRAP)
-            return String(aead.decrypt(decoded, tokenSecurity))
         }
 
         suspend fun clearAccessToken() {
             dataStore.edit { preferences: MutablePreferences ->
-                preferences.remove(accessToken)
+                preferences.remove(accessTokenKey)
             }
+        }
+
+        companion object {
+            private val tokenSecurity: ByteArray = BuildConfig.TOKEN_SECURITY.toByteArray()
+            private val userIdKey: Preferences.Key<String> = stringPreferencesKey("user_id")
+            private val accessTokenKey: Preferences.Key<String> = stringPreferencesKey("access_token")
         }
     }

--- a/android/app/src/main/java/io/coursepick/coursepick/data/auth/TokenLocalDataSource.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/auth/TokenLocalDataSource.kt
@@ -38,8 +38,9 @@ class TokenLocalDataSource
             }
         }
 
-        suspend fun clearAccessToken() {
+        suspend fun clearCredentials() {
             dataStore.edit { preferences: MutablePreferences ->
+                preferences.remove(userIdKey)
                 preferences.remove(accessTokenKey)
             }
         }

--- a/android/app/src/main/java/io/coursepick/coursepick/domain/auth/AuthRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/domain/auth/AuthRepository.kt
@@ -16,5 +16,5 @@ interface AuthRepository {
 
     suspend fun accessToken(): String?
 
-    suspend fun clearAccessToken()
+    suspend fun clearCredentials()
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/domain/auth/AuthRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/domain/auth/AuthRepository.kt
@@ -8,6 +8,8 @@ interface AuthRepository {
         socialToken: SocialToken,
     ): String
 
+    suspend fun userId(): String?
+
     suspend fun saveAccessToken(token: String)
 
     suspend fun preloadAccessToken()

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/auth/AuthViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/auth/AuthViewModel.kt
@@ -29,10 +29,7 @@ class AuthViewModel
                 onSuccess = { socialAccessToken: String ->
                     viewModelScope.launch {
                         runCatching {
-                            authRepository.sign(
-                                authenticator.socialType,
-                                SocialToken(socialAccessToken),
-                            )
+                            authRepository.sign(authenticator.socialType, SocialToken(socialAccessToken))
                         }.onSuccess { token: String ->
                             authRepository.saveAccessToken(token)
                             _uiEvent.emit(AuthUiEvent.AuthenticateSuccess(feature))

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
@@ -253,21 +253,21 @@ private fun CourseDetailScreen(
                         .padding(horizontal = 20.dp, vertical = 10.dp),
                 ) {
                     CourseInfo(
-                        courseName = uiState.detail.name,
-                        length = uiState.detail.length,
-                        isFavorite = uiState.isFavorite,
+                        courseName = uiState.data.name,
+                        length = uiState.data.length,
+                        isFavorite = uiState.data.isFavorite,
                         onToggleFavorite = onToggleFavorite,
-                        averageRating = uiState.detail.averageRating,
+                        averageRating = uiState.data.averageRating,
                     )
 
                     Spacer(Modifier.height(10.dp))
 
-                    CourseReviewHeader(uiState.detail.reviewCount)
+                    CourseReviewHeader(uiState.data.reviewCount)
 
                     Spacer(Modifier.height(10.dp))
 
                     CourseReviews(
-                        reviews = uiState.detail.reviews,
+                        reviews = uiState.data.reviews,
                         onDelete = onDeleteReview,
                         onReport = onReportReview,
                         modifier =
@@ -638,7 +638,7 @@ private fun CourseDetailScreenPreview_Success_EmptyReview() {
     CourseDetailScreen(
         uiState =
             CourseDetailViewModel.UiState.Success(
-                detail =
+                data =
                     CourseDetailUiModel(
                         id = "",
                         name = "석촌호수 동호 한바퀴",
@@ -647,8 +647,8 @@ private fun CourseDetailScreenPreview_Success_EmptyReview() {
                         averageRating = 4.32F,
                         tags = emptyList(),
                         reviews = emptyList(),
+                        isFavorite = false,
                     ),
-                isFavorite = false,
             ),
         onNavigateBack = { },
         onToggleFavorite = { },
@@ -666,7 +666,7 @@ private fun CourseDetailScreenPreview_Success_NonEmptyReviews() {
     CourseDetailScreen(
         uiState =
             CourseDetailViewModel.UiState.Success(
-                detail =
+                data =
                     CourseDetailUiModel(
                         id = "",
                         name = "석촌호수 동호 한바퀴",
@@ -685,8 +685,8 @@ private fun CourseDetailScreenPreview_Success_NonEmptyReviews() {
                                     content = "리뷰 내용 ".repeat(10 + index * 5),
                                 )
                             },
+                        isFavorite = false,
                     ),
-                isFavorite = false,
             ),
         onNavigateBack = { },
         onToggleFavorite = { },

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailUiModel.kt
@@ -13,15 +13,19 @@ data class CourseDetailUiModel(
     val averageRating: Float,
     val tags: List<String>,
     val reviews: List<CourseReviewUiModel>,
+    val isFavorite: Boolean,
 )
 
-fun CourseDetail.toUiModel(): CourseDetailUiModel =
-    CourseDetailUiModel(
-        id = id,
-        name = name.value,
-        length = length.meter.value,
-        reviewCount = reviewCount,
-        averageRating = averageRating,
-        tags = tags,
-        reviews = reviews.map(CourseReview::toUiModel),
-    )
+fun CourseDetail.toUiModel(
+    isFavorite: Boolean,
+    userId: String?,
+) = CourseDetailUiModel(
+    id = id,
+    name = name.value,
+    length = length.meter.value,
+    reviewCount = reviewCount,
+    averageRating = averageRating,
+    tags = tags,
+    reviews = reviews.map { review: CourseReview -> review.toUiModel(review.authorId == userId) },
+    isFavorite = isFavorite,
+)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.coursepick.coursepick.data.NetworkMonitor
 import io.coursepick.coursepick.data.interceptor.NoNetworkException
 import io.coursepick.coursepick.domain.auth.AuthRepository
+import io.coursepick.coursepick.domain.course.CourseDetail
 import io.coursepick.coursepick.domain.course.CourseRepository
 import io.coursepick.coursepick.domain.favorites.FavoriteCourseRepository
 import io.coursepick.coursepick.presentation.auth.AuthFeature
@@ -37,7 +38,7 @@ class CourseDetailViewModel
 
         private val isConnected = MutableStateFlow(networkMonitor.isConnected())
         private val isLoading = MutableStateFlow(true)
-        private val courseDetail = MutableStateFlow<CourseDetailUiModel?>(null)
+        private val courseDetail = MutableStateFlow<CourseDetail?>(null)
 
         val uiState: StateFlow<UiState> =
             combine(
@@ -45,7 +46,7 @@ class CourseDetailViewModel
                 isLoading,
                 courseDetail,
                 favoriteCourseRepository.favoriteCourseIds,
-            ) { isConnected: Boolean, isLoading: Boolean, courseDetail: CourseDetailUiModel?, favoriteCourseIds: Set<String> ->
+            ) { isConnected: Boolean, isLoading: Boolean, courseDetail: CourseDetail?, favoriteCourseIds: Set<String> ->
                 if (!isConnected) {
                     UiState.Failure.NoNetwork
                 } else if (isLoading) {
@@ -53,7 +54,12 @@ class CourseDetailViewModel
                 } else if (courseDetail == null) {
                     UiState.Failure.Unknown
                 } else {
-                    UiState.Success(detail = courseDetail, isFavorite = favoriteCourseIds.contains(courseDetail.id))
+                    UiState.Success(
+                        courseDetail.toUiModel(
+                            isFavorite = favoriteCourseIds.contains(courseDetail.id),
+                            userId = authRepository.userId(),
+                        ),
+                    )
                 }
             }.stateIn(
                 scope = viewModelScope,
@@ -78,9 +84,9 @@ class CourseDetailViewModel
             }
         }
 
-        private suspend fun courseDetail(courseId: String): CourseDetailUiModel? =
+        private suspend fun courseDetail(courseId: String): CourseDetail? =
             runCatching {
-                courseRepository.detail(courseId).toUiModel()
+                courseRepository.detail(courseId)
             }.onFailure { exception: Throwable ->
                 if (exception is CancellationException) throw exception
             }.getOrNull()
@@ -89,10 +95,10 @@ class CourseDetailViewModel
             viewModelScope.launch {
                 val currentState = uiState.value
                 if (currentState is UiState.Success) {
-                    if (currentState.isFavorite) {
-                        favoriteCourseRepository.removeFavorite(currentState.detail.id)
+                    if (currentState.data.isFavorite) {
+                        favoriteCourseRepository.removeFavorite(currentState.data.id)
                     } else {
-                        favoriteCourseRepository.addFavorite(currentState.detail.id)
+                        favoriteCourseRepository.addFavorite(currentState.data.id)
                     }
                 }
             }
@@ -119,9 +125,9 @@ class CourseDetailViewModel
                 (uiState.value as? UiState.Success)?.let { uiState: UiState.Success ->
                     _dialogState.value =
                         if (authRepository.accessToken() == null) {
-                            dialogState.value.copy(authDialog = AuthFeature.ReportCourse(uiState.detail.id))
+                            dialogState.value.copy(authDialog = AuthFeature.ReportCourse(uiState.data.id))
                         } else {
-                            dialogState.value.copy(reportCourseDialog = uiState.detail.name)
+                            dialogState.value.copy(reportCourseDialog = uiState.data.name)
                         }
                 }
             }
@@ -136,7 +142,7 @@ class CourseDetailViewModel
                 try {
                     val currentState: UiState = uiState.value
                     if (currentState is UiState.Success) {
-                        courseRepository.reportCourse(currentState.detail.id)
+                        courseRepository.reportCourse(currentState.data.id)
                         dismissReportCourseDialog()
                         _uiEvent.emit(UiEvent.ReportCourseSuccess)
                     }
@@ -183,9 +189,9 @@ class CourseDetailViewModel
             viewModelScope.launch {
                 (uiState.value as? UiState.Success)?.let { uiState: UiState.Success ->
                     try {
-                        courseRepository.deleteReview(uiState.detail.id, review.id)
+                        courseRepository.deleteReview(uiState.data.id, review.id)
                         _uiEvent.emit(UiEvent.DeleteReviewSuccess)
-                        courseDetail.value = courseDetail(uiState.detail.id)
+                        courseDetail.value = courseDetail(uiState.data.id)
                     } catch (exception: CancellationException) {
                         throw exception
                     } catch (_: NoNetworkException) {
@@ -220,7 +226,7 @@ class CourseDetailViewModel
             viewModelScope.launch {
                 (uiState.value as? UiState.Success)?.let { uiState: UiState.Success ->
                     try {
-                        courseRepository.reportReview(uiState.detail.id, review.id)
+                        courseRepository.reportReview(uiState.data.id, review.id)
                         _uiEvent.emit(UiEvent.ReportReviewSuccess)
                     } catch (exception: CancellationException) {
                         throw exception
@@ -249,19 +255,17 @@ class CourseDetailViewModel
             viewModelScope.launch {
                 (uiState.value as? UiState.Success)?.let { uiState: UiState.Success ->
                     if (authRepository.accessToken() == null) {
-                        _dialogState.value = dialogState.value.copy(authDialog = AuthFeature.WriteReview(uiState.detail.id))
+                        _dialogState.value = dialogState.value.copy(authDialog = AuthFeature.WriteReview(uiState.data.id))
                         return@launch
                     }
 
                     val alreadyReviewed: Boolean =
-                        uiState.detail.reviews.any { review: CourseReviewUiModel ->
-                            review.authorName == "current_user_id" // TODO: API 업데이트될 시 사용자 ID 기반으로 확인하도록 변경
-                        }
+                        uiState.data.reviews.any { review: CourseReviewUiModel -> review.authorId == authRepository.userId() }
                     _uiEvent.emit(
                         if (alreadyReviewed) {
                             UiEvent.CourseAlreadyReviewed
                         } else {
-                            UiEvent.NavigateToWriteCourseReview(uiState.detail)
+                            UiEvent.NavigateToWriteCourseReview(uiState.data)
                         },
                     )
                 }
@@ -296,8 +300,7 @@ class CourseDetailViewModel
             data object Loading : UiState
 
             data class Success(
-                val detail: CourseDetailUiModel,
-                val isFavorite: Boolean,
+                val data: CourseDetailUiModel,
             ) : UiState
 
             sealed interface Failure : UiState {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseReviewUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseReviewUiModel.kt
@@ -13,12 +13,12 @@ data class CourseReviewUiModel(
     val content: String,
 )
 
-fun CourseReview.toUiModel(): CourseReviewUiModel =
+fun CourseReview.toUiModel(isMine: Boolean) =
     CourseReviewUiModel(
         id = id,
         authorId = authorId,
         authorName = authorName,
-        isMine = false, // TODO: API 업데이트될 시 사용자 ID 기반으로 확인하도록 변경
+        isMine = isMine,
         rating = rating.toFloat(),
         content = content,
     )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/ReviewItem.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/ReviewItem.kt
@@ -111,7 +111,7 @@ private fun MyReviewChip(modifier: Modifier = Modifier) {
 
 @Composable
 private fun ReviewActionButton(
-    isMine: Boolean, // TODO: API 업데이트될 시 isMine 값에 따라 다른 메뉴를 표시하도록 변경
+    isMine: Boolean,
     onDelete: () -> Unit,
     onReport: () -> Unit,
     modifier: Modifier = Modifier,
@@ -136,33 +136,35 @@ private fun ReviewActionButton(
             shape = RoundedCornerShape(10.dp),
             containerColor = colorResource(R.color.background_secondary),
         ) {
-            DropdownMenuItem(
-                text = {
-                    Text(
-                        text = stringResource(R.string.review_item_action_delete),
-                        color = colorResource(R.color.item_primary),
-                        fontSize = 14.sp,
-                    )
-                },
-                onClick = {
-                    expanded = false
-                    onDelete()
-                },
-            )
-
-            DropdownMenuItem(
-                text = {
-                    Text(
-                        text = stringResource(R.string.review_item_action_report),
-                        color = colorResource(R.color.item_primary),
-                        fontSize = 14.sp,
-                    )
-                },
-                onClick = {
-                    expanded = false
-                    onReport()
-                },
-            )
+            if (isMine) {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(R.string.review_item_action_delete),
+                            color = colorResource(R.color.item_primary),
+                            fontSize = 14.sp,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onDelete()
+                    },
+                )
+            } else {
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = stringResource(R.string.review_item_action_report),
+                            color = colorResource(R.color.item_primary),
+                            fontSize = 14.sp,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onReport()
+                    },
+                )
+            }
         }
     }
 }

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/auth/AuthViewModelTest.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/auth/AuthViewModelTest.kt
@@ -39,7 +39,7 @@ class AuthViewModelTest {
 
                             override suspend fun accessToken(): String? = null
 
-                            override suspend fun clearAccessToken() = Unit
+                            override suspend fun clearCredentials() = Unit
                         },
                 )
             val uiEvents: MutableList<AuthUiEvent> = mutableListOf()

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/auth/AuthViewModelTest.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/auth/AuthViewModelTest.kt
@@ -33,6 +33,8 @@ class AuthViewModelTest {
                                 socialToken: SocialToken,
                             ): String = "token 123456"
 
+                            override suspend fun userId(): String = "user id"
+
                             override suspend fun saveAccessToken(token: String) = Unit
 
                             override suspend fun preloadAccessToken() = Unit

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeAuthRepository.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeAuthRepository.kt
@@ -4,12 +4,18 @@ import io.coursepick.coursepick.domain.auth.AuthRepository
 import io.coursepick.coursepick.domain.auth.SocialToken
 
 class FakeAuthRepository : AuthRepository {
+    private var userId: String? = null
     override var cachedAccessToken: String? = null
 
     override suspend fun sign(
         socialType: String,
         socialToken: SocialToken,
-    ): String = "access_token"
+    ): String {
+        userId = USER_ID
+        return ACCESS_TOKEN
+    }
+
+    override suspend fun userId(): String? = userId
 
     override suspend fun saveAccessToken(token: String) {
         cachedAccessToken = token
@@ -21,12 +27,18 @@ class FakeAuthRepository : AuthRepository {
 
     override suspend fun accessToken(): String? {
         if (cachedAccessToken == null) {
-            cachedAccessToken = "access_token"
+            cachedAccessToken = ACCESS_TOKEN
         }
         return cachedAccessToken
     }
 
     override suspend fun clearCredentials() {
+        userId = null
         cachedAccessToken = null
+    }
+
+    companion object {
+        private const val USER_ID = "user_id"
+        private const val ACCESS_TOKEN = "access_token"
     }
 }

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeAuthRepository.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeAuthRepository.kt
@@ -26,7 +26,7 @@ class FakeAuthRepository : AuthRepository {
         return cachedAccessToken
     }
 
-    override suspend fun clearAccessToken() {
+    override suspend fun clearCredentials() {
         cachedAccessToken = null
     }
 }


### PR DESCRIPTION
## 🛠️ 설명
사용자 ID를 기반으로 `내가 작성한 리뷰`와 `다른 사용자가 작성한 리뷰`에 대한 UI가 다르게 처리되도록 변경됐습니다.
- 사용자 본인이 작성한 리뷰에는 `내 리뷰` 표시를 띄웁니다.
- 사용자 본인이 작성한 리뷰에만 `삭제하기` 메뉴가 표시됩니다.
- 다른 사용자가 작성한 리뷰에만 `신고하기` 메뉴가 표시됩니다.
- 이미 리뷰를 작성한 코스의 상세 화면에서는 리뷰 작성 화면으로 넘어갈 수 없게 됩니다.


## 📸 스크린샷 / 동영상
[Screen_recording_20260529_212729.webm](https://github.com/user-attachments/assets/9b1c0771-a4a8-4623-b586-4e541608880f)


## 🔗 관련 이슈
- closes #941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 ID 저장 및 조회 기능 추가
  * 코스 상세 화면에서 찜하기 상태 표시 개선

* **Improvements**
  * 소셜 로그인 응답 처리 최적화
  * 리뷰 작성자 판별 로직 개선 (사용자 ID 기반)
  * 본인 리뷰와 타인 리뷰 구분으로 메뉴 항목 조건부 표시 (본인만 삭제, 타인만 신고)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->