### PR TITLE
나의 코스 삭제 기능

### DIFF
--- a/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
+++ b/backend/src/main/java/coursepick/coursepick/application/CourseApplicationService.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +41,14 @@ public class CourseApplicationService {
 
         Course newCourse = new Course(null, courseName, coordinates, user);
         courseRepository.save(newCourse);
+    }
+
+    @Transactional
+    public void deleteCourse(String courseId, String userId) {
+        Course course = getCourse(courseId);
+        course.verifyDeletable(userId);
+
+        courseRepository.delete(course);
     }
 
     @Transactional

--- a/backend/src/main/java/coursepick/coursepick/application/dto/CourseDetailResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/application/dto/CourseDetailResponse.java
@@ -15,7 +15,8 @@ public record CourseDetailResponse(
         int reviewCount,
         double averageRating,
         List<ReviewResponse> reviews,
-        List<CourseTag> tags
+        List<CourseTag> tags,
+        String creatorId
 ) {
     public static CourseDetailResponse from(Course course) {
         return new CourseDetailResponse(
@@ -26,7 +27,8 @@ public record CourseDetailResponse(
                 course.reviews().size(),
                 course.calculateAverageRating(),
                 ReviewResponse.from(course.reviews()),
-                course.tags()
+                course.tags(),
+                course.creatorId()
         );
     }
 }

--- a/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
+++ b/backend/src/main/java/coursepick/coursepick/domain/course/Course.java
@@ -131,6 +131,12 @@ public class Course {
         }
     }
 
+    public void verifyDeletable(String userId) {
+        if (!creatorId.equals(userId)) {
+            throw AUTHENTICATION_FAIL.create();
+        }
+    }
+
     public void addReport(User user) {
         if (reportUserIds.contains(user.id())) {
             throw ALREADY_REPORTED_COURSE.create(this.id, user.id());

--- a/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/CourseV1WebController.java
@@ -107,6 +107,12 @@ public class CourseV1WebController {
         courseApplicationService.addCustomCourse(request.name(), request.toCoordinates(), userId);
     }
 
+    @Login
+    @DeleteMapping("/courses/{id}")
+    public void deleteCourse(@PathVariable("id") String id, @UserId String userId) {
+        courseApplicationService.deleteCourse(id, userId);
+    }
+
     @PostMapping("/courses/draft/route")
     public DraftRouteWebResponse findDraftRoute(@Valid @RequestBody FindDraftRouteWebRequest request) {
         DraftSegment route = courseApplicationService.findDraftRoute(request.toCoordinates());

--- a/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseDetailWebResponse.java
+++ b/backend/src/main/java/coursepick/coursepick/presentation/dto/CourseDetailWebResponse.java
@@ -11,7 +11,8 @@ public record CourseDetailWebResponse(
         List<CoordinateWebResponse> coordinates,
         ReviewOverviewWebResponse reviewOverview,
         List<ReviewWebResponse> reviews,
-        List<CourseTagWebResponse> tags
+        List<CourseTagWebResponse> tags,
+        String creatorId
 ) {
     public static CourseDetailWebResponse from(CourseDetailResponse response) {
         return new CourseDetailWebResponse(
@@ -21,7 +22,8 @@ public record CourseDetailWebResponse(
                 CoordinateWebResponse.from(response.coordinates()),
                 ReviewOverviewWebResponse.from(response.reviewCount(), response.averageRating()),
                 ReviewWebResponse.from(response.reviews()),
-                CourseTagWebResponse.from(response.tags())
+                CourseTagWebResponse.from(response.tags()),
+                response.creatorId()
         );
     }
 }

--- a/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
+++ b/backend/src/test/java/coursepick/coursepick/application/CourseApplicationServiceTest.java
@@ -321,6 +321,34 @@ class CourseApplicationServiceTest extends AbstractIntegrationTest {
     }
 
     @Nested
+    class 나의_코스_삭제 {
+
+        @Test
+        void 내가_만든_코스를_삭제한다() {
+            var course = dbUtil.saveCourse(createCourse("내 코스", 한강_좌표, TEST_USER));
+
+            sut.deleteCourse(course.id(), TEST_USER.id());
+
+            assertThat(dbUtil.findCourseById(course.id())).isNull();
+        }
+
+        @Test
+        void 다른_사람이_만든_코스는_삭제할_수_없다() {
+            var course = dbUtil.saveCourse(createCourse("남의 코스", 한강_좌표, TEST_USER2));
+
+            assertThatThrownBy(() -> sut.deleteCourse(course.id(), TEST_USER.id()))
+                    .isInstanceOf(UnauthorizedException.class);
+            assertThat(dbUtil.findCourseById(course.id())).isNotNull();
+        }
+
+        @Test
+        void 존재하지_않는_코스를_삭제하면_예외가_발생한다() {
+            assertThatThrownBy(() -> sut.deleteCourse("notExistCourseId", TEST_USER.id()))
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+    }
+
+    @Nested
     class 유저_코스_생성 {
 
         @Test

--- a/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
+++ b/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
@@ -425,7 +425,6 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
         }
 
 
-
         @Test
         void 커스텀_코스_생성_API() throws Exception {
             doNothing().when(courseApplicationService).addCustomCourse(anyString(), anyList(), anyString());
@@ -465,6 +464,29 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
                                                     .description(경도)
                                                     .attributes(key("example")
                                                             .value("127.103611")))
+                                    .build())));
+        }
+
+        @Test
+        void 코스_삭제_API() throws Exception {
+            doNothing().when(courseApplicationService).deleteCourse(anyString(), anyString());
+
+            mockMvc.perform(delete("/v1/courses/{id}", "689c3143182cecc6353cca7b")
+                            .header("Authorization", "Bearer " + "test.jwt.token")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andDo(MockMvcRestDocumentationWrapper.document("course-delete",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            resource(ResourceSnippetParameters.builder()
+                                    .tag(TAG)
+                                    .summary("코스 삭제")
+                                    .description("내가 생성한 코스를 삭제합니다. (로그인 필요)")
+                                    .pathParameters(
+                                            parameterWithName("id")
+                                                    .description(코스_ID)
+                                                    .attributes(key("example")
+                                                            .value("689c3143182cecc6353cca7b")))
                                     .build())));
         }
 

--- a/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
+++ b/backend/src/test/java/coursepick/coursepick/docs/CourseApiDocsTest.java
@@ -241,7 +241,8 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
                     5.0,
                     List.of(new ReviewResponse("69d8c0b54561463adc32f259", "착한 강아지",
                             "69d8c0b12361463adc32f259", "노을이 예뻐요.", 5)),
-                    List.of(CourseTag.NIGHT_VIEW, CourseTag.SCENIC)
+                    List.of(CourseTag.NIGHT_VIEW, CourseTag.SCENIC),
+                    "69d8c0b12361463adc32f259"
             );
             given(courseApplicationService.findCourseDetail(anyString()))
                     .willReturn(detailResponse);
@@ -285,7 +286,8 @@ class CourseApiDocsTest extends AbstractApiDocsSupport {
                                             fieldWithPath("reviews[].content")
                                                     .description(리뷰_내용),
                                             fieldWithPath("tags[].name").description("태그 이름 (enum 값)"),
-                                            fieldWithPath("tags[].label").description("태그 라벨 (UI 표시용)")
+                                            fieldWithPath("tags[].label").description("태그 라벨 (UI 표시용)"),
+                                            fieldWithPath("creatorId").description(코스_등록_주체_ID)
                                     )
                                     .build())));
         }

--- a/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
+++ b/backend/src/test/java/coursepick/coursepick/domain/course/CourseTest.java
@@ -1,9 +1,6 @@
 package coursepick.coursepick.domain.course;
 
 import coursepick.coursepick.application.exception.UnauthorizedException;
-import coursepick.coursepick.domain.user.Nickname;
-import coursepick.coursepick.domain.user.User;
-import coursepick.coursepick.domain.user.UserProvider;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -136,6 +133,26 @@ class CourseTest {
             course.addReport(TEST_USER3);
 
             assertThat(course.isReportThreshold()).isTrue();
+        }
+    }
+
+    @Nested
+    class 나의코스삭제_테스트 {
+
+        @Test
+        void 작성자가_본인이면_삭제할_수_있다() {
+            var course = createCourse("코스", of(new Coordinate(0, 0), new Coordinate(2, 2)), TEST_USER);
+
+            assertThatCode(() -> course.verifyDeletable(TEST_USER.id()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void 작성자가_아니면_삭제할_수_없다() {
+            var course = createCourse("코스", of(new Coordinate(0, 0), new Coordinate(2, 2)), TEST_USER);
+
+            assertThatThrownBy(() -> course.verifyDeletable(TEST_USER2.id()))
+                    .isInstanceOf(UnauthorizedException.class);
         }
     }
 


### PR DESCRIPTION
## 🛠️ 설명
내가 생성한 코스를 삭제하는 기능을 추가했습니다.

`DELETE /v1/courses/{id}` API로, 
로그인한 사용자가 본인이 작성한 코스만 삭제할 수 있습니다.

- 도메인: Course.verifyDeletable(userId) — 코스 작성자 본인인지 검증, 본인이 아니면 UnauthorizedException 발생
- 서비스: CourseApplicationService.deleteCourse(courseId, userId) — 코스 조회 → 본인 검증 → 삭제
- API: CourseV1WebController에 @Login 적용한 DELETE /v1/courses/{id} 엔드포인트 추가

## 🔗 관련 이슈

- closes #976 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 코스 상세 응답에 작성자 정보가 추가되었습니다.
  * 로그인한 사용자가 자신의 코스를 삭제할 수 있는 기능이 추가되었습니다.
  * 코스 삭제 API가 새로 제공됩니다.

* **Bug Fixes**
  * 작성자가 아닌 사용자의 삭제 요청은 거부되도록 권한 검증이 강화되었습니다.
  * 존재하지 않는 코스 삭제 시 예외 처리가 명확해졌습니다.

* **Tests**
  * 코스 삭제 및 상세 응답 변경에 대한 테스트와 API 문서가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->