### PR TITLE
나의 코스 삭제 기능 추가

### DIFF
--- a/android/app/src/main/java/io/coursepick/coursepick/data/course/CourseDetailDto.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/course/CourseDetailDto.kt
@@ -3,21 +3,24 @@ package io.coursepick.coursepick.data.course
 import io.coursepick.coursepick.domain.course.CourseDetail
 import io.coursepick.coursepick.domain.course.CourseName
 import io.coursepick.coursepick.domain.course.Length
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class CourseDetailDto(
-    val id: String,
-    val name: String,
-    val length: Double,
-    val coordinates: List<CoordinateDto>,
-    val reviewOverview: ReviewOverviewDto,
-    val tags: List<TagDto>,
-    val reviews: List<CourseReviewDto>,
+    @SerialName("id") val courseId: String,
+    @SerialName("creatorId") val creatorId: String = "", // TODO: 백엔드 API 추가될 시 기본값 제거
+    @SerialName("name") val name: String,
+    @SerialName("length") val length: Double,
+    @SerialName("coordinates") val coordinates: List<CoordinateDto>,
+    @SerialName("reviewOverview") val reviewOverview: ReviewOverviewDto,
+    @SerialName("tags") val tags: List<TagDto>,
+    @SerialName("reviews") val reviews: List<CourseReviewDto>,
 ) {
     fun toCourseDetail(): CourseDetail =
         CourseDetail(
-            id = id,
+            courseId = courseId,
+            creatorId = creatorId,
             name = CourseName(name),
             length = Length(length),
             coordinates = coordinates.map(CoordinateDto::toCoordinate),

--- a/android/app/src/main/java/io/coursepick/coursepick/data/customcourse/CustomCourseService.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/customcourse/CustomCourseService.kt
@@ -2,8 +2,10 @@ package io.coursepick.coursepick.data.customcourse
 
 import io.coursepick.coursepick.data.course.CoursesPageDto
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface CustomCourseService {
@@ -15,6 +17,11 @@ interface CustomCourseService {
     @POST("/v1/courses")
     suspend fun submitCourse(
         @Body course: DraftCourseDto,
+    )
+
+    @DELETE("/v1/courses/{id}")
+    suspend fun deleteCourse(
+        @Path("id") courseId: String,
     )
 
     @GET("/v1/courses/custom")

--- a/android/app/src/main/java/io/coursepick/coursepick/data/customcourse/DefaultCustomCourseRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/data/customcourse/DefaultCustomCourseRepository.kt
@@ -29,6 +29,10 @@ class DefaultCustomCourseRepository
             service.submitCourse(DraftCourseDto(course))
         }
 
+        override suspend fun deleteCourse(courseId: String) {
+            service.deleteCourse(courseId)
+        }
+
         override suspend fun customCourses(userCoordinate: Coordinate?): CoursesPage =
             service
                 .customCourses(

--- a/android/app/src/main/java/io/coursepick/coursepick/domain/course/CourseDetail.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/domain/course/CourseDetail.kt
@@ -1,7 +1,8 @@
 package io.coursepick.coursepick.domain.course
 
 data class CourseDetail(
-    val id: String,
+    val courseId: String,
+    val creatorId: String,
     val name: CourseName,
     val length: Length,
     val coordinates: List<Coordinate>,

--- a/android/app/src/main/java/io/coursepick/coursepick/domain/customcourse/CustomCourseRepository.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/domain/customcourse/CustomCourseRepository.kt
@@ -11,5 +11,7 @@ interface CustomCourseRepository {
 
     suspend fun submitCourse(course: DraftCourse)
 
+    suspend fun deleteCourse(courseId: String)
+
     suspend fun customCourses(userCoordinate: Coordinate?): CoursesPage
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseItemListener.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseItemListener.kt
@@ -1,11 +1,11 @@
 package io.coursepick.coursepick.presentation.course
 
 interface CourseItemListener {
-    fun select(course: CourseItem)
+    fun select(course: CourseUiModel)
 
-    fun toggleFavorite(course: CourseItem)
+    fun toggleFavorite(course: CourseUiModel)
 
-    fun navigateToCourse(course: CourseItem)
+    fun navigateToCourse(course: CourseUiModel)
 
-    fun navigateToDetail(course: CourseItem)
+    fun navigateToDetail(course: CourseUiModel)
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseListItem.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseListItem.kt
@@ -6,7 +6,7 @@ sealed class CourseListItem(
     val viewType: Int = itemViewType.ordinal
 
     data class Course(
-        val item: CourseItem,
+        val item: CourseUiModel,
     ) : CourseListItem(ItemViewType.COURSE)
 
     data object Loading : CourseListItem(ItemViewType.LOADING)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseUiModel.kt
@@ -3,7 +3,7 @@ package io.coursepick.coursepick.presentation.course
 import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.course.Course
 
-data class CourseItem(
+data class CourseUiModel(
     val course: Course,
     val selected: Boolean,
     val favorite: Boolean = false,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseViewHolder.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CourseViewHolder.kt
@@ -13,7 +13,7 @@ class CourseViewHolder private constructor(
         binding.courseItemListener = courseItemListener
     }
 
-    fun bind(course: CourseItem) {
+    fun bind(course: CourseUiModel) {
         binding.course = course
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -58,7 +58,7 @@ import io.coursepick.coursepick.presentation.InstallStateObserver
 import io.coursepick.coursepick.presentation.Logger
 import io.coursepick.coursepick.presentation.compat.OnReconnectListener
 import io.coursepick.coursepick.presentation.coursedetail.CourseDetailActivity
-import io.coursepick.coursepick.presentation.customcourse.CustomCourseItem
+import io.coursepick.coursepick.presentation.customcourse.CustomCourseUiModel
 import io.coursepick.coursepick.presentation.customcourse.CustomCourseViewModel
 import io.coursepick.coursepick.presentation.customcourse.CustomCoursesFragment
 import io.coursepick.coursepick.presentation.customcourse.toCourseUiModel
@@ -707,9 +707,9 @@ class CoursesActivity :
                 customCourseViewModel.state
                     .map { it.selectedCustomCourse }
                     .distinctUntilChanged()
-                    .collect { customCourseItem: CustomCourseItem? ->
-                        customCourseItem?.let {
-                            val courseItem = customCourseItem.toCourseUiModel()
+                    .collect { customCourse: CustomCourseUiModel? ->
+                        customCourse?.let {
+                            val courseItem = customCourse.toCourseUiModel()
                             viewModel.selectExternalCourse(courseItem)
                         }
                     }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesActivity.kt
@@ -61,7 +61,7 @@ import io.coursepick.coursepick.presentation.coursedetail.CourseDetailActivity
 import io.coursepick.coursepick.presentation.customcourse.CustomCourseItem
 import io.coursepick.coursepick.presentation.customcourse.CustomCourseViewModel
 import io.coursepick.coursepick.presentation.customcourse.CustomCoursesFragment
-import io.coursepick.coursepick.presentation.customcourse.toCourseItem
+import io.coursepick.coursepick.presentation.customcourse.toCourseUiModel
 import io.coursepick.coursepick.presentation.favorites.FavoriteCoursesFragment
 import io.coursepick.coursepick.presentation.filter.CourseFilterBottomSheet
 import io.coursepick.coursepick.presentation.map.CameraMoveReason
@@ -102,7 +102,7 @@ class CoursesActivity :
 
     private val courseItemListener =
         object : CourseItemListener {
-            override fun select(course: CourseItem) {
+            override fun select(course: CourseUiModel) {
                 Logger.log(
                     Logger.Event.Click("course_on_list"),
                     "id" to course.id,
@@ -111,15 +111,15 @@ class CoursesActivity :
                 viewModel.select(course)
             }
 
-            override fun toggleFavorite(course: CourseItem) {
+            override fun toggleFavorite(course: CourseUiModel) {
                 viewModel.toggleFavorite(course)
             }
 
-            override fun navigateToCourse(course: CourseItem) {
+            override fun navigateToCourse(course: CourseUiModel) {
                 this@CoursesActivity.navigateToCourse(course)
             }
 
-            override fun navigateToDetail(course: CourseItem) {
+            override fun navigateToDetail(course: CourseUiModel) {
                 startActivity(CourseDetailActivity.intent(this@CoursesActivity, course.id))
             }
         }
@@ -166,7 +166,7 @@ class CoursesActivity :
                 }
             }
 
-            mapManager.setOnCourseClickListener { course: CourseItem ->
+            mapManager.setOnCourseClickListener { course: CourseUiModel ->
                 viewModel.select(course)
             }
 
@@ -398,7 +398,7 @@ class CoursesActivity :
         }
     }
 
-    fun navigateToCourse(course: CourseItem) {
+    fun navigateToCourse(course: CourseUiModel) {
         Logger.log(
             Logger.Event.Click("navigate"),
             "id" to course.id,
@@ -709,7 +709,7 @@ class CoursesActivity :
                     .distinctUntilChanged()
                     .collect { customCourseItem: CustomCourseItem? ->
                         customCourseItem?.let {
-                            val courseItem = customCourseItem.toCourseItem()
+                            val courseItem = customCourseItem.toCourseUiModel()
                             viewModel.selectExternalCourse(courseItem)
                         }
                     }
@@ -721,7 +721,7 @@ class CoursesActivity :
         viewModel.state.observe(this) { state: CoursesUiState ->
             courseAdapter.submitList(state.courses)
             mapManager.clearRoute()
-            val courses: List<CourseItem> =
+            val courses: List<CourseUiModel> =
                 state.courses
                     .filterIsInstance<CourseListItem.Course>()
                     .map(CourseListItem.Course::item)
@@ -853,7 +853,7 @@ class CoursesActivity :
                         )
                     }
 
-                    viewModel.routeFinderDialogCourse.collectAsStateWithLifecycle().value?.let { course: CourseItem ->
+                    viewModel.routeFinderDialogCourse.collectAsStateWithLifecycle().value?.let { course: CourseUiModel ->
                         RouteFinderDialog(
                             onConfirm = { routeFinder: RouteFinder, rememberSelection: Boolean ->
                                 viewModel.onRouteFinderSelected(course, routeFinder, rememberSelection)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiEvent.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesUiEvent.kt
@@ -7,16 +7,16 @@ sealed interface CoursesUiEvent {
     object FetchCourseFailure : CoursesUiEvent
 
     class SelectCourseManually(
-        val course: CourseItem,
+        val course: CourseUiModel,
     ) : CoursesUiEvent
 
     class FetchRouteToCourseSuccess(
         val route: List<Coordinate>,
-        val course: CourseItem,
+        val course: CourseUiModel,
     ) : CoursesUiEvent
 
     class LaunchThirdPartyRouteFinder(
-        val course: CourseItem,
+        val course: CourseUiModel,
         val origin: Coordinate,
         val destination: Coordinate,
         val routeFinder: RouteFinder.ThirdParty,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/CoursesViewModel.kt
@@ -68,8 +68,8 @@ class CoursesViewModel
                 initialValue = null,
             )
 
-        private val _routeFinderDialogCourse = MutableStateFlow<CourseItem?>(null)
-        val routeFinderDialogCourse: StateFlow<CourseItem?> get() = _routeFinderDialogCourse.asStateFlow()
+        private val _routeFinderDialogCourse = MutableStateFlow<CourseUiModel?>(null)
+        val routeFinderDialogCourse: StateFlow<CourseUiModel?> get() = _routeFinderDialogCourse.asStateFlow()
 
         private val _event: MutableSingleLiveData<CoursesUiEvent> = MutableSingleLiveData()
         val event: SingleLiveData<CoursesUiEvent> get() = _event
@@ -98,22 +98,22 @@ class CoursesViewModel
             collectFavorites()
         }
 
-        fun selectExternalCourse(courseItem: CourseItem) {
-            syncExternalSelectedCourse(courseItem)
-            _event.value = CoursesUiEvent.SelectCourseManually(courseItem)
+        fun selectExternalCourse(course: CourseUiModel) {
+            syncExternalSelectedCourse(course)
+            _event.value = CoursesUiEvent.SelectCourseManually(course)
         }
 
-        private fun syncExternalSelectedCourse(courseItem: CourseItem) {
+        private fun syncExternalSelectedCourse(course: CourseUiModel) {
             _state.value =
                 _state.value?.copy(
                     courses =
                         _state.value?.courses?.let { oldList: List<CourseListItem> ->
                             val hasCourse: Boolean =
-                                oldList.any { it is CourseListItem.Course && it.item.id == courseItem.id }
+                                oldList.any { it is CourseListItem.Course && it.item.id == course.id }
                             if (hasCourse) {
                                 oldList.map { item ->
                                     if (item is CourseListItem.Course) {
-                                        CourseListItem.Course(item.item.copy(selected = item.item.id == courseItem.id))
+                                        CourseListItem.Course(item.item.copy(selected = item.item.id == course.id))
                                     } else {
                                         item
                                     }
@@ -131,9 +131,9 @@ class CoursesViewModel
                                             item
                                         }
                                     }
-                                listOf(CourseListItem.Course(courseItem)) + clearedList
+                                listOf(CourseListItem.Course(course)) + clearedList
                             }
-                        } ?: listOf(CourseListItem.Course(courseItem)),
+                        } ?: listOf(CourseListItem.Course(course)),
                     status = UiStatus.Success,
                 )
         }
@@ -173,7 +173,7 @@ class CoursesViewModel
             mapCoordinate = coordinate
         }
 
-        fun select(course: CourseItem) {
+        fun select(course: CourseUiModel) {
             if (course.selected) {
                 _event.value = CoursesUiEvent.SelectCourseManually(course)
                 return
@@ -189,7 +189,7 @@ class CoursesViewModel
             _event.value = CoursesUiEvent.SelectCourseManually(course)
         }
 
-        fun toggleFavorite(toggledCourse: CourseItem) {
+        fun toggleFavorite(toggledCourse: CourseUiModel) {
             viewModelScope.launch {
                 if (toggledCourse.favorite) {
                     favoriteCourseRepository.removeFavorite(toggledCourse.id)
@@ -236,11 +236,11 @@ class CoursesViewModel
                 }.onSuccess { coursesPage: CoursesPage ->
                     Logger.log(Logger.Event.Success("fetch_courses_new"))
 
-                    val courseItems: List<CourseItem> =
+                    val courses: List<CourseUiModel> =
                         coursesPage.courses
                             .sortedBy(Course::distance)
                             .mapIndexed { index, course ->
-                                CourseItem(
+                                CourseUiModel(
                                     course = course,
                                     selected = index == 0,
                                     favorite = favoriteCourseIds.value.contains(course.id),
@@ -256,7 +256,7 @@ class CoursesViewModel
 
                     _state.value =
                         state.value?.copy(
-                            courses = courseItems.map(CourseListItem::Course),
+                            courses = courses.map(CourseListItem::Course),
                             status = UiStatus.Success,
                         )
                 }.onFailure { exception: Throwable ->
@@ -329,7 +329,7 @@ class CoursesViewModel
                     val newCourses =
                         coursesPage.courses.map { course: Course ->
                             CourseListItem.Course(
-                                CourseItem(
+                                CourseUiModel(
                                     course = course,
                                     selected = false,
                                     favorite = favoriteCourseIds.value.contains(course.id),
@@ -385,9 +385,9 @@ class CoursesViewModel
                 runCatching {
                     courseRepository.courses(favoriteCourseIds.value.toList())
                 }.onSuccess { courses: List<Course> ->
-                    val courseItems: List<CourseItem> =
+                    val courseItems: List<CourseUiModel> =
                         courses.map { course: Course ->
-                            CourseItem(
+                            CourseUiModel(
                                 course = course,
                                 selected = false,
                                 favorite = true,
@@ -424,7 +424,7 @@ class CoursesViewModel
             }
         }
 
-        fun onNavigateToCourse(course: CourseItem) {
+        fun onNavigateToCourse(course: CourseUiModel) {
             if (!locationRepository.isFineLocationPermissionGranted) {
                 _event.value = CoursesUiEvent.RequireFineLocationPermission
                 return
@@ -437,7 +437,7 @@ class CoursesViewModel
         }
 
         fun onRouteFinderSelected(
-            course: CourseItem,
+            course: CourseUiModel,
             routeFinder: RouteFinder,
             rememberSelection: Boolean,
         ) {
@@ -456,13 +456,13 @@ class CoursesViewModel
         }
 
         private fun navigateToCourse(
-            course: CourseItem,
+            course: CourseUiModel,
             routeFinder: RouteFinder,
         ) {
             val oldCourses: List<CourseListItem> = state.value?.courses ?: return
             val newCourseItems: List<CourseListItem> = newCoursesListItem(oldCourses, course)
             _state.value = state.value?.copy(courses = newCourseItems, status = UiStatus.Loading)
-            val selectedCourse: CourseItem = course.copy(selected = true)
+            val selectedCourse: CourseUiModel = course.copy(selected = true)
 
             viewModelScope.launch {
                 currentLocation()?.let { location: Location ->
@@ -487,7 +487,7 @@ class CoursesViewModel
         }
 
         private fun fetchRouteToCourse(
-            course: CourseItem,
+            course: CourseUiModel,
             origin: Coordinate,
         ) {
             viewModelScope.launch {
@@ -514,7 +514,7 @@ class CoursesViewModel
         }
 
         private fun launchThirdPartyRouteFinder(
-            course: CourseItem,
+            course: CourseUiModel,
             origin: Coordinate,
             routeFinder: RouteFinder.ThirdParty,
         ) {
@@ -639,7 +639,7 @@ class CoursesViewModel
 
         private fun newCoursesListItem(
             oldCourses: List<CourseListItem>,
-            selectedCourse: CourseItem,
+            selectedCourse: CourseUiModel,
         ): List<CourseListItem> =
             oldCourses.map { courseListItem: CourseListItem ->
                 if (courseListItem is CourseListItem.Course) {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/course/ExploreCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/course/ExploreCoursesFragment.kt
@@ -84,10 +84,10 @@ class ExploreCoursesFragment(
         )
     }
 
-    fun scrollTo(courseItem: CourseItem) {
+    fun scrollTo(course: CourseUiModel) {
         val position =
             courseAdapter.currentList.indexOfFirst { item: CourseListItem ->
-                item is CourseListItem.Course && item.item.id == courseItem.id
+                item is CourseListItem.Course && item.item.id == course.id
             }
         if (position == -1) return
         val layoutManager = binding.exploreCourses.layoutManager as? LinearLayoutManager ?: return

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailActivity.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailActivity.kt
@@ -47,6 +47,10 @@ class CourseDetailActivity : ComponentActivity() {
                                 navigateToWriteCourseReview = { courseDetail: CourseDetailUiModel ->
                                     backstack.add(CourseDetailRoute.WriteReview(courseDetail))
                                 },
+                                onCourseDeleted = {
+                                    setResult(RESULT_OK)
+                                    finish()
+                                },
                                 viewModel = courseDetailViewModel,
                             )
                         }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
@@ -648,6 +648,7 @@ private fun CourseDetailScreenPreview_Success_EmptyReview() {
                         tags = emptyList(),
                         reviews = emptyList(),
                         isFavorite = false,
+                        isMine = false,
                     ),
             ),
         onNavigateBack = { },
@@ -686,6 +687,7 @@ private fun CourseDetailScreenPreview_Success_NonEmptyReviews() {
                                 )
                             },
                         isFavorite = false,
+                        isMine = false,
                     ),
             ),
         onNavigateBack = { },

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
@@ -70,6 +70,7 @@ fun CourseDetailScreen(
     courseId: String,
     navigateBack: () -> Unit,
     navigateToWriteCourseReview: (CourseDetailUiModel) -> Unit,
+    onCourseDeleted: () -> Unit,
     viewModel: CourseDetailViewModel = viewModel(),
 ) {
     val context: Context = LocalContext.current
@@ -80,7 +81,7 @@ fun CourseDetailScreen(
 
     LaunchedEffect(Unit) {
         viewModel.uiEvent.collect { event: CourseDetailViewModel.UiEvent ->
-            event.handle(context, navigateBack, navigateToWriteCourseReview)
+            event.handle(context, navigateToWriteCourseReview, onCourseDeleted)
         }
     }
 
@@ -115,8 +116,8 @@ fun CourseDetailScreen(
 
 private fun CourseDetailViewModel.UiEvent.handle(
     context: Context,
-    navigateBack: () -> Unit,
     navigateToWriteCourseReview: (CourseDetailUiModel) -> Unit,
+    onCourseDeleted: () -> Unit,
 ) {
     when (this) {
         CourseDetailViewModel.UiEvent.AuthenticationSuccess -> {
@@ -176,7 +177,7 @@ private fun CourseDetailViewModel.UiEvent.handle(
         }
 
         CourseDetailViewModel.UiEvent.Exit -> {
-            navigateBack()
+            onCourseDeleted()
         }
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
@@ -633,7 +633,7 @@ private fun CourseDetailScreenDialogs(
 
     if (dialogState.deleteCourseDialog != null) {
         DeleteCustomCourseDialog(
-            courseName = dialogState.deleteCourseDialog,
+            state = dialogState.deleteCourseDialog,
             onDismiss = onDismissDeleteCourseDialog,
             onConfirm = onConfirmDeleteCourseDialog,
         )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
@@ -79,7 +79,9 @@ fun CourseDetailScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.uiEvent.collect { event: CourseDetailViewModel.UiEvent -> event.handle(context, navigateToWriteCourseReview) }
+        viewModel.uiEvent.collect { event: CourseDetailViewModel.UiEvent ->
+            event.handle(context, navigateBack, navigateToWriteCourseReview)
+        }
     }
 
     val state: CourseDetailViewModel.UiState = viewModel.uiState.collectAsStateWithLifecycle().value
@@ -113,6 +115,7 @@ fun CourseDetailScreen(
 
 private fun CourseDetailViewModel.UiEvent.handle(
     context: Context,
+    navigateBack: () -> Unit,
     navigateToWriteCourseReview: (CourseDetailUiModel) -> Unit,
 ) {
     when (this) {
@@ -148,6 +151,10 @@ private fun CourseDetailViewModel.UiEvent.handle(
             Toast.makeText(context, context.getString(R.string.report_course_failure_already_reported_message), Toast.LENGTH_SHORT).show()
         }
 
+        CourseDetailViewModel.UiEvent.DeleteCourseSuccess -> {
+            Toast.makeText(context, context.getString(R.string.delete_custom_course_dialog_success_message), Toast.LENGTH_SHORT).show()
+        }
+
         CourseDetailViewModel.UiEvent.DeleteReviewSuccess -> {
             Toast.makeText(context, context.getString(R.string.delete_review_success_message), Toast.LENGTH_SHORT).show()
         }
@@ -166,6 +173,10 @@ private fun CourseDetailViewModel.UiEvent.handle(
 
         CourseDetailViewModel.UiEvent.CourseAlreadyReviewed -> {
             Toast.makeText(context, context.getString(R.string.write_course_review_already_reviewed_message), Toast.LENGTH_SHORT).show()
+        }
+
+        CourseDetailViewModel.UiEvent.Exit -> {
+            navigateBack()
         }
     }
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailScreen.kt
@@ -63,6 +63,7 @@ import io.coursepick.coursepick.R
 import io.coursepick.coursepick.data.auth.KakaoAuthenticator
 import io.coursepick.coursepick.domain.auth.Authenticator
 import io.coursepick.coursepick.presentation.auth.AuthDialog
+import io.coursepick.coursepick.presentation.customcourse.DeleteCustomCourseDialog
 
 @Composable
 fun CourseDetailScreen(
@@ -88,6 +89,7 @@ fun CourseDetailScreen(
         onNavigateBack = navigateBack,
         onToggleFavorite = viewModel::toggleFavorite,
         onReportCourse = viewModel::onReportCourse,
+        onDeleteCourse = viewModel::onDeleteCourse,
         onDeleteReview = viewModel::onDeleteReview,
         onReportReview = viewModel::onReportReview,
         onWriteReview = viewModel::onWriteReview,
@@ -100,6 +102,8 @@ fun CourseDetailScreen(
         onConfirmAuthDialog = viewModel::signIn,
         onDismissReportCourseDialog = viewModel::dismissReportCourseDialog,
         onConfirmReportCourseDialog = viewModel::submitCourseReport,
+        onDismissDeleteCourseDialog = viewModel::dismissDeleteCourseDialog,
+        onConfirmDeleteCourseDialog = viewModel::confirmDeleteCourse,
         onDismissDeleteReviewDialog = viewModel::dismissDeleteReviewDialog,
         onConfirmDeleteReviewDialog = viewModel::confirmDeleteReview,
         onDismissReportReviewDialog = viewModel::dismissReportReviewDialog,
@@ -172,6 +176,7 @@ private fun CourseDetailScreen(
     onNavigateBack: () -> Unit,
     onToggleFavorite: () -> Unit,
     onReportCourse: () -> Unit,
+    onDeleteCourse: () -> Unit,
     onDeleteReview: (CourseReviewUiModel) -> Unit,
     onReportReview: (CourseReviewUiModel) -> Unit,
     onWriteReview: () -> Unit,
@@ -205,8 +210,10 @@ private fun CourseDetailScreen(
         topBar = {
             TopAppBar(
                 navigateBack = onNavigateBack,
-                canReportCourse = uiState is CourseDetailViewModel.UiState.Success,
+                isMyCourse = uiState is CourseDetailViewModel.UiState.Success && uiState.data.isMine,
+                isActionEnabled = uiState is CourseDetailViewModel.UiState.Success,
                 onReportCourse = onReportCourse,
+                onDeleteCourse = onDeleteCourse,
             )
         },
         floatingActionButton = {
@@ -301,8 +308,10 @@ private fun CourseDetailScreen(
 @Composable
 private fun TopAppBar(
     navigateBack: () -> Unit,
-    canReportCourse: Boolean,
+    isMyCourse: Boolean,
+    isActionEnabled: Boolean,
     onReportCourse: () -> Unit,
+    onDeleteCourse: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -324,15 +333,22 @@ private fun TopAppBar(
         },
         actions = {
             Icon(
-                painter = painterResource(R.drawable.icon_report_course),
-                contentDescription = stringResource(R.string.course_detail_report_course_button_description),
-                tint = colorResource(if (canReportCourse) R.color.item_primary else R.color.item_tertiary),
+                painter = painterResource(if (isMyCourse) R.drawable.icon_delete_course else R.drawable.icon_report_course),
+                contentDescription =
+                    stringResource(
+                        if (isMyCourse) {
+                            R.string.course_detail_delete_course_button_description
+                        } else {
+                            R.string.course_detail_report_course_button_description
+                        },
+                    ),
+                tint = colorResource(if (isActionEnabled) R.color.item_primary else R.color.item_tertiary),
                 modifier =
                     Modifier
                         .padding(end = 10.dp)
                         .size(48.dp)
                         .clip(CircleShape)
-                        .clickable(canReportCourse) { onReportCourse() }
+                        .clickable(isActionEnabled) { if (isMyCourse) onDeleteCourse() else onReportCourse() }
                         .padding(8.dp),
             )
         },
@@ -569,6 +585,8 @@ private fun CourseDetailScreenDialogs(
     onConfirmAuthDialog: (Authenticator, CourseDetailViewModel.AuthFeature) -> Unit,
     onDismissReportCourseDialog: () -> Unit,
     onConfirmReportCourseDialog: () -> Unit,
+    onDismissDeleteCourseDialog: () -> Unit,
+    onConfirmDeleteCourseDialog: () -> Unit,
     onDismissDeleteReviewDialog: () -> Unit,
     onConfirmDeleteReviewDialog: (CourseReviewUiModel) -> Unit,
     onDismissReportReviewDialog: () -> Unit,
@@ -580,6 +598,7 @@ private fun CourseDetailScreenDialogs(
         val featureName: String =
             when (dialogState.authDialog) {
                 is CourseDetailViewModel.AuthFeature.ReportCourse -> stringResource(R.string.report_course_feature_name)
+                is CourseDetailViewModel.AuthFeature.DeleteCourse -> stringResource(R.string.course_detail_delete_course_feature_name)
                 is CourseDetailViewModel.AuthFeature.DeleteReview -> stringResource(R.string.delete_review_feature_name)
                 is CourseDetailViewModel.AuthFeature.ReportReview -> stringResource(R.string.report_review_feature_name)
                 is CourseDetailViewModel.AuthFeature.WriteReview -> stringResource(R.string.write_course_review_feature_name)
@@ -597,6 +616,14 @@ private fun CourseDetailScreenDialogs(
             courseName = dialogState.reportCourseDialog,
             onDismiss = onDismissReportCourseDialog,
             onConfirm = onConfirmReportCourseDialog,
+        )
+    }
+
+    if (dialogState.deleteCourseDialog != null) {
+        DeleteCustomCourseDialog(
+            courseName = dialogState.deleteCourseDialog,
+            onDismiss = onDismissDeleteCourseDialog,
+            onConfirm = onConfirmDeleteCourseDialog,
         )
     }
 
@@ -625,6 +652,7 @@ private fun CourseDetailScreenPreview_Loading() {
         onNavigateBack = { },
         onToggleFavorite = { },
         onReportCourse = { },
+        onDeleteCourse = { },
         onDeleteReview = { },
         onReportReview = { },
         onWriteReview = { },
@@ -634,7 +662,37 @@ private fun CourseDetailScreenPreview_Loading() {
 
 @PreviewLightDark
 @Composable
-private fun CourseDetailScreenPreview_Success_EmptyReview() {
+private fun CourseDetailScreenPreview_Success_EmptyReview_MyCourse() {
+    CourseDetailScreen(
+        uiState =
+            CourseDetailViewModel.UiState.Success(
+                data =
+                    CourseDetailUiModel(
+                        id = "",
+                        name = "석촌호수 동호 한바퀴",
+                        length = 0.0,
+                        reviewCount = 0,
+                        averageRating = 4.32F,
+                        tags = emptyList(),
+                        reviews = emptyList(),
+                        isFavorite = false,
+                        isMine = true,
+                    ),
+            ),
+        onNavigateBack = { },
+        onToggleFavorite = { },
+        onReportCourse = { },
+        onDeleteCourse = { },
+        onDeleteReview = { },
+        onReportReview = { },
+        onWriteReview = { },
+        onRetry = { },
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun CourseDetailScreenPreview_Success_EmptyReview_NotMyCourse() {
     CourseDetailScreen(
         uiState =
             CourseDetailViewModel.UiState.Success(
@@ -654,6 +712,7 @@ private fun CourseDetailScreenPreview_Success_EmptyReview() {
         onNavigateBack = { },
         onToggleFavorite = { },
         onReportCourse = { },
+        onDeleteCourse = { },
         onDeleteReview = { },
         onReportReview = { },
         onWriteReview = { },
@@ -693,6 +752,7 @@ private fun CourseDetailScreenPreview_Success_NonEmptyReviews() {
         onNavigateBack = { },
         onToggleFavorite = { },
         onReportCourse = { },
+        onDeleteCourse = { },
         onDeleteReview = { },
         onReportReview = { },
         onWriteReview = { },
@@ -708,6 +768,7 @@ private fun CourseDetailScreenPreview_Failure_NoNetwork() {
         onNavigateBack = { },
         onToggleFavorite = { },
         onReportCourse = { },
+        onDeleteCourse = { },
         onDeleteReview = { },
         onReportReview = { },
         onWriteReview = { },
@@ -723,6 +784,7 @@ private fun CourseDetailScreenPreview_Failure_Unknown() {
         onNavigateBack = { },
         onToggleFavorite = { },
         onReportCourse = { },
+        onDeleteCourse = { },
         onDeleteReview = { },
         onReportReview = { },
         onWriteReview = { },

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailUiModel.kt
@@ -14,6 +14,7 @@ data class CourseDetailUiModel(
     val tags: List<String>,
     val reviews: List<CourseReviewUiModel>,
     val isFavorite: Boolean,
+    val isMine: Boolean,
 )
 
 fun CourseDetail.toUiModel(
@@ -28,4 +29,5 @@ fun CourseDetail.toUiModel(
     tags = tags,
     reviews = reviews.map { review: CourseReview -> review.toUiModel(review.authorId == userId) },
     isFavorite = isFavorite,
+    isMine = creatorId == userId,
 )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailUiModel.kt
@@ -20,7 +20,7 @@ fun CourseDetail.toUiModel(
     isFavorite: Boolean,
     userId: String?,
 ) = CourseDetailUiModel(
-    id = id,
+    id = courseId,
     name = name.value,
     length = length.meter.value,
     reviewCount = reviewCount,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
@@ -57,10 +57,11 @@ class CourseDetailViewModel
                 } else if (courseDetail == null) {
                     UiState.Failure.Unknown
                 } else {
+                    val userId: String? = authRepository.userId()
                     UiState.Success(
                         courseDetail.toUiModel(
                             isFavorite = favoriteCourseIds.contains(courseDetail.courseId),
-                            userId = authRepository.userId(),
+                            userId = userId,
                         ),
                     )
                 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
@@ -130,6 +130,7 @@ class CourseDetailViewModel
                         _uiEvent.emit(UiEvent.AuthenticationSuccess)
                         when (authFeature) {
                             is AuthFeature.ReportCourse -> onReportCourse()
+                            is AuthFeature.DeleteCourse -> onDeleteCourse()
                             is AuthFeature.DeleteReview -> onDeleteReview(authFeature.review)
                             is AuthFeature.ReportReview -> onReportReview(authFeature.review)
                             is AuthFeature.WriteReview -> onWriteReview()
@@ -227,6 +228,28 @@ class CourseDetailViewModel
                     }
                 }
             }
+        }
+
+        fun onDeleteCourse() {
+            viewModelScope.launch {
+                (uiState.value as? UiState.Success)?.let { uiState: UiState.Success ->
+                    _dialogState.value =
+                        if (authRepository.accessToken() == null) {
+                            dialogState.value.copy(authDialog = AuthFeature.DeleteCourse(uiState.data.id))
+                        } else {
+                            dialogState.value.copy(deleteCourseDialog = uiState.data.name)
+                        }
+                }
+            }
+        }
+
+        fun dismissDeleteCourseDialog() {
+            _dialogState.value = dialogState.value.copy(deleteCourseDialog = null)
+        }
+
+        fun confirmDeleteCourse() {
+            // TODO: 백엔드 API 추가될 시 구현
+            dismissDeleteCourseDialog()
         }
 
         fun onDeleteReview(review: CourseReviewUiModel) {
@@ -425,12 +448,17 @@ class CourseDetailViewModel
         data class DialogState(
             val authDialog: AuthFeature? = null,
             val reportCourseDialog: String? = null,
+            val deleteCourseDialog: String? = null,
             val deleteReviewDialog: CourseReviewUiModel? = null,
             val reportReviewDialog: CourseReviewUiModel? = null,
         )
 
         sealed interface AuthFeature {
             data class ReportCourse(
+                val courseId: String,
+            ) : AuthFeature
+
+            data class DeleteCourse(
                 val courseId: String,
             ) : AuthFeature
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
@@ -57,11 +57,10 @@ class CourseDetailViewModel
                 } else if (courseDetail == null) {
                     UiState.Failure.Unknown
                 } else {
-                    val userId: String? = authRepository.userId()
                     UiState.Success(
                         courseDetail.toUiModel(
                             isFavorite = favoriteCourseIds.contains(courseDetail.courseId),
-                            userId = userId,
+                            userId = authRepository.userId(),
                         ),
                     )
                 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
@@ -14,6 +14,7 @@ import io.coursepick.coursepick.domain.course.CourseRepository
 import io.coursepick.coursepick.domain.customcourse.CustomCourseRepository
 import io.coursepick.coursepick.domain.favorites.FavoriteCourseRepository
 import io.coursepick.coursepick.presentation.Logger
+import io.coursepick.coursepick.presentation.customcourse.DeleteCourseDialogState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -238,7 +239,7 @@ class CourseDetailViewModel
                         if (authRepository.accessToken() == null) {
                             dialogState.value.copy(authDialog = AuthFeature.DeleteCourse(uiState.data.id))
                         } else {
-                            dialogState.value.copy(deleteCourseDialog = uiState.data.name)
+                            dialogState.value.copy(deleteCourseDialog = DeleteCourseDialogState(uiState.data.id, uiState.data.name))
                         }
                 }
             }
@@ -249,9 +250,13 @@ class CourseDetailViewModel
         }
 
         fun confirmDeleteCourse() {
+            if (dialogState.value.deleteCourseDialog?.isDeleting == true) return
+
             viewModelScope.launch {
                 (uiState.value as? UiState.Success)?.let { state: UiState.Success ->
                     try {
+                        _dialogState.value =
+                            dialogState.value.copy(deleteCourseDialog = dialogState.value.deleteCourseDialog?.copy(isDeleting = true))
                         customCourseRepository.deleteCourse(state.data.id)
                         dismissDeleteCourseDialog()
                         _uiEvent.emit(UiEvent.DeleteCourseSuccess)
@@ -292,6 +297,9 @@ class CourseDetailViewModel
                                 _uiEvent.emit(UiEvent.UnknownFailure)
                             }
                         }
+                    } finally {
+                        _dialogState.value =
+                            dialogState.value.copy(deleteCourseDialog = dialogState.value.deleteCourseDialog?.copy(isDeleting = false))
                     }
                 }
             }
@@ -497,7 +505,7 @@ class CourseDetailViewModel
         data class DialogState(
             val authDialog: AuthFeature? = null,
             val reportCourseDialog: String? = null,
-            val deleteCourseDialog: String? = null,
+            val deleteCourseDialog: DeleteCourseDialogState? = null,
             val deleteReviewDialog: CourseReviewUiModel? = null,
             val reportReviewDialog: CourseReviewUiModel? = null,
         )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
@@ -59,7 +59,7 @@ class CourseDetailViewModel
                 } else {
                     UiState.Success(
                         courseDetail.toUiModel(
-                            isFavorite = favoriteCourseIds.contains(courseDetail.id),
+                            isFavorite = favoriteCourseIds.contains(courseDetail.courseId),
                             userId = authRepository.userId(),
                         ),
                     )
@@ -93,7 +93,7 @@ class CourseDetailViewModel
             }.onSuccess { detail: CourseDetail ->
                 Logger.log(
                     Logger.Event.Success("fetch_course_detail"),
-                    "courseId" to detail.id,
+                    "courseId" to detail.courseId,
                     "courseName" to detail.name.value,
                 )
             }.onFailure { exception: Throwable ->

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/coursedetail/CourseDetailViewModel.kt
@@ -11,6 +11,7 @@ import io.coursepick.coursepick.domain.auth.AuthenticationError
 import io.coursepick.coursepick.domain.auth.Authenticator
 import io.coursepick.coursepick.domain.course.CourseDetail
 import io.coursepick.coursepick.domain.course.CourseRepository
+import io.coursepick.coursepick.domain.customcourse.CustomCourseRepository
 import io.coursepick.coursepick.domain.favorites.FavoriteCourseRepository
 import io.coursepick.coursepick.presentation.Logger
 import kotlinx.coroutines.CancellationException
@@ -33,6 +34,7 @@ class CourseDetailViewModel
     constructor(
         private val courseRepository: CourseRepository,
         private val favoriteCourseRepository: FavoriteCourseRepository,
+        private val customCourseRepository: CustomCourseRepository,
         private val authRepository: AuthRepository,
         private val networkMonitor: NetworkMonitor,
     ) : ViewModel() {
@@ -247,8 +249,52 @@ class CourseDetailViewModel
         }
 
         fun confirmDeleteCourse() {
-            // TODO: 백엔드 API 추가될 시 구현
-            dismissDeleteCourseDialog()
+            viewModelScope.launch {
+                (uiState.value as? UiState.Success)?.let { state: UiState.Success ->
+                    try {
+                        customCourseRepository.deleteCourse(state.data.id)
+                        dismissDeleteCourseDialog()
+                        _uiEvent.emit(UiEvent.DeleteCourseSuccess)
+                        _uiEvent.emit(UiEvent.Exit)
+
+                        Logger.log(
+                            Logger.Event.Success("delete_custom_course"),
+                            "courseId" to state.data.id,
+                            "courseName" to state.data.name,
+                        )
+                    } catch (exception: Throwable) {
+                        Logger.log(
+                            Logger.Event.Failure("submit_course_report"),
+                            "exception" to exception.message.orEmpty(),
+                            "courseId" to state.data.id,
+                            "courseName" to state.data.name,
+                        )
+
+                        when (exception) {
+                            is CancellationException -> {
+                                throw exception
+                            }
+
+                            is NoNetworkException -> {
+                                _uiEvent.emit(UiEvent.NoNetwork)
+                            }
+
+                            is HttpException -> {
+                                _uiEvent.emit(
+                                    when (exception.code()) {
+                                        401 -> UiEvent.UnauthorizedUser
+                                        else -> UiEvent.UnknownFailure
+                                    },
+                                )
+                            }
+
+                            else -> {
+                                _uiEvent.emit(UiEvent.UnknownFailure)
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         fun onDeleteReview(review: CourseReviewUiModel) {
@@ -417,6 +463,8 @@ class CourseDetailViewModel
 
             data object CourseAlreadyReported : UiEvent
 
+            data object DeleteCourseSuccess : UiEvent
+
             data object DeleteReviewSuccess : UiEvent
 
             data object ReportReviewSuccess : UiEvent
@@ -428,6 +476,8 @@ class CourseDetailViewModel
             ) : UiEvent
 
             data object CourseAlreadyReviewed : UiEvent
+
+            data object Exit : UiEvent
         }
 
         sealed interface UiState {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItem.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItem.kt
@@ -2,6 +2,7 @@ package io.coursepick.coursepick.presentation.customcourse
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -47,6 +48,7 @@ import io.coursepick.coursepick.presentation.customcourse.component.CourseNaviga
 fun CustomCourseItem(
     customCourse: CustomCourseUiModel,
     onSelect: () -> Unit,
+    onDelete: () -> Unit,
     onNavigateToCourse: () -> Unit,
     onNavigateToDetail: () -> Unit,
     modifier: Modifier = Modifier,
@@ -61,14 +63,20 @@ fun CustomCourseItem(
     val horizontalDividerColor: Color =
         if (customCourse.selected) backgroundColor else colorResource(R.color.background_border_light)
 
-    Column(modifier.fillMaxWidth()) {
+    Column(
+        modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = onSelect,
+                onLongClick = onDelete,
+            ),
+    ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .background(backgroundColor)
-                    .clickable { onSelect() }
                     .padding(vertical = 8.dp)
                     .padding(start = 20.dp),
         ) {
@@ -154,6 +162,7 @@ private fun CustomCourseItemPreview() {
                 selected = false,
             ),
         onSelect = { },
+        onDelete = { },
         onNavigateToCourse = { },
         onNavigateToDetail = { },
         modifier = Modifier,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItem.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItem.kt
@@ -4,7 +4,7 @@ import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.course.Course
 import io.coursepick.coursepick.domain.course.Distance
 import io.coursepick.coursepick.domain.course.Length
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 
 data class CustomCourseItem(
     val course: Course,
@@ -21,8 +21,4 @@ data class CustomCourseItem(
     fun deselect(): CustomCourseItem = copy(selected = false)
 }
 
-fun CustomCourseItem.toCourseItem(): CourseItem =
-    CourseItem(
-        course = course,
-        selected = selected,
-    )
+fun CustomCourseItem.toCourseUiModel(): CourseUiModel = CourseUiModel(course = course, selected = selected)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItem.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItem.kt
@@ -44,7 +44,7 @@ import io.coursepick.coursepick.presentation.customcourse.component.CourseLength
 import io.coursepick.coursepick.presentation.customcourse.component.CourseNavigationButton
 
 @Composable
-fun CustomCourseItemCard(
+fun CustomCourseItem(
     customCourse: CustomCourseUiModel,
     onSelect: () -> Unit,
     onNavigateToCourse: () -> Unit,
@@ -133,7 +133,7 @@ fun CustomCourseItemCard(
 
 @PreviewLightDark
 @Composable
-private fun CustomCourseItemCardPreview() {
+private fun CustomCourseItemPreview() {
     val course =
         Course(
             id = "1",
@@ -147,7 +147,7 @@ private fun CustomCourseItemCardPreview() {
                     Coordinate(Latitude(37.5500), Longitude(127.0800)),
                 ),
         )
-    CustomCourseItemCard(
+    CustomCourseItem(
         customCourse =
             CustomCourseUiModel(
                 course = course,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItemCard.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseItemCard.kt
@@ -45,7 +45,7 @@ import io.coursepick.coursepick.presentation.customcourse.component.CourseNaviga
 
 @Composable
 fun CustomCourseItemCard(
-    customCourse: CustomCourseItem,
+    customCourse: CustomCourseUiModel,
     onSelect: () -> Unit,
     onNavigateToCourse: () -> Unit,
     onNavigateToDetail: () -> Unit,
@@ -149,7 +149,7 @@ private fun CustomCourseItemCardPreview() {
         )
     CustomCourseItemCard(
         customCourse =
-            CustomCourseItem(
+            CustomCourseUiModel(
                 course = course,
                 selected = false,
             ),

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
@@ -48,6 +48,7 @@ fun CustomCourseScreen(
     onReconnect: OnReconnectListener,
     onGoToCreateCustomCourse: () -> Unit,
     onSelect: (CustomCourseUiModel) -> Unit,
+    onDelete: (CustomCourseUiModel) -> Unit,
     onNavigateToCourse: (CustomCourseUiModel) -> Unit,
     onNavigateToDetail: (CustomCourseUiModel) -> Unit,
     modifier: Modifier = Modifier,
@@ -96,6 +97,7 @@ fun CustomCourseScreen(
                                 CustomCourseItem(
                                     customCourse = customCourse,
                                     onSelect = { onSelect(customCourse) },
+                                    onDelete = { onDelete(customCourse) },
                                     onNavigateToCourse = { onNavigateToCourse(customCourse) },
                                     onNavigateToDetail = { onNavigateToDetail(customCourse) },
                                 )
@@ -150,6 +152,7 @@ private fun CustomCourseScreen_EmptyPreview() {
         onReconnect = { },
         onGoToCreateCustomCourse = { },
         onSelect = { },
+        onDelete = { },
         onNavigateToCourse = { },
         onNavigateToDetail = { },
     )
@@ -191,6 +194,7 @@ private fun CustomCourseScreen_WithCoursesPreview() {
         onReconnect = {},
         onGoToCreateCustomCourse = { },
         onSelect = { },
+        onDelete = { },
         onNavigateToCourse = { },
         onNavigateToDetail = { },
     )
@@ -209,6 +213,7 @@ private fun CustomCourseScreen_LoadingPreview() {
         onReconnect = {},
         onGoToCreateCustomCourse = { },
         onSelect = { },
+        onDelete = { },
         onNavigateToCourse = { },
         onNavigateToDetail = { },
     )
@@ -227,6 +232,7 @@ private fun CustomCourseScreen_NoInternetPreview() {
         onReconnect = {},
         onGoToCreateCustomCourse = { },
         onSelect = { },
+        onDelete = { },
         onNavigateToCourse = { },
         onNavigateToDetail = { },
     )
@@ -245,6 +251,7 @@ private fun CustomCourseScreen_FailurePreview() {
         onReconnect = {},
         onGoToCreateCustomCourse = { },
         onSelect = { },
+        onDelete = { },
         onNavigateToCourse = { },
         onNavigateToDetail = { },
     )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
@@ -93,7 +93,7 @@ fun CustomCourseScreen(
                                 items = status.customCourses,
                                 key = CustomCourseUiModel::id,
                             ) { customCourse: CustomCourseUiModel ->
-                                CustomCourseItemCard(
+                                CustomCourseItem(
                                     customCourse = customCourse,
                                     onSelect = { onSelect(customCourse) },
                                     onNavigateToCourse = { onNavigateToCourse(customCourse) },

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseScreen.kt
@@ -47,9 +47,9 @@ fun CustomCourseScreen(
     status: CustomCourseUiState,
     onReconnect: OnReconnectListener,
     onGoToCreateCustomCourse: () -> Unit,
-    onSelect: (CustomCourseItem) -> Unit,
-    onNavigateToCourse: (CustomCourseItem) -> Unit,
-    onNavigateToDetail: (CustomCourseItem) -> Unit,
+    onSelect: (CustomCourseUiModel) -> Unit,
+    onNavigateToCourse: (CustomCourseUiModel) -> Unit,
+    onNavigateToDetail: (CustomCourseUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -91,8 +91,8 @@ fun CustomCourseScreen(
                         ) {
                             items(
                                 items = status.customCourses,
-                                key = CustomCourseItem::id,
-                            ) { customCourse: CustomCourseItem ->
+                                key = CustomCourseUiModel::id,
+                            ) { customCourse: CustomCourseUiModel ->
                                 CustomCourseItemCard(
                                     customCourse = customCourse,
                                     onSelect = { onSelect(customCourse) },
@@ -158,9 +158,9 @@ private fun CustomCourseScreen_EmptyPreview() {
 @PreviewLightDark
 @Composable
 private fun CustomCourseScreen_WithCoursesPreview() {
-    val customCourse: List<CustomCourseItem> =
+    val customCourse: List<CustomCourseUiModel> =
         List(10) { index: Int ->
-            CustomCourseItem(
+            CustomCourseUiModel(
                 course =
                     Course(
                         id = index.toString(),

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiEvent.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiEvent.kt
@@ -14,6 +14,6 @@ sealed interface CustomCourseUiEvent {
     data object UnauthorizedUser : CustomCourseUiEvent
 
     data class SelectCustomCourse(
-        val customCourse: CustomCourseItem,
+        val customCourse: CustomCourseUiModel,
     ) : CustomCourseUiEvent
 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiEvent.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiEvent.kt
@@ -1,6 +1,12 @@
 package io.coursepick.coursepick.presentation.customcourse
 
 sealed interface CustomCourseUiEvent {
+    data object NoNetwork : CustomCourseUiEvent
+
+    data object UnauthorizedUser : CustomCourseUiEvent
+
+    data object UnknownFailure : CustomCourseUiEvent
+
     data object AuthenticationSuccess : CustomCourseUiEvent
 
     data object AuthenticationCancelled : CustomCourseUiEvent
@@ -11,7 +17,7 @@ sealed interface CustomCourseUiEvent {
 
     object FetchCustomCourseFailure : CustomCourseUiEvent
 
-    data object UnauthorizedUser : CustomCourseUiEvent
+    data object DeleteCourseSuccess : CustomCourseUiEvent
 
     data class SelectCustomCourse(
         val customCourse: CustomCourseUiModel,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiModel.kt
@@ -6,7 +6,7 @@ import io.coursepick.coursepick.domain.course.Distance
 import io.coursepick.coursepick.domain.course.Length
 import io.coursepick.coursepick.presentation.course.CourseUiModel
 
-data class CustomCourseItem(
+data class CustomCourseUiModel(
     val course: Course,
     val selected: Boolean,
 ) {
@@ -16,9 +16,9 @@ data class CustomCourseItem(
     val length: Length = course.length
     val coordinates: List<Coordinate> = course.coordinates
 
-    fun select(): CustomCourseItem = copy(selected = true)
+    fun select(): CustomCourseUiModel = copy(selected = true)
 
-    fun deselect(): CustomCourseItem = copy(selected = false)
+    fun deselect(): CustomCourseUiModel = copy(selected = false)
 }
 
-fun CustomCourseItem.toCourseUiModel(): CourseUiModel = CourseUiModel(course = course, selected = selected)
+fun CustomCourseUiModel.toCourseUiModel(): CourseUiModel = CourseUiModel(course = course, selected = selected)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiState.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseUiState.kt
@@ -4,6 +4,6 @@ import io.coursepick.coursepick.presentation.course.UiStatus
 
 data class CustomCourseUiState(
     val status: UiStatus = UiStatus.Loading,
-    val customCourses: List<CustomCourseItem>,
-    val selectedCustomCourse: CustomCourseItem? = null,
+    val customCourses: List<CustomCourseUiModel>,
+    val selectedCustomCourse: CustomCourseUiModel? = null,
 )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
@@ -129,9 +129,9 @@ class CustomCourseViewModel
                 }.onSuccess { coursesPage: CoursesPage ->
                     Logger.log(Logger.Event.Success("fetch_custom_courses_new"))
 
-                    val customCourseItems: List<CustomCourseItem> =
+                    val customCourse: List<CustomCourseUiModel> =
                         coursesPage.courses.mapIndexed { index, course ->
-                            CustomCourseItem(
+                            CustomCourseUiModel(
                                 course = course,
                                 selected = index == 0,
                             )
@@ -140,8 +140,8 @@ class CustomCourseViewModel
                     _state.update { currentState ->
                         currentState.copy(
                             status = UiStatus.Success,
-                            customCourses = customCourseItems,
-                            selectedCustomCourse = customCourseItems.firstOrNull(),
+                            customCourses = customCourse,
+                            selectedCustomCourse = customCourse.firstOrNull(),
                         )
                     }
                 }.onFailure { exception: Throwable ->
@@ -190,7 +190,7 @@ class CustomCourseViewModel
             }
         }
 
-        fun select(customCourse: CustomCourseItem) {
+        fun select(customCourse: CustomCourseUiModel) {
             val isAlreadySelected = _state.value.selectedCustomCourse?.id == customCourse.id
 
             if (isAlreadySelected) {
@@ -213,7 +213,7 @@ class CustomCourseViewModel
         }
 
         fun onNavigateToCourse(
-            customCourse: CustomCourseItem,
+            customCourse: CustomCourseUiModel,
             onNavigateTo: (CourseUiModel) -> Unit,
         ) {
             select(customCourse)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
@@ -220,7 +220,7 @@ class CustomCourseViewModel
                     if (authRepository.accessToken() == null) {
                         dialogState.value.copy(authFeature = AuthFeature.DeleteCustomCourse(customCourse))
                     } else {
-                        dialogState.value.copy(deleteCourseDialog = customCourse)
+                        dialogState.value.copy(deleteCourseDialog = DeleteCourseDialogState(customCourse.id, customCourse.name))
                     }
             }
         }
@@ -230,8 +230,12 @@ class CustomCourseViewModel
         }
 
         fun confirmDeleteCustomCourse(courseId: String) {
+            if (dialogState.value.deleteCourseDialog?.isDeleting == true) return
+
             viewModelScope.launch {
                 try {
+                    _dialogState.value =
+                        dialogState.value.copy(deleteCourseDialog = dialogState.value.deleteCourseDialog?.copy(isDeleting = true))
                     customCourseRepository.deleteCourse(courseId)
                     dismissDeleteCourseDialog()
                     _uiEvent.emit(CustomCourseUiEvent.DeleteCourseSuccess)
@@ -267,6 +271,9 @@ class CustomCourseViewModel
                             _uiEvent.emit(CustomCourseUiEvent.UnknownFailure)
                         }
                     }
+                } finally {
+                    _dialogState.value =
+                        dialogState.value.copy(deleteCourseDialog = dialogState.value.deleteCourseDialog?.copy(isDeleting = false))
                 }
             }
         }
@@ -282,7 +289,7 @@ class CustomCourseViewModel
 
         data class DialogState(
             val authFeature: AuthFeature? = null,
-            val deleteCourseDialog: CustomCourseUiModel? = null,
+            val deleteCourseDialog: DeleteCourseDialogState? = null,
         )
 
         sealed interface AuthFeature {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
@@ -16,6 +16,7 @@ import io.coursepick.coursepick.domain.location.LocationRepository
 import io.coursepick.coursepick.presentation.Logger
 import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.course.UiStatus
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -228,9 +229,45 @@ class CustomCourseViewModel
             _dialogState.value = dialogState.value.copy(deleteCourseDialog = null)
         }
 
-        fun confirmDeleteCustomCourse() {
-            // TODO: 백엔드 API 추가될 시 구현
-            dismissDeleteCourseDialog()
+        fun confirmDeleteCustomCourse(courseId: String) {
+            viewModelScope.launch {
+                try {
+                    customCourseRepository.deleteCourse(courseId)
+                    dismissDeleteCourseDialog()
+                    _uiEvent.emit(CustomCourseUiEvent.DeleteCourseSuccess)
+
+                    Logger.log(Logger.Event.Success("delete_custom_course"), "courseId" to courseId)
+                } catch (exception: Throwable) {
+                    Logger.log(
+                        Logger.Event.Failure("submit_course_report"),
+                        "exception" to exception.message.orEmpty(),
+                        "courseId" to courseId,
+                    )
+
+                    when (exception) {
+                        is CancellationException -> {
+                            throw exception
+                        }
+
+                        is NoNetworkException -> {
+                            _uiEvent.emit(CustomCourseUiEvent.NoNetwork)
+                        }
+
+                        is HttpException -> {
+                            _uiEvent.emit(
+                                when (exception.code()) {
+                                    401 -> CustomCourseUiEvent.UnauthorizedUser
+                                    else -> CustomCourseUiEvent.UnknownFailure
+                                },
+                            )
+                        }
+
+                        else -> {
+                            _uiEvent.emit(CustomCourseUiEvent.UnknownFailure)
+                        }
+                    }
+                }
+            }
         }
 
         fun onNavigateToCourse(

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
@@ -14,7 +14,7 @@ import io.coursepick.coursepick.domain.course.CoursesPage
 import io.coursepick.coursepick.domain.customcourse.CustomCourseRepository
 import io.coursepick.coursepick.domain.location.LocationRepository
 import io.coursepick.coursepick.presentation.Logger
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.course.UiStatus
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -214,11 +214,11 @@ class CustomCourseViewModel
 
         fun onNavigateToCourse(
             customCourse: CustomCourseItem,
-            onNavigateTo: (CourseItem) -> Unit,
+            onNavigateTo: (CourseUiModel) -> Unit,
         ) {
             select(customCourse)
-            val courseItem: CourseItem = _state.value.selectedCustomCourse?.toCourseItem() ?: return
-            onNavigateTo(courseItem)
+            val course: CourseUiModel = _state.value.selectedCustomCourse?.toCourseUiModel() ?: return
+            onNavigateTo(course)
         }
 
         sealed interface AuthFeature {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
@@ -235,6 +235,7 @@ class CustomCourseViewModel
                     customCourseRepository.deleteCourse(courseId)
                     dismissDeleteCourseDialog()
                     _uiEvent.emit(CustomCourseUiEvent.DeleteCourseSuccess)
+                    fetchCustomCourses()
 
                     Logger.log(Logger.Event.Success("delete_custom_course"), "courseId" to courseId)
                 } catch (exception: Throwable) {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCourseViewModel.kt
@@ -39,8 +39,8 @@ class CustomCourseViewModel
         private val _uiEvent = MutableSharedFlow<CustomCourseUiEvent>()
         val uiEvent: SharedFlow<CustomCourseUiEvent> get() = _uiEvent.asSharedFlow()
 
-        private val _authDialogState = MutableStateFlow<AuthFeature?>(null)
-        val authDialogState: StateFlow<AuthFeature?> get() = _authDialogState.asStateFlow()
+        private val _dialogState = MutableStateFlow<DialogState>(DialogState())
+        val dialogState: StateFlow<DialogState> get() = _dialogState.asStateFlow()
 
         private val _state =
             MutableStateFlow(
@@ -55,7 +55,7 @@ class CustomCourseViewModel
         fun onGoToCreateCustomCourse() {
             viewModelScope.launch {
                 if (authRepository.accessToken() == null) {
-                    _authDialogState.value = AuthFeature.CreateCustomCourse
+                    _dialogState.value = dialogState.value.copy(authFeature = AuthFeature.CreateCustomCourse)
                 } else {
                     _uiEvent.emit(CustomCourseUiEvent.NavigateToCreateCourse)
                 }
@@ -63,7 +63,7 @@ class CustomCourseViewModel
         }
 
         fun dismissAuthDialog() {
-            _authDialogState.value = null
+            _dialogState.value = dialogState.value.copy(authFeature = null)
         }
 
         fun signIn(
@@ -77,6 +77,7 @@ class CustomCourseViewModel
                         _uiEvent.emit(CustomCourseUiEvent.AuthenticationSuccess)
                         when (authFeature) {
                             AuthFeature.FetchCustomCourses -> fetchCustomCourses()
+                            is AuthFeature.DeleteCustomCourse -> onDeleteCustomCourse(authFeature.course)
                             AuthFeature.CreateCustomCourse -> _uiEvent.emit(CustomCourseUiEvent.NavigateToCreateCourse)
                         }
                     }
@@ -112,7 +113,7 @@ class CustomCourseViewModel
                 }
 
                 if (authRepository.accessToken() == null) {
-                    _authDialogState.value = AuthFeature.FetchCustomCourses
+                    _dialogState.value = dialogState.value.copy(authFeature = AuthFeature.FetchCustomCourses)
                     _state.update { currentState ->
                         currentState.copy(status = UiStatus.Success, customCourses = emptyList())
                     }
@@ -212,6 +213,26 @@ class CustomCourseViewModel
             }
         }
 
+        fun onDeleteCustomCourse(customCourse: CustomCourseUiModel) {
+            viewModelScope.launch {
+                _dialogState.value =
+                    if (authRepository.accessToken() == null) {
+                        dialogState.value.copy(authFeature = AuthFeature.DeleteCustomCourse(customCourse))
+                    } else {
+                        dialogState.value.copy(deleteCourseDialog = customCourse)
+                    }
+            }
+        }
+
+        fun dismissDeleteCourseDialog() {
+            _dialogState.value = dialogState.value.copy(deleteCourseDialog = null)
+        }
+
+        fun confirmDeleteCustomCourse() {
+            // TODO: 백엔드 API 추가될 시 구현
+            dismissDeleteCourseDialog()
+        }
+
         fun onNavigateToCourse(
             customCourse: CustomCourseUiModel,
             onNavigateTo: (CourseUiModel) -> Unit,
@@ -221,8 +242,17 @@ class CustomCourseViewModel
             onNavigateTo(course)
         }
 
+        data class DialogState(
+            val authFeature: AuthFeature? = null,
+            val deleteCourseDialog: CustomCourseUiModel? = null,
+        )
+
         sealed interface AuthFeature {
             data object FetchCustomCourses : AuthFeature
+
+            data class DeleteCustomCourse(
+                val course: CustomCourseUiModel,
+            ) : AuthFeature
 
             data object CreateCustomCourse : AuthFeature
         }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -116,7 +116,7 @@ class CustomCoursesFragment(
                     DeleteCustomCourseDialog(
                         courseName = dialogState.deleteCourseDialog.name,
                         onDismiss = customCourseViewModel::dismissDeleteCourseDialog,
-                        onConfirm = customCourseViewModel::confirmDeleteCustomCourse,
+                        onConfirm = { customCourseViewModel.confirmDeleteCustomCourse(dialogState.deleteCourseDialog.id) },
                     )
                 }
             }
@@ -134,6 +134,24 @@ class CustomCoursesFragment(
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 customCourseViewModel.uiEvent.collect { event: CustomCourseUiEvent ->
                     when (event) {
+                        CustomCourseUiEvent.NoNetwork -> {
+                            Toast
+                                .makeText(requireContext(), R.string.failure_no_network_message, Toast.LENGTH_SHORT)
+                                .show()
+                        }
+
+                        CustomCourseUiEvent.UnauthorizedUser -> {
+                            Toast
+                                .makeText(requireContext(), R.string.failure_unauthorized_user_toast_message, Toast.LENGTH_SHORT)
+                                .show()
+                        }
+
+                        CustomCourseUiEvent.UnknownFailure -> {
+                            Toast
+                                .makeText(requireContext(), R.string.failure_unknown_toast_message, Toast.LENGTH_SHORT)
+                                .show()
+                        }
+
                         CustomCourseUiEvent.AuthenticationSuccess -> {
                             Toast
                                 .makeText(requireContext(), getString(R.string.authentication_success_message), Toast.LENGTH_SHORT)
@@ -162,9 +180,9 @@ class CustomCoursesFragment(
                                 .show()
                         }
 
-                        CustomCourseUiEvent.UnauthorizedUser -> {
+                        CustomCourseUiEvent.DeleteCourseSuccess -> {
                             Toast
-                                .makeText(requireContext(), R.string.failure_unauthorized_user_toast_message, Toast.LENGTH_SHORT)
+                                .makeText(requireContext(), R.string.delete_custom_course_dialog_success_message, Toast.LENGTH_SHORT)
                                 .show()
                         }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.Modifier
@@ -46,9 +47,12 @@ class CustomCoursesFragment(
     private val customCourseViewModel: CustomCourseViewModel by activityViewModels()
 
     private val createCustomCourseLauncher: ActivityResultLauncher<Intent> =
-        registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult(),
-        ) { result ->
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            if (result.resultCode == Activity.RESULT_OK) customCourseViewModel.fetchCustomCourses()
+        }
+
+    private val courseDetailLauncher: ActivityResultLauncher<Intent> =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
             if (result.resultCode == Activity.RESULT_OK) customCourseViewModel.fetchCustomCourses()
         }
 
@@ -83,7 +87,7 @@ class CustomCoursesFragment(
                         }
                     },
                     onNavigateToDetail = { customCourse: CustomCourseUiModel ->
-                        startActivity(CourseDetailActivity.intent(requireContext(), customCourse.course.id))
+                        courseDetailLauncher.launch(CourseDetailActivity.intent(requireContext(), customCourse.course.id))
                     },
                     modifier = Modifier.nestedScroll(nestedScrollInterop),
                 )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -26,7 +26,7 @@ import io.coursepick.coursepick.databinding.FragmentCustomCoursesBinding
 import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.presentation.auth.AuthDialog
 import io.coursepick.coursepick.presentation.compat.OnReconnectListener
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.course.CoursesActivity
 import io.coursepick.coursepick.presentation.course.CoursesViewModel
 import io.coursepick.coursepick.presentation.coursedetail.CourseDetailActivity
@@ -77,8 +77,8 @@ class CustomCoursesFragment(
                     onGoToCreateCustomCourse = customCourseViewModel::onGoToCreateCustomCourse,
                     onSelect = { customCourse: CustomCourseItem -> customCourseViewModel.select(customCourse) },
                     onNavigateToCourse = { customCourse: CustomCourseItem ->
-                        customCourseViewModel.onNavigateToCourse(customCourse) { courseItem: CourseItem ->
-                            (activity as? CoursesActivity)?.navigateToCourse(courseItem)
+                        customCourseViewModel.onNavigateToCourse(customCourse) { course: CourseUiModel ->
+                            (activity as? CoursesActivity)?.navigateToCourse(course)
                         }
                     },
                     onNavigateToDetail = { customCourse: CustomCourseItem ->
@@ -151,7 +151,7 @@ class CustomCoursesFragment(
                         }
 
                         is CustomCourseUiEvent.SelectCustomCourse -> {
-                            coursesViewModel.selectExternalCourse(event.customCourse.toCourseItem())
+                            coursesViewModel.selectExternalCourse(event.customCourse.toCourseUiModel())
                         }
                     }
                 }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -75,13 +75,13 @@ class CustomCoursesFragment(
                     status = customCourseState,
                     onReconnect = onReconnectListener,
                     onGoToCreateCustomCourse = customCourseViewModel::onGoToCreateCustomCourse,
-                    onSelect = { customCourse: CustomCourseItem -> customCourseViewModel.select(customCourse) },
-                    onNavigateToCourse = { customCourse: CustomCourseItem ->
+                    onSelect = { customCourse: CustomCourseUiModel -> customCourseViewModel.select(customCourse) },
+                    onNavigateToCourse = { customCourse: CustomCourseUiModel ->
                         customCourseViewModel.onNavigateToCourse(customCourse) { course: CourseUiModel ->
                             (activity as? CoursesActivity)?.navigateToCourse(course)
                         }
                     },
-                    onNavigateToDetail = { customCourse: CustomCourseItem ->
+                    onNavigateToDetail = { customCourse: CustomCourseUiModel ->
                         startActivity(CourseDetailActivity.intent(requireContext(), customCourse.course.id))
                     },
                     modifier = Modifier.nestedScroll(nestedScrollInterop),

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -118,9 +118,9 @@ class CustomCoursesFragment(
 
                 if (dialogState.deleteCourseDialog != null) {
                     DeleteCustomCourseDialog(
-                        courseName = dialogState.deleteCourseDialog.name,
+                        state = dialogState.deleteCourseDialog,
                         onDismiss = customCourseViewModel::dismissDeleteCourseDialog,
-                        onConfirm = { customCourseViewModel.confirmDeleteCustomCourse(dialogState.deleteCourseDialog.id) },
+                        onConfirm = { customCourseViewModel.confirmDeleteCustomCourse(dialogState.deleteCourseDialog.courseId) },
                     )
                 }
             }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/CustomCoursesFragment.kt
@@ -76,6 +76,7 @@ class CustomCoursesFragment(
                     onReconnect = onReconnectListener,
                     onGoToCreateCustomCourse = customCourseViewModel::onGoToCreateCustomCourse,
                     onSelect = { customCourse: CustomCourseUiModel -> customCourseViewModel.select(customCourse) },
+                    onDelete = { customCourse: CustomCourseUiModel -> customCourseViewModel.onDeleteCustomCourse(customCourse) },
                     onNavigateToCourse = { customCourse: CustomCourseUiModel ->
                         customCourseViewModel.onNavigateToCourse(customCourse) { course: CourseUiModel ->
                             (activity as? CoursesActivity)?.navigateToCourse(course)
@@ -87,18 +88,35 @@ class CustomCoursesFragment(
                     modifier = Modifier.nestedScroll(nestedScrollInterop),
                 )
 
-                val authDialogState = customCourseViewModel.authDialogState.collectAsStateWithLifecycle().value
-                if (authDialogState != null) {
+                val dialogState: CustomCourseViewModel.DialogState = customCourseViewModel.dialogState.collectAsStateWithLifecycle().value
+                if (dialogState.authFeature != null) {
                     val featureName: String =
-                        when (authDialogState) {
-                            CustomCourseViewModel.AuthFeature.FetchCustomCourses -> getString(R.string.custom_course_feature_name)
-                            CustomCourseViewModel.AuthFeature.CreateCustomCourse -> getString(R.string.create_custom_course_feature_name)
+                        when (dialogState.authFeature) {
+                            CustomCourseViewModel.AuthFeature.FetchCustomCourses -> {
+                                getString(R.string.custom_course_feature_name)
+                            }
+
+                            is CustomCourseViewModel.AuthFeature.DeleteCustomCourse -> {
+                                getString(R.string.delete_custom_course_dialog_feature_name)
+                            }
+
+                            CustomCourseViewModel.AuthFeature.CreateCustomCourse -> {
+                                getString(R.string.create_custom_course_feature_name)
+                            }
                         }
 
                     AuthDialog(
                         featureName = featureName,
                         onDismissRequest = customCourseViewModel::dismissAuthDialog,
-                        onKakaoLoginClick = { customCourseViewModel.signIn(KakaoAuthenticator(requireContext()), authDialogState) },
+                        onKakaoLoginClick = { customCourseViewModel.signIn(KakaoAuthenticator(requireContext()), dialogState.authFeature) },
+                    )
+                }
+
+                if (dialogState.deleteCourseDialog != null) {
+                    DeleteCustomCourseDialog(
+                        courseName = dialogState.deleteCourseDialog.name,
+                        onDismiss = customCourseViewModel::dismissDeleteCourseDialog,
+                        onConfirm = customCourseViewModel::confirmDeleteCustomCourse,
                     )
                 }
             }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCourseDialogState.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCourseDialogState.kt
@@ -1,0 +1,7 @@
+package io.coursepick.coursepick.presentation.customcourse
+
+data class DeleteCourseDialogState(
+    val courseId: String,
+    val courseName: String,
+    val isDeleting: Boolean = false,
+)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCustomCourseDialog.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCustomCourseDialog.kt
@@ -124,7 +124,7 @@ private fun DeleteCustomCourseDialogButtons(
                     .weight(1F)
                     .clip(RoundedCornerShape(50))
                     .clickable(enabled = !isDeleting) { onConfirm() }
-                    .background(colorResource(R.color.point_primary))
+                    .background(colorResource(if (!isDeleting) R.color.point_primary else R.color.background_tertiary))
                     .padding(horizontal = 20.dp, vertical = 10.dp),
         ) {
             Text(
@@ -136,6 +136,7 @@ private fun DeleteCustomCourseDialogButtons(
 
             CircularProgressIndicator(
                 color = colorResource(R.color.item_primary),
+                strokeWidth = 2.dp,
                 modifier =
                     Modifier
                         .size(16.dp)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCustomCourseDialog.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCustomCourseDialog.kt
@@ -9,11 +9,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -26,13 +29,13 @@ import io.coursepick.coursepick.R
 
 @Composable
 fun DeleteCustomCourseDialog(
-    courseName: String,
+    state: DeleteCourseDialogState,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
-    Dialog(onDismiss) {
+    Dialog(onDismissRequest = { if (!state.isDeleting) onDismiss() }) {
         DeleteCustomCourseDialogContent(
-            courseName = courseName,
+            state = state,
             onDismiss = onDismiss,
             onConfirm = onConfirm,
         )
@@ -41,7 +44,7 @@ fun DeleteCustomCourseDialog(
 
 @Composable
 private fun DeleteCustomCourseDialogContent(
-    courseName: String,
+    state: DeleteCourseDialogState,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
@@ -54,7 +57,7 @@ private fun DeleteCustomCourseDialogContent(
                 .padding(20.dp),
     ) {
         Text(
-            text = courseName,
+            text = state.courseName,
             color = colorResource(R.color.item_primary),
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
@@ -77,6 +80,7 @@ private fun DeleteCustomCourseDialogContent(
         )
 
         DeleteCustomCourseDialogButtons(
+            isDeleting = state.isDeleting,
             onDismiss = onDismiss,
             onConfirm = onConfirm,
             modifier = Modifier.padding(10.dp),
@@ -86,6 +90,7 @@ private fun DeleteCustomCourseDialogContent(
 
 @Composable
 private fun DeleteCustomCourseDialogButtons(
+    isDeleting: Boolean,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
     modifier: Modifier = Modifier,
@@ -101,7 +106,7 @@ private fun DeleteCustomCourseDialogButtons(
                 Modifier
                     .weight(1F)
                     .clip(RoundedCornerShape(50))
-                    .clickable { onDismiss() }
+                    .clickable(enabled = !isDeleting) { onDismiss() }
                     .background(colorResource(R.color.background_tertiary))
                     .padding(horizontal = 20.dp, vertical = 10.dp),
         ) {
@@ -118,7 +123,7 @@ private fun DeleteCustomCourseDialogButtons(
                 Modifier
                     .weight(1F)
                     .clip(RoundedCornerShape(50))
-                    .clickable { onConfirm() }
+                    .clickable(enabled = !isDeleting) { onConfirm() }
                     .background(colorResource(R.color.point_primary))
                     .padding(horizontal = 20.dp, vertical = 10.dp),
         ) {
@@ -126,6 +131,15 @@ private fun DeleteCustomCourseDialogButtons(
                 text = stringResource(R.string.delete_custom_course_dialog_positive_button),
                 color = colorResource(R.color.item_primary),
                 fontSize = 16.sp,
+                modifier = Modifier.alpha(if (isDeleting) 0F else 1F),
+            )
+
+            CircularProgressIndicator(
+                color = colorResource(R.color.item_primary),
+                modifier =
+                    Modifier
+                        .size(16.dp)
+                        .alpha(if (isDeleting) 1F else 0F),
             )
         }
     }
@@ -135,7 +149,17 @@ private fun DeleteCustomCourseDialogButtons(
 @Composable
 private fun DeleteCustomCourseDialogPreview() {
     DeleteCustomCourseDialogContent(
-        courseName = "석촌호수 한바퀴",
+        state = DeleteCourseDialogState("", "석촌호수 한바퀴", false),
+        onDismiss = { },
+        onConfirm = { },
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun DeleteCustomCourseDialogDeletingPreview() {
+    DeleteCustomCourseDialogContent(
+        state = DeleteCourseDialogState("", "석촌호수 한바퀴", true),
         onDismiss = { },
         onConfirm = { },
     )

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCustomCourseDialog.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/customcourse/DeleteCustomCourseDialog.kt
@@ -1,0 +1,142 @@
+package io.coursepick.coursepick.presentation.customcourse
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import io.coursepick.coursepick.R
+
+@Composable
+fun DeleteCustomCourseDialog(
+    courseName: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Dialog(onDismiss) {
+        DeleteCustomCourseDialogContent(
+            courseName = courseName,
+            onDismiss = onDismiss,
+            onConfirm = onConfirm,
+        )
+    }
+}
+
+@Composable
+private fun DeleteCustomCourseDialogContent(
+    courseName: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier =
+            Modifier
+                .clip(RoundedCornerShape(10))
+                .background(colorResource(R.color.background_primary))
+                .padding(20.dp),
+    ) {
+        Text(
+            text = courseName,
+            color = colorResource(R.color.item_primary),
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        Text(
+            text = stringResource(R.string.delete_custom_course_dialog_title),
+            color = colorResource(R.color.item_primary),
+            fontSize = 16.sp,
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        Text(
+            text = stringResource(R.string.delete_custom_course_dialog_warning),
+            color = colorResource(R.color.item_secondary),
+            fontSize = 14.sp,
+        )
+
+        DeleteCustomCourseDialogButtons(
+            onDismiss = onDismiss,
+            onConfirm = onConfirm,
+            modifier = Modifier.padding(10.dp),
+        )
+    }
+}
+
+@Composable
+private fun DeleteCustomCourseDialogButtons(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier
+                    .weight(1F)
+                    .clip(RoundedCornerShape(50))
+                    .clickable { onDismiss() }
+                    .background(colorResource(R.color.background_tertiary))
+                    .padding(horizontal = 20.dp, vertical = 10.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.delete_custom_course_dialog_negative_button),
+                fontSize = 16.sp,
+                color = colorResource(R.color.item_tertiary),
+            )
+        }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier
+                    .weight(1F)
+                    .clip(RoundedCornerShape(50))
+                    .clickable { onConfirm() }
+                    .background(colorResource(R.color.point_primary))
+                    .padding(horizontal = 20.dp, vertical = 10.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.delete_custom_course_dialog_positive_button),
+                color = colorResource(R.color.item_primary),
+                fontSize = 16.sp,
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DeleteCustomCourseDialogPreview() {
+    DeleteCustomCourseDialogContent(
+        courseName = "석촌호수 한바퀴",
+        onDismiss = { },
+        onConfirm = { },
+    )
+}

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/CourseDiffHandler.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/CourseDiffHandler.kt
@@ -1,23 +1,23 @@
 package io.coursepick.coursepick.presentation.map
 
 import io.coursepick.coursepick.presentation.Logger
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 
 class CourseDiffHandler(
-    private val onItemAdded: (CourseItem) -> Unit,
-    private val onItemRemoved: (CourseItem) -> Unit,
+    private val onItemAdded: (CourseUiModel) -> Unit,
+    private val onItemRemoved: (CourseUiModel) -> Unit,
 ) {
-    private val courses = mutableSetOf<CourseItem>()
+    private val courses = mutableSetOf<CourseUiModel>()
 
-    fun updateCourses(newValue: Set<CourseItem>) {
+    fun updateCourses(newValue: Set<CourseUiModel>) {
         val removedCourses = courses.subtract(newValue)
         val addedCourses = newValue.subtract(courses)
 
-        removedCourses.forEach { course: CourseItem ->
+        removedCourses.forEach { course: CourseUiModel ->
             courses.remove(course)
             onItemRemoved(course)
         }
-        addedCourses.forEach { course: CourseItem ->
+        addedCourses.forEach { course: CourseUiModel ->
             courses.add(course)
             onItemAdded(course)
         }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/MapManager.kt
@@ -4,7 +4,7 @@ import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.course.Scope
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 
 interface MapManager {
     val cameraCoordinate: Coordinate?
@@ -13,7 +13,7 @@ interface MapManager {
 
     fun startMap(onMapReady: () -> Unit)
 
-    fun updateCourses(courses: List<CourseItem>)
+    fun updateCourses(courses: List<CourseUiModel>)
 
     fun drawRoute(route: List<Coordinate>)
 
@@ -37,9 +37,9 @@ interface MapManager {
 
     fun fitTo(coordinates: List<Coordinate>)
 
-    fun fitTo(course: CourseItem)
+    fun fitTo(course: CourseUiModel)
 
-    fun setOnCourseClickListener(onClick: (CourseItem) -> Unit)
+    fun setOnCourseClickListener(onClick: (CourseUiModel) -> Unit)
 
     fun setOnCameraMoveListener(onCameraMove: (coordinate: Coordinate, reason: CameraMoveReason) -> Unit)
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapDrawer.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapDrawer.kt
@@ -18,7 +18,7 @@ import io.coursepick.coursepick.R
 import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.map.BitmapScaler
 import io.coursepick.coursepick.presentation.map.CoordinateAnimator
 import io.coursepick.coursepick.presentation.map.CourseDiffHandler
@@ -68,11 +68,11 @@ class GoogleMapDrawer(
     private var fineUserLocationAnimator: ValueAnimator? = null
     private var coarseUserLocationAnimator: ValueAnimator? = null
 
-    fun updateCourses(courses: List<CourseItem>) {
+    fun updateCourses(courses: List<CourseUiModel>) {
         courseDiffHandler.updateCourses(courses.toSet())
     }
 
-    private fun addCoursePolyline(course: CourseItem) {
+    private fun addCoursePolyline(course: CourseUiModel) {
         if (course.selected) {
             addSelectedCoursePolyline(course)
         } else {
@@ -80,7 +80,7 @@ class GoogleMapDrawer(
         }
     }
 
-    private fun addUnselectedCoursePolyline(course: CourseItem) {
+    private fun addUnselectedCoursePolyline(course: CourseUiModel) {
         val options =
             PolylineOptions()
                 .addAll(course.coordinates.map(Coordinate::toLatLng))
@@ -92,7 +92,7 @@ class GoogleMapDrawer(
         courseIdToPolyline[course.id] = map.addPolyline(options).apply { tag = course }
     }
 
-    private fun addSelectedCoursePolyline(course: CourseItem) {
+    private fun addSelectedCoursePolyline(course: CourseUiModel) {
         val courseStrokeStyle =
             StrokeStyle
                 .colorBuilder(context.getColor(R.color.course_selected))
@@ -112,7 +112,7 @@ class GoogleMapDrawer(
         courseIdToPolyline[course.id] = map.addPolyline(courseOptions).apply { tag = course }
     }
 
-    private fun removeCoursePolyline(course: CourseItem) {
+    private fun removeCoursePolyline(course: CourseUiModel) {
         courseIdToPolyline.remove(course.id)?.remove()
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/google/GoogleMapManager.kt
@@ -16,7 +16,7 @@ import io.coursepick.coursepick.domain.course.Scope
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
 import io.coursepick.coursepick.presentation.Logger
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import io.coursepick.coursepick.presentation.map.DistanceCalculator
 import io.coursepick.coursepick.presentation.map.MapManager
@@ -70,7 +70,7 @@ class GoogleMapManager(
         }
     }
 
-    override fun updateCourses(courses: List<CourseItem>) {
+    override fun updateCourses(courses: List<CourseUiModel>) {
         drawer?.updateCourses(courses) ?: run { Timber.w(DRAWER_IS_NULL_MESSAGE) }
     }
 
@@ -136,14 +136,14 @@ class GoogleMapManager(
         } ?: run { Timber.w(MAP_IS_NULL_MESSAGE) }
     }
 
-    override fun fitTo(course: CourseItem) {
+    override fun fitTo(course: CourseUiModel) {
         fitTo(course.coordinates)
     }
 
-    override fun setOnCourseClickListener(onClick: (CourseItem) -> Unit) {
+    override fun setOnCourseClickListener(onClick: (CourseUiModel) -> Unit) {
         map?.let { map: GoogleMap ->
             map.setOnPolylineClickListener { polyline: Polyline ->
-                (polyline.tag as? CourseItem)?.let { course: CourseItem ->
+                (polyline.tag as? CourseUiModel)?.let { course: CourseUiModel ->
                     Logger.log(
                         Logger.Event.Click("course_on_map"),
                         "id" to course.id,

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapCameraController.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapCameraController.kt
@@ -8,7 +8,7 @@ import com.kakao.vectormap.camera.CameraUpdate
 import com.kakao.vectormap.camera.CameraUpdateFactory
 import io.coursepick.coursepick.R
 import io.coursepick.coursepick.domain.course.Coordinate
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 
 class KakaoMapCameraController(
     context: Context,
@@ -44,7 +44,7 @@ class KakaoMapCameraController(
     }
 
     fun fitTo(
-        course: CourseItem,
+        course: CourseUiModel,
         map: KakaoMap,
     ) {
         fitTo(course.coordinates, map)

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapDrawer.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapDrawer.kt
@@ -25,7 +25,7 @@ import io.coursepick.coursepick.R
 import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.map.BitmapScaler
 import io.coursepick.coursepick.presentation.map.CourseDiffHandler
 
@@ -60,11 +60,11 @@ class KakaoMapDrawer(
             kakaoAdjustedDimension(R.dimen.waypoint_marker_size),
         )
 
-    fun updateCourses(courses: List<CourseItem>) {
+    fun updateCourses(courses: List<CourseUiModel>) {
         courseDiffHandler.updateCourses(courses.toSet())
     }
 
-    private fun addCourseRouteLine(course: CourseItem) {
+    private fun addCourseRouteLine(course: CourseUiModel) {
         val layer: RouteLineLayer = map.routeLineManager?.layer ?: return
         val options: RouteLineOptions =
             routeLineOptionsFactory.routeLineOptions(course).apply {
@@ -73,7 +73,7 @@ class KakaoMapDrawer(
         layer.addRouteLine(options)
     }
 
-    private fun removeCourseRouteLine(course: CourseItem) {
+    private fun removeCourseRouteLine(course: CourseUiModel) {
         map.routeLineManager?.layer?.apply {
             getRouteLine(course.id)?.let(::remove)
         }

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapEventHandler.kt
@@ -9,21 +9,21 @@ import com.kakao.vectormap.Poi
 import com.kakao.vectormap.camera.CameraPosition
 import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.presentation.Logger
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import kotlin.math.pow
 import kotlin.math.sqrt
 
 class KakaoMapEventHandler {
-    private var courses: List<CourseItem> = listOf()
+    private var courses: List<CourseUiModel> = listOf()
 
-    fun updateCourses(courses: List<CourseItem>) {
+    fun updateCourses(courses: List<CourseUiModel>) {
         this.courses = courses
     }
 
     fun setOnCourseClickListener(
         map: KakaoMap,
-        onClick: (CourseItem) -> Unit,
+        onClick: (CourseUiModel) -> Unit,
     ) {
         map.setOnMapClickListener { kakaoMap: KakaoMap, latLng: LatLng, target: PointF, poi: Poi ->
             Logger.log(
@@ -35,7 +35,7 @@ class KakaoMapEventHandler {
                 "point_of_interest" to poi.name,
             )
 
-            for (course: CourseItem in courses) {
+            for (course: CourseUiModel in courses) {
                 if (course.isNear(kakaoMap, target)) {
                     Logger.log(
                         Logger.Event.Click("course_on_map"),
@@ -80,7 +80,7 @@ class KakaoMapEventHandler {
         }
     }
 
-    private fun CourseItem.isNear(
+    private fun CourseUiModel.isNear(
         map: KakaoMap,
         target: PointF,
     ): Boolean {

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/KakaoMapManager.kt
@@ -10,7 +10,7 @@ import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.course.Scope
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import io.coursepick.coursepick.presentation.map.DistanceCalculator
 import io.coursepick.coursepick.presentation.map.MapManager
@@ -55,7 +55,7 @@ class KakaoMapManager(
         }
     }
 
-    override fun updateCourses(courses: List<CourseItem>) {
+    override fun updateCourses(courses: List<CourseUiModel>) {
         eventHandler.updateCourses(courses)
         drawer?.updateCourses(courses) ?: Timber.w("KakaoMapDrawer is null")
     }
@@ -106,15 +106,15 @@ class KakaoMapManager(
         } ?: Timber.w("kakaoMap is null")
     }
 
-    override fun fitTo(course: CourseItem) {
+    override fun fitTo(course: CourseUiModel) {
         kakaoMap?.let { kakaoMap: KakaoMap ->
             cameraController.fitTo(course, kakaoMap)
         } ?: Timber.w("kakaoMap is null")
     }
 
-    override fun setOnCourseClickListener(onClick: (CourseItem) -> Unit) {
+    override fun setOnCourseClickListener(onClick: (CourseUiModel) -> Unit) {
         kakaoMap?.let { kakaoMap: KakaoMap ->
-            eventHandler.setOnCourseClickListener(kakaoMap) { course: CourseItem ->
+            eventHandler.setOnCourseClickListener(kakaoMap) { course: CourseUiModel ->
                 onClick(course)
             }
         } ?: Timber.w("kakaoMap is null")

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/RouteLineOptionsFactory.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/kakao/RouteLineOptionsFactory.kt
@@ -11,7 +11,7 @@ import com.kakao.vectormap.route.RouteLineStyle
 import com.kakao.vectormap.route.RouteLineStyles
 import io.coursepick.coursepick.R
 import io.coursepick.coursepick.domain.course.Coordinate
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 
 class RouteLineOptionsFactory(
     private val context: Context,
@@ -35,7 +35,7 @@ class RouteLineOptionsFactory(
             ),
         )
 
-    fun routeLineOptions(course: CourseItem): RouteLineOptions =
+    fun routeLineOptions(course: CourseUiModel): RouteLineOptions =
         RouteLineOptions.from(
             course.id,
             routeLineSegmentWithStyle(

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/naver/NaverMapManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/naver/NaverMapManager.kt
@@ -16,7 +16,7 @@ import io.coursepick.coursepick.domain.course.Scope
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
 import io.coursepick.coursepick.presentation.Logger
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.map.CameraMoveReason
 import io.coursepick.coursepick.presentation.map.DistanceCalculator
 import io.coursepick.coursepick.presentation.map.MapManager
@@ -62,7 +62,7 @@ class NaverMapManager(
         }
     }
 
-    override fun updateCourses(courses: List<CourseItem>) {
+    override fun updateCourses(courses: List<CourseUiModel>) {
         overlayManager?.updateCourses(courses) ?: run { Timber.w(OVERLAY_MANAGER_IS_NULL_MESSAGE) }
     }
 
@@ -122,11 +122,11 @@ class NaverMapManager(
         ) ?: run { Timber.w(MAP_IS_NULL_MESSAGE) }
     }
 
-    override fun fitTo(course: CourseItem) {
+    override fun fitTo(course: CourseUiModel) {
         fitTo(course.coordinates)
     }
 
-    override fun setOnCourseClickListener(onClick: (CourseItem) -> Unit) {
+    override fun setOnCourseClickListener(onClick: (CourseUiModel) -> Unit) {
         overlayManager?.setOnCourseClickListener(onClick) ?: run { Timber.w(OVERLAY_MANAGER_IS_NULL_MESSAGE) }
     }
 

--- a/android/app/src/main/java/io/coursepick/coursepick/presentation/map/naver/NaverMapOverlayManager.kt
+++ b/android/app/src/main/java/io/coursepick/coursepick/presentation/map/naver/NaverMapOverlayManager.kt
@@ -16,7 +16,7 @@ import io.coursepick.coursepick.domain.course.Coordinate
 import io.coursepick.coursepick.domain.customcourse.DraftSegment
 import io.coursepick.coursepick.domain.location.Location
 import io.coursepick.coursepick.presentation.Logger
-import io.coursepick.coursepick.presentation.course.CourseItem
+import io.coursepick.coursepick.presentation.course.CourseUiModel
 import io.coursepick.coursepick.presentation.map.BitmapScaler
 import io.coursepick.coursepick.presentation.map.CoordinateAnimator
 import io.coursepick.coursepick.presentation.map.CourseDiffHandler
@@ -66,11 +66,11 @@ class NaverMapOverlayManager(
 
     private var courseClickListener: Overlay.OnClickListener? = null
 
-    fun updateCourses(newCourses: List<CourseItem>) {
+    fun updateCourses(newCourses: List<CourseUiModel>) {
         courseDiffHandler.updateCourses(newCourses.toSet())
     }
 
-    private fun addCourseOverlay(course: CourseItem) {
+    private fun addCourseOverlay(course: CourseUiModel) {
         if (course.coordinates.size < 2) return
         val latLngs: List<LatLng> = course.coordinates.map(Coordinate::toLatLng)
 
@@ -99,7 +99,7 @@ class NaverMapOverlayManager(
 
     private fun addClickableCourseOverlay(
         latLngs: List<LatLng>,
-        course: CourseItem,
+        course: CourseUiModel,
     ) {
         PathOverlay().apply {
             coords = latLngs
@@ -121,7 +121,7 @@ class NaverMapOverlayManager(
         }
     }
 
-    private fun removeCourseOverlay(course: CourseItem) {
+    private fun removeCourseOverlay(course: CourseUiModel) {
         courseIdToOverlay.remove(course.id)?.map = null
         courseIdToClickableOverlay.remove(course.id)?.map = null
     }
@@ -275,11 +275,11 @@ class NaverMapOverlayManager(
         segments.clear()
     }
 
-    fun setOnCourseClickListener(onClick: (CourseItem) -> Unit) {
+    fun setOnCourseClickListener(onClick: (CourseUiModel) -> Unit) {
         courseClickListener =
             Overlay.OnClickListener { overlay: Overlay ->
                 if (overlay is PathOverlay) {
-                    (overlay.tag as? CourseItem)?.let { course: CourseItem ->
+                    (overlay.tag as? CourseUiModel)?.let { course: CourseUiModel ->
                         Logger.log(
                             Logger.Event.Click("course_on_map"),
                             "id" to course.id,
@@ -292,7 +292,7 @@ class NaverMapOverlayManager(
             }
 
         courseIdToClickableOverlay.values.forEach { pathOverlay: PathOverlay ->
-            if (pathOverlay.tag is CourseItem) {
+            if (pathOverlay.tag is CourseUiModel) {
                 pathOverlay.onClickListener = courseClickListener
             }
         }

--- a/android/app/src/main/res/drawable/icon_delete_course.xml
+++ b/android/app/src/main/res/drawable/icon_delete_course.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@color/item_primary"
+        android:pathData="M280,840q-33,0 -56.5,-23.5T200,760v-520h-40v-80h200v-40h240v40h200v80h-40v520q0,33 -23.5,56.5T680,840L280,840ZM680,240L280,240v520h400v-520ZM360,680h80v-360h-80v360ZM520,680h80v-360h-80v360ZM280,240v520,-520Z" />
+</vector>

--- a/android/app/src/main/res/layout/item_course.xml
+++ b/android/app/src/main/res/layout/item_course.xml
@@ -9,7 +9,7 @@
 
         <variable
             name="course"
-            type="io.coursepick.coursepick.presentation.course.CourseItem" />
+            type="io.coursepick.coursepick.presentation.course.CourseUiModel" />
 
         <variable
             name="courseItemListener"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="delete_custom_course_dialog_warning">삭제된 코스는 되돌릴 수 없어요.</string>
     <string name="delete_custom_course_dialog_negative_button">취소</string>
     <string name="delete_custom_course_dialog_positive_button">확인</string>
+    <string name="delete_custom_course_dialog_success_message">코스가 삭제됐습니다.</string>
 
     <!--  코스 화면: 현 위치로 이동 권한  -->
     <string name="current_location_location_permission_rationale_message">현 위치 표시를 위해 위치 권한을 허용해주세요.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="course_detail_header">코스 정보</string>
     <string name="course_detail_load_failure_message">코스 정보를 불러오지 못했습니다.</string>
     <string name="course_detail_report_course_button_description">코스 신고</string>
+    <string name="course_detail_delete_course_button_description">코스 삭제</string>
     <string name="course_detail_navigate_back_description">뒤로 가기</string>
     <string name="course_detail_review_header">리뷰</string>
     <string name="course_detail_review_count">(%1$d개)</string>
@@ -95,6 +96,7 @@
     <string name="course_detail_write_review_button">리뷰 작성</string>
     <string name="course_detail_already_reviewed_message">이 코스는 이미 리뷰하셨어요.</string>
     <string name="star_rating_description">별 %1$d개</string>
+    <string name="course_detail_delete_course_feature_name">코스 삭제</string>
     <string name="course_detail_delete_review_feature_name">리뷰 삭제</string>
 
     <!--  코스 상세 화면 - 리뷰 목록 아이템  -->

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -50,6 +50,14 @@
     <string name="custom_courses_empty_description">등록한 코스가 없어요</string>
     <string name="custom_courses_load_failed">데이터를 불러오는 데 실패했습니다.</string>
 
+
+    <!--  나의 코스 - 삭제 다이얼로그  -->
+    <string name="delete_custom_course_dialog_feature_name">나의 코스 삭제</string>
+    <string name="delete_custom_course_dialog_title">이 코스를 삭제할까요?</string>
+    <string name="delete_custom_course_dialog_warning">삭제된 코스는 되돌릴 수 없어요.</string>
+    <string name="delete_custom_course_dialog_negative_button">취소</string>
+    <string name="delete_custom_course_dialog_positive_button">확인</string>
+
     <!--  코스 화면: 현 위치로 이동 권한  -->
     <string name="current_location_location_permission_rationale_message">현 위치 표시를 위해 위치 권한을 허용해주세요.</string>
     <string name="current_location_location_permission_rationale_negative_button">설정으로 이동</string>

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/course/CoursesViewModelTest.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/course/CoursesViewModelTest.kt
@@ -56,7 +56,7 @@ class CoursesViewModelTest {
                 courses =
                     FAKE_COURSES.mapIndexed { index: Int, course: Course ->
                         CourseListItem.Course(
-                            CourseItem(course, selected = index == 0, favorite = false),
+                            CourseUiModel(course, selected = index == 0, favorite = false),
                         )
                     },
                 status = UiStatus.Success,
@@ -74,7 +74,7 @@ class CoursesViewModelTest {
             CoursesUiState(
                 FAKE_COURSES.map { course: Course ->
                     CourseListItem.Course(
-                        CourseItem(
+                        CourseUiModel(
                             course,
                             selected = course == COURSE_FIXTURE_20,
                             favorite = false,
@@ -85,7 +85,7 @@ class CoursesViewModelTest {
             )
 
         // when
-        mainViewModel.select(CourseItem(COURSE_FIXTURE_20, selected = false, favorite = false))
+        mainViewModel.select(CourseUiModel(COURSE_FIXTURE_20, selected = false, favorite = false))
 
         // then
         Assertions.assertThat(mainViewModel.state.getOrAwaitValue()).isEqualTo(expected)
@@ -94,13 +94,13 @@ class CoursesViewModelTest {
     @Test
     fun `이미 선택된 코스가 선택되면 해당 코스가 유지된다`() {
         // given
-        mainViewModel.select(CourseItem(COURSE_FIXTURE_20, selected = false, favorite = false))
+        mainViewModel.select(CourseUiModel(COURSE_FIXTURE_20, selected = false, favorite = false))
 
         val expected =
             CoursesUiState(
                 FAKE_COURSES.map { course: Course ->
                     CourseListItem.Course(
-                        CourseItem(
+                        CourseUiModel(
                             course,
                             selected = course == COURSE_FIXTURE_20,
                             favorite = false,
@@ -111,7 +111,7 @@ class CoursesViewModelTest {
             )
 
         // when
-        mainViewModel.select(CourseItem(COURSE_FIXTURE_20, selected = true, favorite = false))
+        mainViewModel.select(CourseUiModel(COURSE_FIXTURE_20, selected = true, favorite = false))
 
         // then
         Assertions.assertThat(mainViewModel.state.getOrAwaitValue()).isEqualTo(expected)

--- a/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeCourseRepository.kt
+++ b/android/app/src/test/java/io/coursepick/coursepick/presentation/fixtures/FakeCourseRepository.kt
@@ -50,7 +50,8 @@ class FakeCourseRepository : CourseRepository {
 
     override suspend fun detail(courseId: String): CourseDetail =
         CourseDetail(
-            id = COURSE_FIXTURE_1.id,
+            courseId = COURSE_FIXTURE_1.id,
+            creatorId = "creatorId",
             name = COURSE_FIXTURE_1.name,
             length = COURSE_FIXTURE_1.length,
             coordinates = COURSE_FIXTURE_1.coordinates,


### PR DESCRIPTION
## 🛠️ 설명
- `나의 코스` 삭제를 위한 UI가 추가됐습니다.
  - 나의 코스 목록에서 코스 아이템을 꾹 눌러서 삭제하는 UI가 추가됐습니다.
  - 사용자 본인이 만든 코스의 상세 화면은 `신고` 버튼 대신 `삭제` 버튼이 표시되도록 변경됐습니다.

- `나의 코스` 기능을 추가할 때 논의된 방향대로, 일관성과 파일명 충돌 방지를 위해 코스 UI 관련 클래스/컴포저블 이름을 변경했습니다. 맨 처음 3개의 커밋을 제외하고 c8387a3a5ddc9bb6f4df985d893b916f7fa9cb90 커밋부터 보면 이름 관련 변경사항을 제외하고 볼 수 있습니다.
  - `CourseItem` → `CourseUiModel`
  - `CustomCourseItem` → `CustomCourseUiModel`
  - `CustomCourseItemCard` → `CustomCourseItem`


## 📸 스크린샷 / 동영상
[Screen_recording_20260726_174844.webm](https://github.com/user-attachments/assets/5c7f711b-4edc-41d9-b039-6e2849256810)


## 🔗 관련 이슈
- closes #982


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 코스 상세 화면에서 내 코스 삭제 기능이 추가되었습니다(삭제 확인, 삭제 진행 표시, 삭제 성공 안내).
  * 커스텀 코스 목록에서도 삭제 확인 다이얼로그 및 삭제 동작을 지원합니다.
  * 상세 화면에 작성자 여부가 반영되어 내 코스/일반 코스 구분이 명확해졌습니다.
* **Bug Fixes**
  * 코스 선택·이동·지도/목록 동작이 전반적으로 더 일관되게 동작하도록 정리되어 오류 가능성이 줄었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->