### PR TITLE
예외 응답 errorCode 추가

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -115,11 +115,12 @@ public enum ErrorType {
     }
 
     public RuntimeException create(Object... messageArgs) {
-        return exceptionConstructor.apply(message(messageArgs));
+        return exceptionConstructor.apply(buildMessage(messageArgs));
     }
 
-    public String message(Object... messageArgs) {
-        return this.message.formatted(messageArgs);
+    private String buildMessage(Object... messageArgs) {
+        String formattedMessage = this.message.formatted(messageArgs);
+        return "%s [ErrorCode = %s]".formatted(formattedMessage, this.name());
     }
 
     public String getRawMessage() {

--- a/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
+++ b/backend/src/main/java/coursepick/coursepick/application/exception/ErrorType.java
@@ -115,10 +115,10 @@ public enum ErrorType {
     }
 
     public RuntimeException create(Object... messageArgs) {
-        return exceptionConstructor.apply(buildMessage(messageArgs));
+        return exceptionConstructor.apply(message(messageArgs));
     }
 
-    private String buildMessage(Object... messageArgs) {
+    public String message(Object... messageArgs) {
         String formattedMessage = this.message.formatted(messageArgs);
         return "%s [ErrorCode = %s]".formatted(formattedMessage, this.name());
     }

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
@@ -16,8 +16,14 @@ public record ErrorResponse(
 
     public static ErrorResponse from(Exception exception) {
         String message = exception.getMessage();
+        String errorCode = "UNKNOWN_ERROR";
+
         Matcher matcher = ERROR_CODE_PATTERN.matcher(message);
-        String errorCode = matcher.find() ? matcher.group(1) : "UNKNOWN_ERROR";
+
+        if (matcher.find()) {
+            errorCode = matcher.group(1);
+            message = matcher.replaceFirst("");
+        }
 
         return new ErrorResponse(
                 message,

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
@@ -3,6 +3,7 @@ package coursepick.coursepick.presentation.dto;
 import org.springframework.validation.BindingResult;
 
 import java.time.LocalDateTime;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -14,10 +15,15 @@ public record ErrorResponse(
     private static final Pattern ERROR_CODE_PATTERN = Pattern.compile("\\[ErrorCode = ([^\\]]+)\\]");
 
     public static ErrorResponse from(Exception exception) {
+        String message = exception.getMessage();
+        Matcher matcher = ERROR_CODE_PATTERN.matcher(message);
+        String errorCode = matcher.find() ? matcher.group(1) : "UNKNOWN_ERROR";
+
         return new ErrorResponse(
-                exception.getMessage(),
-                ERROR_CODE_PATTERN.matcher(exception.getMessage()).group(1),
-                LocalDateTime.now().toString());
+                message,
+                errorCode,
+                LocalDateTime.now().toString()
+        );
     }
 
     public static ErrorResponse from(BindingResult bindingResult) {

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/ErrorResponse.java
@@ -8,13 +8,15 @@ import java.util.stream.Collectors;
 
 public record ErrorResponse(
         String message,
+        String errorCode,
         String timestamp) {
 
-    private static final Pattern DUP_KEY_PATTERN = Pattern.compile("dup key: \\{\\s*(.*?)\\s*}");
+    private static final Pattern ERROR_CODE_PATTERN = Pattern.compile("\\[ErrorCode = ([^\\]]+)\\]");
 
     public static ErrorResponse from(Exception exception) {
         return new ErrorResponse(
                 exception.getMessage(),
+                ERROR_CODE_PATTERN.matcher(exception.getMessage()).group(1),
                 LocalDateTime.now().toString());
     }
 
@@ -22,6 +24,6 @@ public record ErrorResponse(
         String errorMessage = bindingResult.getFieldErrors().stream()
                 .map(error -> error.getDefaultMessage())
                 .collect(Collectors.joining(", "));
-        return new ErrorResponse(errorMessage, LocalDateTime.now().toString());
+        return new ErrorResponse(errorMessage, "INVALID_INPUT", LocalDateTime.now().toString());
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/application/exception/ErrorTypeTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/exception/ErrorTypeTest.java
@@ -1,0 +1,57 @@
+package coursepick.coursepick.application.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import coursepick.coursepick.presentation.dto.ErrorResponse;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+class ErrorTypeTest {
+
+    @Test
+    void ErrorType으로_예외_생성_시_메시지에_에러_코드가_포함된다() {
+        var errorType = ErrorType.INVALID_LATITUDE_RANGE;
+        var argument = "100";
+
+        var exception = errorType.create(argument);
+
+        assertThat(exception.getMessage()).contains("[ErrorCode = INVALID_LATITUDE_RANGE]");
+        assertThat(exception.getMessage()).contains("위도는 -90 이상, 90 이하이어야 합니다. 입력값=100");
+    }
+
+    @Test
+    void ErrorResponse는_예외_메시지에서_에러_코드를_정상적으로_추출한다() {
+        var errorType = ErrorType.NOT_EXIST_COURSE;
+        var exception = errorType.create("1");
+
+        var response = ErrorResponse.from(exception);
+
+        assertThat(response.errorCode()).isEqualTo("NOT_EXIST_COURSE");
+    }
+
+    @Test
+    void BindingResult로부터_ErrorResponse_생성_시_에러_코드는_INVALID_INPUT이다() {
+        var bindingResult = mock(BindingResult.class);
+        given(bindingResult.getFieldErrors()).willReturn(List.of(
+                new FieldError("object", "field", "defaultMessage")
+        ));
+
+        var response = ErrorResponse.from(bindingResult);
+
+        assertThat(response.errorCode()).isEqualTo("INVALID_INPUT");
+        assertThat(response.message()).isEqualTo("defaultMessage");
+    }
+
+    @Test
+    void 에러_코드가_없는_예외_메시지로부터_ErrorResponse_생성_시_에러_코드는_UNKNOWN_ERROR이다() {
+        var exception = new RuntimeException("일반 예외 메시지");
+
+        var response = ErrorResponse.from(exception);
+
+        assertThat(response.errorCode()).isEqualTo("UNKNOWN_ERROR");
+    }
+}

--- a/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
+++ b/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
@@ -934,6 +934,7 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
         private FieldDescriptor[] errorResponseFields() {
             return new FieldDescriptor[]{
                     fieldWithPath("message").description("에러 상세 메시지"),
+                    fieldWithPath("errorCode").description("에러 코드"),
                     fieldWithPath("timestamp").description("에러 발생 시각")
             };
         }

--- a/backend/src/test/java/coursepick/coursepick/docs/UserApiDocsTest.java
+++ b/backend/src/test/java/coursepick/coursepick/docs/UserApiDocsTest.java
@@ -80,6 +80,7 @@ class UserApiDocsTest extends AbstractApiDocsSupport {
     private FieldDescriptor[] errorResponseFields() {
         return new FieldDescriptor[]{
                 fieldWithPath("message").description("에러 상세 메시지"),
+                fieldWithPath("errorCode").description("에러 코드"),
                 fieldWithPath("timestamp").description("에러 발생 시각")
         };
     }

--- a/backend/src/test/java/coursepick/coursepick/domain/course/MeterTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/MeterTest.java
@@ -24,7 +24,7 @@ class MeterTest {
 
         Assertions.assertThatThrownBy(() -> meter.getRateOf(other))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("0을 기준으로 비율을 계산할 수 없습니다.");
+                .hasMessageContaining("0을 기준으로 비율을 계산할 수 없습니다.");
 
     }
 }


### PR DESCRIPTION
## 🛠️ 설명
- 400번대 코드의 에러 종류를 구분하기 위해서 errorCode를 에러응답에 추가하였습니다.
  - 리뷰 글자수 초과
  - 유저 코스 반복 리뷰 금지 
- 바로 사용되지 않을 것 같지만, 추후에 사용될 가능성이 커 보여 미리 작업했습니다!  
```json
{
  "message": "리뷰 평점은 1이상 5이하여야 합니다. 입력값=6 ",
  "errorCode": "INVALID_REVIEW_RATING",
  "timestamp": "2026-05-30T01:12:15.731138"
}
```

## 📸 스크린샷 / 동영상
<img width="424" height="228" alt="image" src="https://github.com/user-attachments/assets/a5e40f88-847f-4e07-8912-434b4c815e6b" />


## 🔍 리뷰 요청사항

## ✅ 체크리스트

- [ ] `application*.yml`에 새 환경변수(`${...}`)를 추가했나요?
  - [ ] 홈서버의 `.env.home-prod` / `.env.home-dev`에도 동일한 키를 추가했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * 에러 응답에 에러 코드 필드가 포함됩니다.

* **Documentation**
  * API 문서의 에러 응답 스키마가 에러 코드 필드를 포함하도록 업데이트되었습니다.

* **Tests**
  * 에러 처리 및 응답 검증 관련 테스트가 추가되고 수정되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/woowacourse-teams/2025-course-pick/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->