### PR TITLE
코스 정보 칩을 스크롤할 수 있도록 변경

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItemCard.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItemCard.kt
@@ -2,6 +2,7 @@ package io.coursepick.coursepick.presentation.customcourse
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -82,7 +84,12 @@ fun CustomCourseItemCard(
 
                 Spacer(modifier = Modifier.height(10.dp))
 
-                Row(Modifier.height(IntrinsicSize.Min).fillMaxWidth()) {
+                Row(
+                    Modifier
+                        .height(IntrinsicSize.Min)
+                        .padding(end = 8.dp)
+                        .horizontalScroll(rememberScrollState()),
+                ) {
                     CourseLengthChip(
                         length = customCourse.length,
                         modifier = Modifier.fillMaxHeight(),

--- a/android/app/src/main/res/layout/item_course.xml
+++ b/android/app/src/main/res/layout/item_course.xml
@@ -69,12 +69,8 @@
             app:layout_constraintTop_toBottomOf="@id/courseName">
 
             <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/courseNavigationButton"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/courseName">
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
 
                 <LinearLayout
                     android:id="@+id/courseLength"
@@ -83,10 +79,7 @@
                     android:background="@drawable/background_course_detail"
                     android:gravity="center_vertical"
                     android:paddingHorizontal="10dp"
-                    android:paddingVertical="4dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/courseName">
+                    android:paddingVertical="4dp">
 
                     <ImageView
                         android:id="@+id/courseLengthIcon"
@@ -123,9 +116,6 @@
                     android:textSize="13sp"
                     android:textStyle="bold"
                     android:visibility="@{course.distance != null ? View.VISIBLE : View.GONE}"
-                    app:layout_constraintBottom_toBottomOf="@id/courseLength"
-                    app:layout_constraintStart_toEndOf="@id/courseLength"
-                    app:layout_constraintTop_toTopOf="@id/courseLength"
                     tools:text="10m만큼 떨어짐" />
             </LinearLayout>
         </HorizontalScrollView>

--- a/android/app/src/main/res/layout/item_course.xml
+++ b/android/app/src/main/res/layout/item_course.xml
@@ -56,70 +56,79 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="석촌 호수 뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑뺑이" />
 
-        <LinearLayout
+        <HorizontalScrollView
             android:id="@+id/courseInfoChips"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
+            android:layout_marginEnd="8dp"
+            android:scrollbars="none"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@id/courseNavigationButton"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/courseName">
 
             <LinearLayout
-                android:id="@+id/courseLength"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:background="@drawable/background_course_detail"
-                android:gravity="center_vertical"
-                android:paddingHorizontal="10dp"
-                android:paddingVertical="4dp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
                 app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/courseNavigationButton"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/courseName">
 
-                <ImageView
-                    android:id="@+id/courseLengthIcon"
+                <LinearLayout
+                    android:id="@+id/courseLength"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:src="@drawable/icon_length" />
+                    android:layout_height="match_parent"
+                    android:background="@drawable/background_course_detail"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="10dp"
+                    android:paddingVertical="4dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/courseName">
+
+                    <ImageView
+                        android:id="@+id/courseLengthIcon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:src="@drawable/icon_length" />
+
+                    <TextView
+                        android:id="@+id/courseLengthText"
+                        courseLength="@{course.length}"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="6dp"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textColor="@color/item_primary"
+                        android:textSize="13sp"
+                        android:textStyle="bold"
+                        tools:text="5km" />
+                </LinearLayout>
 
                 <TextView
-                    android:id="@+id/courseLengthText"
-                    courseLength="@{course.length}"
+                    android:id="@+id/courseDistance"
+                    courseDistance="@{course.distance}"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="6dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="8dp"
+                    android:background="@drawable/background_course_detail"
                     android:ellipsize="end"
                     android:maxLines="1"
-                    android:textColor="@color/item_primary"
+                    android:paddingHorizontal="10dp"
+                    android:paddingVertical="4dp"
+                    android:textColor="@color/point_primary"
                     android:textSize="13sp"
                     android:textStyle="bold"
-                    tools:text="5km" />
+                    android:visibility="@{course.distance != null ? View.VISIBLE : View.GONE}"
+                    app:layout_constraintBottom_toBottomOf="@id/courseLength"
+                    app:layout_constraintStart_toEndOf="@id/courseLength"
+                    app:layout_constraintTop_toTopOf="@id/courseLength"
+                    tools:text="10m만큼 떨어짐" />
             </LinearLayout>
-
-            <TextView
-                android:id="@+id/courseDistance"
-                courseDistance="@{course.distance}"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:layout_marginStart="8dp"
-                android:background="@drawable/background_course_detail"
-                android:ellipsize="end"
-                android:maxLines="1"
-                android:paddingHorizontal="10dp"
-                android:paddingVertical="4dp"
-                android:textColor="@color/point_primary"
-                android:textSize="13sp"
-                android:textStyle="bold"
-                android:visibility="@{course.distance != null ? View.VISIBLE : View.GONE}"
-                app:layout_constraintBottom_toBottomOf="@id/courseLength"
-                app:layout_constraintStart_toEndOf="@id/courseLength"
-                app:layout_constraintTop_toTopOf="@id/courseLength"
-                tools:text="10m만큼 떨어짐" />
-
-        </LinearLayout>
-
+        </HorizontalScrollView>
 
         <TextView
             android:id="@+id/courseNavigationButton"


### PR DESCRIPTION
## 🛠️ 설명
폰트 크기 설정이나 코스 정보의 길이 등과 무관하게 코스 정보 칩 전체를 볼 수 있도록 코스 정보 칩에 좌우 스크롤을 추가됐습니다.


## 📸 스크린샷 / 동영상
<table>
  <tr>
    <th>As-is</th>
    <th>To-be</th>
  </tr>
  <tr>
    <td><img alt="image" src="https://github.com/user-attachments/assets/5191690e-40d3-494b-9d3f-4eb3726f1a1a"></td>
    <td><video src="https://github.com/user-attachments/assets/cd777edb-6e4f-4be3-977b-6f74599aeff5"></video></td>
  </tr>
</table>


## 🔗 관련 이슈
- closes #957


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 코스 길이 및 거리 정보 표시 영역에 가로 스크롤 기능이 추가되어, 콘텐츠가 화면을 초과할 경우 스크롤로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->